### PR TITLE
Add support for --nodedir and --citgmdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Options:
   -k, --hmac <key>     HMAC Key for Script Verification
   -l, --lookup [path]  Use the lookup table. Optional [path] for alternate
                        json file
+  -d, --nodedir <path> Path to the node source to use when compiling native
+                       addons
   -n, --no-color       Turns off colorized output
   -s, --su             Allow running the tool as root
   -u, --uid <uid>      Set the uid (posix only)
@@ -128,7 +130,16 @@ Options:
   -r, --run            Run the docker image immediately after build
   -v, --verbose        Verbose output
   -k, --hmac <key>     HMAC Key for Script Verification
-  -l, --lookup [path]  Use the lookup table. Optional [path] for alternate json file
+  -l, --lookup [path]  Use the lookup table. Optional [path] for alternate json
+                       file
+  -d, --nodedir        Create the docker image with a /nodedir volume.
+                       The workding directory MUST contain a nodedir
+                       directory containing the node source image to use.
+                       This must be located in the working directory in
+                       or docker will refuse to copy it.
+  -c, --citgmdir <path> By default, the docker image will install citgm from
+                        npm. Use this to tell the image to install from a host
+                        volume.
   -n, --no-color       Turns off colorized output
   -s, --su             Allow running the tool as root
   -u, --uid <uid>      Set the uid (posix only)

--- a/SIGNED.md
+++ b/SIGNED.md
@@ -3,13 +3,13 @@
 -----BEGIN PGP SIGNATURE-----
 Comment: GPGTools - https://gpgtools.org
 
-iQEcBAABCgAGBQJVtsCtAAoJEHNBsVwHCHes2FwIAIwdNFcEnbqrbZqn3aKqNGfv
-aCi5aK2IQwr/OWuIrHXLjFqJupdoB3WIxF0tX6JWLlDdc7UB7Xn4vHiyn4EbLuSG
-ig6krDsEo1WzXDPWv62CDx+DrjSVGJ1RlywsKQwbBn6+OvSm9OxZ3bqLLCtNU/z+
-aRann0IEzJ2mhlKOkkbtsjPPNV1RorM0JbQNBnL5W6jeN+N35TtNEJzwJc7bHgJ4
-fU6DBcVp4DhS3HJEc5Sky5lI7r3fExlxnFVZZJlm/5cTCFOz8uYvqSP6UgZwHU0l
-ab9oUALYJnq202s/yoLQtBcEXicgQbsox8+8Yg7rA/GfzByyYJf7tjAxpqI4NYY=
-=GG6r
+iQEcBAABCgAGBQJVwP3BAAoJEHNBsVwHCHesOYAH/2SS7VERDwkVa4lLrEWJXgIJ
+d9TVumyE6WPO1LoWIjPy4tm/h6sE+7EZc4BCnNccRyV+ctFQcRWrBu1IkeSO963f
+UQzRHyVhPe31i6rvgC9JccbMkxa2GSZJVNcaCrMYCtnYS/GPL6u9a5OE2+lgIBJR
+fA30akbYcGrWoBEPqd9KKabCuqOhBN8Sxm1lq+hAag+ApZENxPlbhaAjQBQnF8Vx
+ICs52GjK/KaCsxt0U3OGuE7a3QP/EZTfzp+tFYaFzmdyuWSpxNsmdL+FM4aYpU7s
+H58QKt3Sw4fsi8iQniULMwpcX61Bx/mAAuHPi5SmXAdPi7cIOVo/S/lONJ4jUZo=
+=t7I6
 -----END PGP SIGNATURE-----
 
 ```
@@ -27,14 +27,14 @@ size   exec  file                   contents
 19             .jshintrc            d862dcf6091929f90429363ddf72864c1076a22e9f2673f35552a05ba056ce49
 54             AUTHORS              47bb87633797121247b7c831c6090ddc32f3e7b91072914a7035398a3dd738b1
                bin/                                                                                 
-1963   x         citgm              4ea7a042f2150a19522c6b14f66a2d2c2b6254e9b6a15671293a6a66e2377929
-8056   x         citgm-dockerify    6b595088d589daf67e946f7e079f93a099942ced7091caca07a06a0757fa3a77
+2100   x         citgm              4c4aa3615fffe837b0d02d4ce6ded745b6b8d9b170065bfef430f568e6afefe4
+10515  x         citgm-dockerify    46c5f5525b370629367c21512968875a19b09125f8f084228b07fc6ca1e5358b
                known/                                                                               
                  lodash/                                                                            
 43                 lookup.json      af3ecb554661a1664a9cc10db8b26dd8ab713aa2490c81f6f055fe36f66095dc
 121    x           test.js          fb292b5b5d811b68dcf2dac7ef04ff06c0ce3ebac1f38235f02d58fbebb33550
                lib/                                                                                 
-12148            citgm.js           6104bf28e8b8c31f5916e4e5ae4fdf7aa080f369a97f8b0a0560f035b9b67b37
+12411            citgm.js           c2d1e9aaf8e5afc7361fdafe55e66b48b9e969d2b0552187c1db224fad64b9bc
 2799             lookup.js          f5f951ba0b10e653ae5c6e1bb70fed4368a0f6c4cfef60c1d85a01323aaf04e5
 1466             lookup.json        340d61ff3abc8e8676a0e12362daab9395f1a8b243bbc80c8d5959daa0bb1be4
 1505             out.js             d726c2820cca48ff7453f9e4e389160dfe7c92602aeefd17adb93789c5ea3aea
@@ -43,8 +43,8 @@ size   exec  file                   contents
                man/                                                                                 
 2564             citgm-dockerify.1  7dbb503c53f7da4e8b1414665d0571ae8f86a7032132ac66ac3a5670493ac031
 2563             citgm.1            d5989c7f373bcba3704c0fc72e5e063aeda65ab826909c0bf0b0402b3eba0e97
-1302           package.json         f2df46b47415e8221787ddd9324a543e7af75164bd1710774c5ead99efc64bd4
-10299          README.md            ecc665d5f622812d29c8fededa190689b8b9768ece13df6d4b9996f88cdf29e0
+1302           package.json         92a6d4d5c40c19ac3fece88c470aa474946c4440463e7e2ec14f488383153176
+10959          README.md            42dc30aa4b584c9aa8e3e8ad2fef167fe598659a6c0179ed459e9801f17baf23
                test/                                                                                
                  test-dir/                                                                          
 26                 index.js         0e3ff6bf26b1727bdb29101212803b124fd519a2ac3c351cde3beb8d21c3118f

--- a/bin/citgm
+++ b/bin/citgm
@@ -24,6 +24,10 @@ app
       'Use the lookup table. Optional [path] for alternate json file'
   )
   .option(
+      '-d, --nodedir <path>',
+      'Path to the node source to use when compiling native addons'
+  )
+  .option(
     '-n, --no-color', 'Turns off colorized output'
   )
   .option(
@@ -57,7 +61,8 @@ var options = {
   script: test,
   reporter: app.reporter,
   hmac: app.hmac,
-  lookup: app.lookup
+  lookup: app.lookup,
+  nodedir: app.nodedir
 };
 if (!citgm.windows) {
   var uidnumber = require('uid-number');

--- a/bin/citgm-dockerify
+++ b/bin/citgm-dockerify
@@ -45,6 +45,19 @@ app
       'Use the lookup table. Optional [path] for alternate json file'
   )
   .option(
+      '-d, --nodedir',
+      'Create the docker image with a /nodedir volume. \n' +
+      '                The workding directory MUST contain a nodedir\n' +
+      '                directory containing the node source image to use.\n' +
+      '                This must be located in the working directory in\n' +
+      '                or docker will refuse to copy it.'
+  )
+  .option(
+      '-c, --citgmdir <path>',
+      'By default, the docker image will install citgm from npm.\n' +
+      '                Use this to tell the image to install from a host volume.'
+  )
+  .option(
     '-n, --no-color', 'Turns off colorized output'
   )
   .option(
@@ -88,6 +101,10 @@ function buildCmd(context, next) {
     if (context.lookup)
       parts.push('/usr/src/app/custom-lookup.json');
   }
+  if (app.nodedir) {
+    parts.push('-d');
+    parts.push('/nodedir');
+  }
   if (app.su) {
     parts.push('-s');
   }
@@ -123,9 +140,18 @@ function buildCmd(context, next) {
 }
 
 
-// Optionally run's the docker image... uses no special arguments
+// Optionally run's the docker image...
 function runImage(context, next) {
   if (app.run) {
+    var args = ['run'];
+    out.info('docker-run', 'Running docker image: ' + context.tag);
+    if (typeof app.nodedir === 'string') {
+      var dir = path.resolve(process.cwd(),app.nodedir);
+      out.info('nodedir', 'Using local nodedir: ' + dir);
+      args.push('-v');
+      args.push(util.format('"%s":/nodedir', dir));
+    }
+    args.push(context.tag);
     var proc = child.spawn(bin,
       [
         'run',
@@ -135,6 +161,7 @@ function runImage(context, next) {
         stdio:[0,1,2]
       });
     proc.on('close', function(code) {
+      out.info('docker-run', 'Finished running docker image');
       if (code > 0) {
         out.error('failed', util.format('Docker run failed [%d]', code));
       }
@@ -153,6 +180,8 @@ function cleanLocal(context, next) {
     fs.unlinkSync('custom-test');
   if (context.lookup)
     fs.unlinkSync('custom-lookup.json');
+  if (app.citgmdir)
+    fs.unlinkSync('citgm.tar.gz');
    next(null, context);
 }
 
@@ -187,16 +216,68 @@ function buildImage(context, next) {
   );
 }
 
+function packCitgm(context, next) {
+  function error(err) {
+    out.error('pack-citgm', err);
+    next(Error(util.format('Could not pack citgm')));
+  }
+  if (app.citgmdir) {
+    var dest = path.join(context.wd, 'citgm.tar.gz');
+    var src = path.resolve(process.cwd(), app.citgmdir);
+    var file = fs.createWriteStream(dest)
+      .on('error', error);
+    var compressor = zlib.createGzip()
+      .on('end', function() {
+        file.close();
+        out.info('pack-citgm', 'done');
+        next(null,context);
+      })
+      .on('error', error);
+    var packer = tar.Pack({noProprietary: true}).
+      on('error', error);
+    out.info('pack-citgm', 'packing ' + src);
+    out.info('pack-citgm', 'dest ' + dest);
+    fstream.Reader({path: src, type: "Directory"}).
+       on('error', error).
+       pipe(packer).
+       pipe(compressor).
+       pipe(file);
+  } else {
+    next();
+  }
+}
+
 function writeDockerfile(context, next) {
   var dest = fs.createWriteStream(path.join(context.wd, 'Dockerfile'), {encoding:'utf8'});
   dest.on('close', function() {
-    next(null,context);
+    packCitgm(context, function(err) {
+      if (err) {
+        next(err);
+        return;
+      }
+      next(null, context);
+    });
   });
   dest.on('error', function(err) {
     next(err);
   });
   var m = util.format('FROM %s\n',context.image);
-  m += 'RUN npm install -g citgm@latest\n';
+
+  if (app.nodedir) {
+     m += 'ADD nodedir /nodedir\n';
+  }
+
+  var args = ['-g'];
+  if (app.nodedir) {
+    args = ['--nodedir=/nodedir'].concat(args);
+  }
+  if (!app.citgmdir) {
+    m += 'RUN npm install ' + args.join(' ') + ' citgm@latest\n';
+  } else {
+    m += 'COPY ["citgm.tar.gz","/usr/src/app/"]\n';
+    m += 'RUN npm install ' + args.join(' ') + ' /usr/src/app/citgm.tar.gz\n';
+  }
+
   if (context.local)
     m += 'COPY ["module.tar.gz","/usr/src/app/"]\n';
   if (context.test) {

--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -153,7 +153,7 @@ function grabProject(context, next) {
   if (context.module.type === 'local') {
     package_name = path.resolve(process.cwd(),package_name);
   }
-  context.emit('info','npm-pack-start','Downloading project');
+  context.emit('info','npm-pack-start','Downloading project: ' + package_name);
   var proc =
     spawn(
       'npm',
@@ -300,7 +300,13 @@ function npmsetup(context, next) {
       path.join(context.path, context.module.name),
       [0,1,2],
       context);
-  var proc = spawn('npm', ['install'], options);
+  var args = ['install'];
+  if (context.options.nodedir) {
+    var nodedir = path.resolve(process.cwd(),context.options.nodedir);
+    args.push('--nodedir="' + nodedir + '"');
+    context.emit('info','nodedir', 'Using --nodedir="' + nodedir + '"');
+  }
+  var proc = spawn('npm', args, options);
   proc.on('error', function(err) {
     next(Error('Install Failed'));
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "citgm",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "The Canary in the Goldmine",
   "homepage": "http://nodejs.org",
   "main": "bin/citgm",


### PR DESCRIPTION
The `-d` or `--nodedir` command line flags can now be used to set the `--nodedir` option 
during npm install. 

Note: when using citgm-dockerify, you *must* have a `nodedir` folder containing the node src
located in your local working directory before building the image. This is because docker will 
refuse to copy the node src image if it's not local to the working directory and citgm's npm install
in the docker file won't be able to find it either. This is temporary. An alternative solution is being
worked on.

The `-c` or `--citgmdir` command line flag has been added to citgm-dockerify to specify the local
path to citgm. When specified, the docker image will install citgm from the specified location rather
than using npm.