### PR TITLE
refactor output logging to use winston, add verbose levels

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,3 +1,4 @@
 {
-  "node": true
+  "node": true,
+  "esnext": true
 }

--- a/bin/citgm
+++ b/bin/citgm
@@ -1,13 +1,12 @@
 #!/usr/bin/env node
 'use strict';
-require('../lib/update'); // version update check
-var citgm = require('../lib/citgm');
-var out = require('../lib/out');
-var app = require('commander');
-var util = require('util');
+const update = require('../lib/update');
+const citgm = require('../lib/citgm');
+const logger = require('../lib/out');
+const app = require('commander');
+const util = require('util');
 
-var mod;
-var test;
+var mod, test;
 app
   .version('0.1.0')
   .arguments('<module> [test]')
@@ -16,7 +15,9 @@ app
     test = t;
   })
   .option(
-    '-v, --verbose', 'Verbose output')
+    '-v, --verbose [level]',
+    'Verbose output (info, warn, error)',
+    /^(info|warn|error)$/i, 'info')
   .option(
     '-k, --hmac <key>', 'HMAC Key for Script Verification')
   .option(
@@ -34,7 +35,7 @@ app
     '-s, --su', 'Allow running the tool as root.'
   );
 
-if (process.platform !== 'win32') {
+if (!citgm.windows) {
   app.option(
     '-u, --uid <uid>', 'Set the uid (posix only)'
   )
@@ -45,24 +46,30 @@ if (process.platform !== 'win32') {
 
 app.parse(process.argv);
 
+const log = logger({
+  level:app.verbose,
+  nocolor: !app.color
+});
+update(log);
+
 if (!mod) {
   app.outputHelp();
-  return;
+  process.exit(0);
 }
 
 if (!app.su) {
   require('root-check')(); // silently downgrade if running as root...
                            // unless --su is passed
 } else {
-  out.warn('root', 'Running as root! Use caution!');
+  log.warn('root', 'Running as root! Use caution!');
 }
 
-var options = {
+const options = {
   script: test,
-  reporter: app.reporter,
   hmac: app.hmac,
   lookup: app.lookup,
-  nodedir: app.nodedir
+  nodedir: app.nodedir,
+  level: app.verbose
 };
 if (!citgm.windows) {
   var uidnumber = require('uid-number');
@@ -80,14 +87,13 @@ if (!citgm.windows) {
 function launch(mod, options) {
   citgm.Tester(mod, options)
   .on('start', function(name, options) {
-    out.info('starting', name);
+    log.info('starting', name);
   }).on('fail', function(err) {
-    out.error('failure', err.message);
+    log.error('failure', err.message);
     process.exitCode = 1;
   }).on('info', function(key,message) {
-    if (app.verbose)
-      out.info(key, message);
+    log.info(key, message);
   }).on('end', function(name) {
-    out.info('done', name);
+    log.info('done', name);
   }).run();
 }

--- a/bin/citgm-dockerify
+++ b/bin/citgm-dockerify
@@ -1,22 +1,22 @@
 #!/usr/bin/env node
 'use strict';
-require('../lib/update');  // version update check
-var which = require('which');
-var out = require('../lib/out');
-var app = require('commander');
-var util = require('util');
-var child = require('child_process');
-var uuid = require('node-uuid');
-var async = require('async');
-var path = require('path');
-var url = require('url');
-var npa = require('npm-package-arg');
-var fs = require('fs');
-var fsx = require('fs-extra');
-var tar = require('tar');
-var fstream = require('fstream');
-var zlib = require('zlib');
-var osenv = require('osenv');
+const update = require('../lib/update');  // version update check
+const which = require('which');
+const logger = require('../lib/out');
+const app = require('commander');
+const util = require('util');
+const child = require('child_process');
+const uuid = require('node-uuid');
+const async = require('async');
+const path = require('path');
+const url = require('url');
+const npa = require('npm-package-arg');
+const fs = require('fs');
+const fsx = require('fs-extra');
+const tar = require('tar');
+const fstream = require('fstream');
+const zlib = require('zlib');
+const osenv = require('osenv');
 
 // Collect the command line arguments
 var image, mod, test;
@@ -37,7 +37,8 @@ app
   .option(
     '-r, --run', 'Run the docker image immediately after build')
   .option(
-    '-v, --verbose', 'Verbose output')
+    '-v, --verbose [level]', 'Verbose output',
+    /^(info|warn|error)$/i, 'info')
   .option(
     '-k, --hmac <key>', 'HMAC Key for Script Verification')
   .option(
@@ -75,7 +76,13 @@ app
 
 app.parse(process.argv);
 
-var bin = app.docker || 'docker';
+const log = logger({
+  level:app.verbose,
+  nocolor: !app.color
+});
+update(log);
+
+const bin = app.docker || 'docker';
 
 if (!image || !mod) {
   app.outputHelp();
@@ -86,44 +93,45 @@ if (!app.su) {
   require('root-check')(); // silently downgrade if running as root...
                            // unless --su is passed
 } else {
-  out.warn('root', 'Running as root! Use caution!');
+  log.warn('root', 'Running as root! Use caution!');
 }
 
-var tag = 'citgm-' + (app.tag || uuid.v4());
+const tag = 'citgm-' + (app.tag || uuid.v4());
 
-var detail = npa(mod);
+const detail = npa(mod);
 
 // build the citgm CMD for the Dockerfile
 function buildCmd(context, next) {
   var parts = ['citgm'];
   if (app.lookup) {
-    parts.push('-l');
+    parts.push('--lookup');
     if (context.lookup)
       parts.push('/usr/src/app/custom-lookup.json');
   }
   if (app.nodedir) {
-    parts.push('-d');
+    parts.push('--nodedir');
     parts.push('/nodedir');
   }
   if (app.su) {
-    parts.push('-s');
+    parts.push('--su');
   }
   if (app.verbose) {
-    parts.push('-v');
+    parts.push('--verbose');
+    parts.push(app.verbose);
   }
   if (app.hmac) {
-    parts.push('-h');
+    parts.push('--hmac');
     parts.push('"' + app.hmac + '"');
   }
-  if (app['no-color']) {
-    parts.push('-n');
+  if (!app.color) {
+    parts.push('--no-color');
   }
   if (app.uid) {
-    parts.push('-u');
+    parts.push('--uid');
     parts.push(app.uid);
   }
   if (app.gid) {
-    parts.push('-g');
+    parts.push('--gid');
     parts.push(app.gid);
   }
 
@@ -144,10 +152,10 @@ function buildCmd(context, next) {
 function runImage(context, next) {
   if (app.run) {
     var args = ['run'];
-    out.info('docker-run', 'Running docker image: ' + context.tag);
+    log.info('docker-run', 'Running docker image: ' + context.tag);
     if (typeof app.nodedir === 'string') {
       var dir = path.resolve(process.cwd(),app.nodedir);
-      out.info('nodedir', 'Using local nodedir: ' + dir);
+      log.info('nodedir', 'Using local nodedir: ' + dir);
       args.push('-v');
       args.push(util.format('"%s":/nodedir', dir));
     }
@@ -161,9 +169,9 @@ function runImage(context, next) {
         stdio:[0,1,2]
       });
     proc.on('close', function(code) {
-      out.info('docker-run', 'Finished running docker image');
+      log.info('docker-run', 'Finished running docker image');
       if (code > 0) {
-        out.error('failed', util.format('Docker run failed [%d]', code));
+        log.error('failed', util.format('Docker run failed [%d]', code));
       }
       next(null,context);
     });
@@ -201,7 +209,7 @@ function buildImage(context, next) {
     }
   )
   .on('error', function(err) {
-    out.error('failure', err);
+    log.error('failure', err);
     next(err);
   })
   .on('close', function(code) {
@@ -210,7 +218,7 @@ function buildImage(context, next) {
       return;
     }
     process.chdir(cwd);
-    out.info('created', tag);
+    log.info('created', tag);
       next(null,context);
     }
   );
@@ -218,7 +226,7 @@ function buildImage(context, next) {
 
 function packCitgm(context, next) {
   function error(err) {
-    out.error('pack-citgm', err);
+    log.error('pack-citgm', err);
     next(Error(util.format('Could not pack citgm')));
   }
   if (app.citgmdir) {
@@ -229,14 +237,14 @@ function packCitgm(context, next) {
     var compressor = zlib.createGzip()
       .on('end', function() {
         file.close();
-        out.info('pack-citgm', 'done');
+        log.info('pack-citgm', 'done');
         next(null,context);
       })
       .on('error', error);
     var packer = tar.Pack({noProprietary: true}).
       on('error', error);
-    out.info('pack-citgm', 'packing ' + src);
-    out.info('pack-citgm', 'dest ' + dest);
+    log.info('pack-citgm', 'packing ' + src);
+    log.info('pack-citgm', 'dest ' + dest);
     fstream.Reader({path: src, type: "Directory"}).
        on('error', error).
        pipe(packer).
@@ -289,7 +297,7 @@ function writeDockerfile(context, next) {
   }
   m += 'CMD ' + context.cmd;
   dest.write(m);
-  out.info('docker-file', m);
+  log.info('docker-file', m);
   dest.close();
 }
 
@@ -357,15 +365,15 @@ function prepareLocalModule(context, next) {
   if (detail.type === 'local') {
     context.local = path.join(context.wd,'module.tar.gz');
     var raw = path.resolve(process.cwd(), detail.raw);
-    out.info('prepare-local-src', raw);
-    out.info('prepare-local-dest', context.local);
+    log.info('prepare-local-src', raw);
+    log.info('prepare-local-dest', context.local);
     fs.lstat(raw, function(err,stat) {
       if (err) {
         next(Error(util.format('Cannot access local module: %s', raw)));
         return;
       }
       if (stat.isFile()) {
-        out.info('prepare-local-copy','');
+        log.info('prepare-local-copy','');
         fsx.copy(raw,context.local, function(err) {
           if (err) {
             next(err);
@@ -374,7 +382,7 @@ function prepareLocalModule(context, next) {
           next(null,context);
         });
       } else if (stat.isDirectory()) {
-        out.info('prepare-local-pack','');
+        log.info('prepare-local-pack','');
         packDirectory(raw, context, next);
       } else {
         next(Error(util.format('Cannot access localmodule: %s', raw)));
@@ -397,7 +405,7 @@ function initContext(next) {
 function ensureDocker(context, next) {
   which(bin, function(err,docker) {
     if (err) {
-      out.error('failed', 'The docker client could not be found');
+      log.error('failed', 'The docker client could not be found');
       next(Error('Aborting'));
       return;
     }
@@ -427,9 +435,9 @@ async.waterfall([
   ],
   function(err, context) {
     if (err) {
-      out.error('failed', err.message);
+      log.error('failed', err.message);
       process.exit(1);
     }
-    out.info('done', context.tag);
+    log.info('done', context.tag);
   }
 );

--- a/known/lodash/test.js
+++ b/known/lodash/test.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-var child = require('child_process');
+const child = require('child_process');
 child.spawnSync('node',['test/test.js'], {
   stdio:[0,1,2]
 });

--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -1,23 +1,23 @@
 'use strict';
 
-var os = require('os');
-var fs = require('fs');
-var rimraf = require('rimraf');
-var child = require('child_process');
-var zlib = require('zlib');
-var path = require('path');
-var util = require('util');
-var tar = require('tar');
-var async = require('async');
-var osenv = require('osenv');
-var uuid = require('node-uuid');
-var npa = require('npm-package-arg');
-var which = require('which');
-var EventEmitter = require('events').EventEmitter;
-var lookup = require('./lookup');
-var readPackage = require('read-package-json');
+const os = require('os');
+const fs = require('fs');
+const rimraf = require('rimraf');
+const child = require('child_process');
+const zlib = require('zlib');
+const path = require('path');
+const util = require('util');
+const tar = require('tar');
+const async = require('async');
+const osenv = require('osenv');
+const uuid = require('node-uuid');
+const npa = require('npm-package-arg');
+const which = require('which');
+const EventEmitter = require('events');
+const lookup = require('./lookup');
+const readPackage = require('read-package-json');
 
-var windows = (process.platform === 'win32');
+const windows = (process.platform === 'win32');
 exports.windows = windows;
 
 /**

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -1,6 +1,7 @@
-var normgit = require('normalize-git-url');
-var util = require('util');
-var path = require('path');
+'use strict';
+const normgit = require('normalize-git-url');
+const util = require('util');
+const path = require('path');
 
 // construct the tarball url using the repo, spec and prefix config
 function makeUrl(repo, spec, tags, prefix) {

--- a/lib/out.js
+++ b/lib/out.js
@@ -1,72 +1,61 @@
+'use strict';
+const logger = require('winston');
+const chalk = require('chalk');
+const supportscolor = require('supports-color');
+const columnify = require('columnify');
 
-var chalk = require('chalk');
-var columnify = require('columnify');
-var supportsColor = require('supports-color');
-var flat = require('flat');
+logger.remove(logger.transports.Console);
+logger.add(logger.transports.Console, {
+  prettyPrint:true,
+  depth: 100
+});
 
-var _info = {
-  label: chalk.cyan,
-  tag: chalk.green,
-  message: chalk.white
-};
-var _warn = {
-  label: chalk.yellow,
-  tag: chalk.green,
-  message: chalk.white
-};
-var _err = {
-  label: chalk.red,
-  tag: chalk.red,
-  message: chalk.white
-};
-
-function show(label,scheme,tag,message) {
-  var line = {
-    a:label,
-    b:tag,
-    c:''
-  };
-  if (typeof message !== 'object')
-    line.c = message;
-  if (supportsColor) {
-    line.a = scheme.label(line.a);
-    line.b = scheme.tag(line.b);
-    line.c = scheme.message(line.c);
-  }
-  console.log(columnify([line], {
-    showHeaders: false,
-    maxLineWidth: 'auto',
-    minWidth: 20,
-    maxWidth: 53,
-    columnSplitter: '|',
-    config: {
-      a: { maxWidth: 7 }
-    },
-    preserveNewLines: true
-  }));
+function output(tag, message, dest) {
+  var obj;
   if (typeof message === 'object') {
-    console.log(
-      columnify(
-        flat(message, {
-          maxDepth: 100,
-          safe: true}),
-        {
-          showHeaders:false,
-          maxLineWidth: 'auto',
-          minWidth: 10,
-          maxWidth: 40,
-          dataTransform: function(data) {
-            if (data === '[object Object]')
-              return '{none}';
-            else return data;
-          }
-        }
-      )
-    );
-    console.log();
+    obj = JSON.stringify(message,null,2);
+    message = '';
+  }
+  var msg = columnify(
+    [{tag:tag,message:message}],
+    {
+      showHeaders: false,
+      maxLineWidth: 'auto',
+      minWidth: 20,
+      maxWidth: 50,
+      columnSplitter: '| ',
+      preserveNewLines: true
+    }
+  );
+  msg.split('\n').forEach(function(line) {
+    dest(line);
+  });
+  if (obj) {
+    obj.split('\n').forEach(function(line) {
+      dest(line);
+    });
   }
 }
 
-exports.info = show.bind(null,'Info',_info);
-exports.warn = show.bind(null,'Warn',_warn);
-exports.error = show.bind(null,'Error',_err);
+module.exports = function(options) {
+  var colorize = !options.nocolor && supportscolor;
+  options = options || {
+    level: 'warn'
+  };
+  logger.level = options.level;
+  if (colorize) logger.cli();
+  return {
+    info: function(tag, message) {
+      if (colorize) tag = chalk.cyan(tag);
+      output(tag, message, logger.info);
+    },
+    warn: function(tag, message) {
+      if (colorize) tag = chalk.yellow(tag);
+      output(tag, message, logger.warn);
+    },
+    error: function(tag, message) {
+      if (colorize) tag = chalk.red(tag);
+      output(tag, message, logger.error);
+    }
+  };
+};

--- a/lib/update.js
+++ b/lib/update.js
@@ -1,18 +1,21 @@
-var updateNotifier = require('update-notifier');
-var pkg = require('../package.json');
-var out = require('./out');
-var semver = require('semver');
-var util = require('util');
-var not = updateNotifier({
-  pkg: pkg,
-  name: pkg.name,
-  callback: function(error, update) {
-    if (update && semver.gt(update.latest, update.current)) {
-      out.warn(
-        'update-available',
-        util.format(
-          'v%s (current: v%s)\nnpm install -g %s',
-          update.latest, update.current, pkg.name));
+'use strict';
+const updateNotifier = require('update-notifier');
+const pkg = require('../package.json');
+const semver = require('semver');
+const util = require('util');
+
+module.exports = function(log) {
+  updateNotifier({
+    pkg: pkg,
+    name: pkg.name,
+    callback: function(error, update) {
+      if (update && semver.gt(update.latest, update.current)) {
+        log.warn(
+          'update-available',
+          util.format(
+            'v%s (current: v%s)\nnpm install -g %s',
+            update.latest, update.current, pkg.name));
+      }
     }
-  }
-});
+  });
+};

--- a/man/citgm-dockerify.1
+++ b/man/citgm-dockerify.1
@@ -22,8 +22,8 @@ run the docker image immediately after building it
 .BR \-V ", " \-\-version
 output the version number
 .TP
-.BR \-v ", " \-\-verbose
-Verbose output
+.BR \-v ", " \-\-verbose " " \fI[info|warn|error]\fR
+Verbose output (info,warn,error)
 .TP
 .BR \-k ", " \-\-hmac " " \fIkey\fR
 HMAC Key for Script Verification

--- a/man/citgm.1
+++ b/man/citgm.1
@@ -17,8 +17,8 @@ output usage information
 .BR \-V ", " \-\-version
 output the version number
 .TP
-.BR \-v ", " \-\-verbose
-Verbose output
+.BR \-v ", " \-\-verbose " " \fI[info|warn|error]\fR
+Verbose output (info,warn,error)
 .TP
 .BR \-k ", " \-\-hmac " " \fIkey\fR
 HMAC Key for Script Verification

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "citgm",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "The Canary in the Goldmine",
   "homepage": "http://nodejs.org",
   "main": "bin/citgm",
@@ -31,8 +31,7 @@
     "chalk": "^1.1.0",
     "columnify": "^1.5.1",
     "commander": "^2.8.1",
-    "flat": "^1.6.0",
-    "fs-extra": "^0.22.1",
+    "fs-extra": "^0.24.0",
     "fstream": "^1.0.7",
     "node-uuid": "^1.4.3",
     "normalize-git-url": "^3.0.1",
@@ -47,7 +46,8 @@
     "tar": "^2.1.1",
     "uid-number": "0.0.6",
     "update-notifier": "^0.5.0",
-    "which": "^1.1.1"
+    "which": "^1.1.1",
+    "winston": "^1.0.1"
   },
   "devDependencies": {
     "mocha": "^2.2.5"

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,9 @@
-var child = require('child_process');
-var assert = require('assert');
+const child = require('child_process');
+const assert = require('assert');
+const http = require('http');
+const fs = require('fs');
 
-describe('It should run the test for the module correctlye', function() {
+describe('It should run the test for the module correctly', function() {
   it('should have exit code 0', function(done) {
     this.timeout(60 * 1000); // increase the timeout
     var proc = child.spawn(
@@ -15,7 +17,7 @@ describe('It should run the test for the module correctlye', function() {
   });
 });
 
-describe('It not die because of no npm test support', function() {
+describe('It should die because of no npm test support', function() {
   it('should have exit code 1', function(done) {
     this.timeout(60 * 1000); // increase the timeout
     var proc = child.spawn(
@@ -30,8 +32,6 @@ describe('It not die because of no npm test support', function() {
 });
 
 var server;
-var http = require('http');
-var fs = require('fs');
 function runServer(hmac,done) {
   server = http.createServer(function(req,res) {
     var read = fs.createReadStream('./test/test-script.js');


### PR DESCRIPTION
Bump version to v0.2.2

Using winston for logging output now.

`--verbose` can now take one of three options:

  `info`, `error`, `warn`

The default is `info`, which is the most verbose level.

/cc @rvagg 