### PR TITLE
lookup: use lookup by default 

### DIFF
--- a/bin/citgm
+++ b/bin/citgm
@@ -21,8 +21,8 @@ app
   .option(
     '-k, --hmac <key>', 'HMAC Key for Script Verification')
   .option(
-    '-l, --lookup [path]',
-      'Use the lookup table. Optional [path] for alternate json file'
+    '-l, --lookup <path>',
+      'Use the lookup table provided at <path>'
   )
   .option(
       '-d, --nodedir <path>',

--- a/bin/citgm-dockerify
+++ b/bin/citgm-dockerify
@@ -43,7 +43,7 @@ app
     '-k, --hmac <key>', 'HMAC Key for Script Verification')
   .option(
     '-l, --lookup [path]',
-      'Use the lookup table. Optional [path] for alternate json file'
+      'Use the lookup table provided at <path>'
   )
   .option(
       '-d, --nodedir',

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -49,37 +49,36 @@ function getLookupTable(context) {
  * the path to a different lookup json file can be specified
  **/
 function resolve(context, next) {
-  if (context.options.lookup) {
-    var lookup = getLookupTable(context);
-    if (!lookup) {
-      next(Error('Lookup table could not be loaded'));
-      return;
-    }
-    var detail = context.module;
-    context.emit('info','lookup',detail.name);
-    var meta = context.meta;
-    if (meta) {
-      var rep = lookup[detail.name];
-      if (rep) {
-        if (rep.replace) {
-          context.emit('info','lookup-found',detail.name);
-          var url = makeUrl(
-            getRepo(rep.repo, meta),
-            detail.rawSpec,
-            meta['dist-tags'],
-            rep.prefix);
-          context.emit('info','lookup-replace',url);
-          context.module.raw = url;
-        }
-        if (rep.script) {
-          context.emit('info','lookup-script',rep.script);
-          context.options.script = rep.script;
-        }
-      } else {
-        context.emit('info','lookup-notfound',detail.name);
+  var lookup = getLookupTable(context);
+  if (!lookup) {
+    next(Error('Lookup table could not be loaded'));
+    return;
+  }
+  var detail = context.module;
+  context.emit('info','lookup',detail.name);
+  var meta = context.meta;
+  if (meta) {
+    var rep = lookup[detail.name];
+    if (rep) {
+      if (rep.replace) {
+        context.emit('info','lookup-found',detail.name);
+        var url = makeUrl(
+          getRepo(rep.repo, meta),
+          detail.rawSpec,
+          meta['dist-tags'],
+          rep.prefix);
+        context.emit('info','lookup-replace',url);
+        context.module.raw = url;
       }
+      if (rep.script) {
+        context.emit('info','lookup-script',rep.script);
+        context.options.script = rep.script;
+      }
+    } else {
+      context.emit('info','lookup-notfound',detail.name);
     }
   }
+
   next(null,context);
 }
 module.exports = resolve;


### PR DESCRIPTION
There is no reason to run the test on a module that is included in the
lookup table. This PR change the way the lookup table is handled to
assure the table is always used if a module is included in it.