### PR TITLE
bin: add citgm-all

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,30 @@ available. If a newer version has been published to npm, an info notice
 will appear in the verbose output. If the `-v` or `--verbose` flag is not
 set, the update notice will not be displayed.
 
+## citgm-all
+
+If you want to run all the test suites for all modules found in a lookup
+table use citgm-all. It will automate the running of all tests and give
+itemized results at the end. It has all the same options as citgm except
+for the added markdown option which will print the results in markdown.
+
+```
+Usage: citgm-all [options]
+
+Options:
+
+  -h, --help             output usage information
+  -V, --version          output the version number
+  -v, --verbose [level]  Verbose output (silly, verbose, info, warn, error)
+  -l, --lookup <path>    Use the lookup table provided at <path>
+  -d, --nodedir <path>   Path to the node source to use when compiling native addons
+  -n, --no-color         Turns off colorized output
+  -s, --su               Allow running the tool as root.
+  -m, --markdown         Output results in markdown
+  -u, --uid <uid>        Set the uid (posix only)
+  -g, --gid <uid>        Set the gid (posix only)
+```
+
 ## Testing
 
 You can run the test suite using npm

--- a/bin/citgm
+++ b/bin/citgm
@@ -89,14 +89,14 @@ function launch(mod, options) {
     log.info('starting', name);
   }).on('fail', function(err) {
     log.error('failure', err.message);
-    process.exitCode = 1;
   }).on('data', function(type,key,message) {
     log[type](key, message);
-  }).on('end', function(name) {
-    if (process.exitCode) {
-      log.error('done', 'The test suite for ' + name + ' failed');
+  }).on('end', function(module) {
+    if (module.error) {
+      process.exitCode = 1;
+      log.error('done', 'The test suite for ' + module.name + ' failed');
       process.exit();
     }
-    log.info('done', 'The test suite for ' + name + ' passed.');
+    log.info('done', 'The test suite for ' + module.name + ' passed.');
   }).run();
 }

--- a/bin/citgm
+++ b/bin/citgm
@@ -15,7 +15,7 @@ app
   })
   .option(
     '-v, --verbose [level]',
-    'Verbose output (silly, vebose, info, warn, error)',
+    'Verbose output (silly, verbose, info, warn, error)',
     /^(silly|verbose|info|warn|error)$/i, 'info')
   .option(
     '-k, --hmac <key>', 'HMAC Key for Script Verification')

--- a/bin/citgm
+++ b/bin/citgm
@@ -94,9 +94,9 @@ function launch(mod, options) {
   }).on('end', function(module) {
     if (module.error) {
       process.exitCode = 1;
-      log.error('done', 'The test suite for ' + module.name + ' failed');
+      log.error('done', 'The test suite for ' + module.name + ' version ' + module.version + ' failed');
       process.exit();
     }
-    log.info('done', 'The test suite for ' + module.name + ' passed.');
+    log.info('done', 'The test suite for ' + module.name + ' version ' + module.version + ' passed.');
   }).run();
 }

--- a/bin/citgm-all
+++ b/bin/citgm-all
@@ -16,7 +16,7 @@ app
   })
   .option(
     '-v, --verbose [level]',
-    'Verbose output (silly, vebose, info, warn, error)',
+    'Verbose output (silly, verbose, info, warn, error)',
     /^(silly|verbose|info|warn|error)$/i, 'info')
   .option(
     '-l, --lookup <path>',

--- a/bin/citgm-all
+++ b/bin/citgm-all
@@ -63,7 +63,6 @@ var options = {
 };
 
 var lookup = getLookup(options);
-var modules = Object.getOwnPropertyNames(lookup);
 
 if (!citgm.windows) {
   var uidnumber = require('uid-number');
@@ -81,13 +80,18 @@ if (!citgm.windows) {
 var exitCode = 0;
 var failed = [];
 
-function runCitgm (mod, next) {
-  citgm.Tester(mod, options)
+function runCitgm (module, name, next) {
+  if (module.skip) {
+    next();
+    return;
+  }
+  
+  citgm.Tester(name, options)
   .on('start', function(name) {
     log.info('starting', name);
   }).on('fail', function(err) {
     failed.push({
-      name: mod,
+      name: name,
       err: err.message
     });
     log.error('failure', err.message);
@@ -108,12 +112,12 @@ function runCitgm (mod, next) {
 }
 
 function launch() {
-  async.eachSeries(modules, runCitgm, function done () {
+  async.forEachOfSeries(lookup, runCitgm, function done () {
     if (exitCode) {
       process.exitCode = exitCode;
       log.error('done', 'citgm-all failed');
       log.error('failed modules', failed);
-      process.exit();
+      process.exit(exitCode);
     }
     log.info('done', 'citgm-all passed.');
   });

--- a/bin/citgm-all
+++ b/bin/citgm-all
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+'use strict';
+var update = require('../lib/update');
+var citgm = require('../lib/citgm');
+var logger = require('../lib/out');
+var getLookup = require('../lib/lookup').get;
+var app = require('commander');
+var async = require('async');
+
+app
+  .version('0.2.3')
+  .arguments('<module> [test]')
+  .action(function() {
+  })
+  .option(
+    '-v, --verbose [level]',
+    'Verbose output (silly, vebose, info, warn, error)',
+    /^(silly|verbose|info|warn|error)$/i, 'info')
+  .option(
+    '-l, --lookup <path>',
+      'Use the lookup table provided at <path>'
+  )
+  .option(
+      '-d, --nodedir <path>',
+      'Path to the node source to use when compiling native addons'
+  )
+  .option(
+    '-n, --no-color', 'Turns off colorized output'
+  )
+  .option(
+    '-s, --su', 'Allow running the tool as root.'
+  );
+
+if (!citgm.windows) {
+  app.option(
+    '-u, --uid <uid>', 'Set the uid (posix only)'
+  )
+  .option(
+    '-g, --gid <uid>', 'Set the gid (posix only)'
+  );
+}
+
+app.parse(process.argv);
+
+var log = logger({
+  level: app.verbose,
+  nocolor: !app.color
+});
+
+update(log);
+
+if (!app.su) {
+  require('root-check')(); // silently downgrade if running as root...
+                           // unless --su is passed
+} else {
+  log.warn('root', 'Running as root! Use caution!');
+}
+
+var options = {
+  lookup: app.lookup,
+  nodedir: app.nodedir,
+  level: app.verbose
+};
+
+var lookup = getLookup(options);
+var modules = Object.getOwnPropertyNames(lookup);
+
+if (!citgm.windows) {
+  var uidnumber = require('uid-number');
+  var uid = app.uid || process.getuid();
+  var gid = app.gid || process.getgid();
+  uidnumber(uid,gid, function(err, uid, gid) {
+    options.uid = uid;
+    options.gid = gid;
+    launch(options);
+  });
+} else {
+  launch(options);
+}
+
+var exitCode = 0;
+var failed = [];
+
+function runCitgm (mod, next) {
+  citgm.Tester(mod, options)
+  .on('start', function(name) {
+    log.info('starting', name);
+  }).on('fail', function(err) {
+    failed.push({
+      name: mod,
+      err: err.message
+    });
+    log.error('failure', err.message);
+    process.exitCode = 1;
+  }).on('data', function(type,key,message) {
+    log[type](key, message);
+  }).on('end', function(name) {
+    if (process.exitCode) {
+      log.error('done', 'The test suite for ' + name + ' failed');
+      exitCode = process.exitCode;
+      process.exitCode = 0;
+    }
+    else {
+      log.info('done', 'The test suite for ' + name + ' passed.');
+    }
+    next();
+  }).run();
+}
+
+function launch() {
+  async.eachSeries(modules, runCitgm, function done () {
+    if (exitCode) {
+      process.exitCode = exitCode;
+      log.error('done', 'citgm-all failed');
+      log.error('failed modules', failed);
+      process.exit();
+    }
+    log.info('done', 'citgm-all passed.');
+  });
+}

--- a/bin/citgm-all
+++ b/bin/citgm-all
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 'use strict';
+var app = require('commander');
+var async = require('async');
+var _ = require('lodash');
+
 var update = require('../lib/update');
 var citgm = require('../lib/citgm');
 var logger = require('../lib/out');
 var getLookup = require('../lib/lookup').get;
-var app = require('commander');
-var async = require('async');
 
 app
   .version('0.2.3')
@@ -29,6 +31,9 @@ app
   )
   .option(
     '-s, --su', 'Allow running the tool as root.'
+  )
+  .option(
+    '-m, --markdown', 'Output results in markdown'
   );
 
 if (!citgm.windows) {
@@ -79,9 +84,11 @@ if (!citgm.windows) {
 
 var exitCode = 0;
 var failed = [];
+var passed = [];
+var flakey = [];
 
-function runCitgm (module, name, next) {
-  if (module.skip) {
+function runCitgm (mod, name, next) {
+  if (mod.skip) {
     next();
     return;
   }
@@ -90,35 +97,78 @@ function runCitgm (module, name, next) {
   .on('start', function(name) {
     log.info('starting', name);
   }).on('fail', function(err) {
-    failed.push({
-      name: name,
-      err: err.message
-    });
     log.error('failure', err.message);
-    process.exitCode = 1;
   }).on('data', function(type,key,message) {
     log[type](key, message);
-  }).on('end', function(name) {
-    if (process.exitCode) {
-      log.error('done', 'The test suite for ' + name + ' failed');
-      exitCode = process.exitCode;
-      process.exitCode = 0;
+  }).on('end', function(module) {
+    if (module.error) {
+      log.error('done', 'The test suite for ' + module.name + ' failed');
+      if (mod.flakey) {
+        flakey.push(module);
+      }
+      else {
+        exitCode = 1;
+        failed.push(module);
+      }
     }
     else {
-      log.info('done', 'The test suite for ' + name + ' passed.');
+      passed.push(module);
+      log.info('done', 'The test suite for ' + module.name + ' passed.');
     }
     next();
   }).run();
 }
 
+function printModule(logType, module) {
+  log[logType]('module name', module.name);
+  if (module.error) {
+    log[logType]('error', module.error.message);
+  }
+}
+
+function printModules(logType, modules) {
+  _.each(modules, function (module) {
+    printModule(logType, module);
+  });
+}
+
+function printModulesMarkdown(title, modules) {
+  if (modules.length > 0) {
+    console.log('##' + title + ' Modules');
+    _.each(modules, function (module) {
+      console.log('* ' + module.name);
+      if (module.error) {
+        console.log('  * ' + module.error.message);
+      }
+    });
+    console.log('');
+  }
+}
+
 function launch() {
   async.forEachOfSeries(lookup, runCitgm, function done () {
-    if (exitCode) {
-      process.exitCode = exitCode;
-      log.error('done', 'citgm-all failed');
-      log.error('failed modules', failed);
-      process.exit(exitCode);
+    if (passed.length > 0) {
+      log.info('passing modules');
+      printModules('info', passed);
     }
-    log.info('done', 'citgm-all passed.');
+    if (flakey.length > 0) {
+      log.warn('flakey modules');
+      printModules('warn', flakey);
+    }
+    if (failed.length > 0) {
+      process.exitCode = exitCode;
+      log.error('failing modules');
+      printModules('error', failed);
+      log.error('done', 'citgm-all failed');
+    }
+    else {
+      log.info('done', 'citgm-all passed.');
+    }
+    if (app.markdown) {
+      printModulesMarkdown('Passing', passed);
+      printModulesMarkdown('Flakey', flakey);
+      printModulesMarkdown('Failing', failed);
+    }
+    process.exit(exitCode);
   });
 }

--- a/bin/citgm-all
+++ b/bin/citgm-all
@@ -3,6 +3,7 @@
 var app = require('commander');
 var async = require('async');
 var _ = require('lodash');
+var chalk = require('chalk');
 
 var update = require('../lib/update');
 var citgm = require('../lib/citgm');
@@ -101,7 +102,7 @@ function runCitgm (mod, name, next) {
     log[type](key, message);
   }).on('end', function(module) {
     if (module.error) {
-      log.error('done', 'The test suite for ' + module.name + ' failed');
+      log.error('done', 'The test suite for ' + module.name + ' version ' + module.version + ' failed');
       if (mod.flakey) {
         flakey.push(module);
       }
@@ -112,14 +113,15 @@ function runCitgm (mod, name, next) {
     }
     else {
       passed.push(module);
-      log.info('done', 'The test suite for ' + module.name + ' passed.');
+      log.info('done', 'The test suite for ' + module.name + ' version ' + module.version + ' passed.');
     }
     next();
   }).run();
 }
 
 function printModule(logType, module) {
-  log[logType]('module name', module.name);
+  log[logType](chalk.yellow('module name:'), module.name);
+  log[logType](chalk.yellow('version:'), module.version);
   if (module.error) {
     log[logType]('error', module.error.message);
   }
@@ -132,16 +134,19 @@ function printModules(logType, modules) {
 }
 
 function printModulesMarkdown(title, modules) {
+  /*eslint-disable no-console*/
   if (modules.length > 0) {
     console.log('##' + title + ' Modules');
     _.each(modules, function (module) {
       console.log('* ' + module.name);
+      console.log('  * version ' + module.version);
       if (module.error) {
         console.log('  * ' + module.error.message);
       }
     });
     console.log('');
   }
+  /*eslint-enable no-console*/
 }
 
 function launch() {

--- a/bin/citgm-all
+++ b/bin/citgm-all
@@ -11,7 +11,6 @@ var getLookup = require('../lib/lookup').get;
 
 app
   .version('0.2.3')
-  .arguments('<module> [test]')
   .action(function() {
   })
   .option(

--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -97,8 +97,12 @@ Tester.prototype.run = function() {
   var cleanup = function(code) {
     cleanexit = true;
     tempDirectory.remove(self, function() {
-      self.emit('fail', Error('Process Interupted'));
-      self.emit('end', self.module.raw);
+      var payload = {
+        name: self.module.name || self.module.raw,
+        error: Error('Process Interupted')
+      };
+      self.emit('fail', payload.error);
+      self.emit('end', payload);
       process.exit(code);
     });
   };
@@ -119,12 +123,19 @@ Tester.prototype.run = function() {
     npm.test
   ], function(err) {
     if (!cleanexit) {
-      if (err) self.emit('fail', err);
+      var payload = {
+        name: self.module.name || self.module.raw
+      };
+      if (err) {
+        self.emit('fail', err);
+        payload.error = new Error(err);
+      }
       tempDirectory.remove(self, function() {
-        self.emit('end', self.module.raw);
+        self.emit('end', payload);
         cleanexit = true;
       });
     }
   });
 };
+
 exports.Tester = Tester;

--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -124,7 +124,8 @@ Tester.prototype.run = function() {
   ], function(err) {
     if (!cleanexit) {
       var payload = {
-        name: self.module.name || self.module.raw
+        name: self.module.name || self.module.raw,
+        version: self.module.version
       };
       if (err) {
         self.emit('fail', err);

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -60,6 +60,7 @@ function resolve(context, next) {
   var meta = context.meta;
   if (meta) {
     var rep = lookup[detail.name];
+    context.module.version = meta.version;
     if (rep) {
       if (rep.replace) {
         if (!rep.repo && !meta.repository) {

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -18,6 +18,7 @@ function getRepo(repo, meta) {
   var ret = normgit(repo || meta.repository.url).url;
   ret = ret.replace(/\.git$/,'');
   ret = ret.replace(/^git:/,'https:');
+  ret = ret.replace(/^ssh:\/\/git@/, 'https://');
   return ret;
 }
 

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -67,7 +67,8 @@
     "prefix": "v"
   },
   "david": {
-    "replace": true
+    "replace": true,
+    "prefix": "v"
   },
   "eslint": {
     "replace": true,
@@ -95,7 +96,11 @@
     "replace": true,
     "prefix": "v"
   },
-  "webpack": {
+  "react": {
+    "replace": true,
+    "prefix": "v"
+  },
+  "gulp": {
     "replace": true,
     "prefix": "v"
   }

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -17,17 +17,10 @@
     "repo": "https://github.com/tj/commander.js"
   },
   "express": {
-    "replace": true
-  },
-  "chalk": {
     "replace": true,
-    "prefix": "v"
+    "flakey": true
   },
   "q": {
-    "replace": true,
-    "prefix": "v"
-  },
-  "colors": {
     "replace": true,
     "prefix": "v"
   },
@@ -38,16 +31,8 @@
     "replace": true,
     "prefix": "v"
   },
-  "bluebird": {
-    "replace": true,
-    "prefix": "v"
-  },
   "moment": {
     "replace": true
-  },
-  "yeoman-generator": {
-    "replace": true,
-    "prefix": "v"
   },
   "glob": {
     "replace": true,
@@ -59,10 +44,6 @@
   },
   "jade": {
     "replace": true
-  },
-  "redis": {
-    "replace": true,
-    "prefix": "v"
   },
   "socket.io": {
     "replace": true
@@ -78,26 +59,44 @@
     "prefix": "v"
   },
   "jquery": {
-    "replace": true
-  },
-  "handlebars": {
     "replace": true,
-    "prefix": "v"
+    "flakey": true
   },
   "rimraf": {
     "replace": true,
     "prefix": "v"
   },
-  "yosay": {
+  "david": {
+    "replace": true
+  },
+  "eslint": {
     "replace": true,
     "prefix": "v"
   },
-  "mime": {
+  "tape": {
     "replace": true,
     "prefix": "v"
   },
-  "mongodb": {
+  "browserify": {
+    "replace": true
+  },
+  "watchify": {
     "replace": true,
-    "prefix": "V"
+    "prefix": "v"
+  },
+  "stylus": {
+    "replace": true
+  },
+  "level": {
+    "replace": true,
+    "prefix": "v"
+  },
+  "torrent-stream": {
+    "replace": true,
+    "prefix": "v"
+  },
+  "webpack": {
+    "replace": true,
+    "prefix": "v"
   }
 }

--- a/man/citgm-all.1
+++ b/man/citgm-all.1
@@ -1,14 +1,14 @@
-.\" Manpage for citgm
-.\" Contact jasnell@gmail.com to correct errors or typos
+.\" Manpage for citgm-all
+.\" Contact mborins@us.ibm.com to correct errors or typos
 .TH "0.1.0" "MIT"
 .SH NAME
-citgm \- Canary in the Goldmine
+citgm-all \- Canary in the Goldmine
 .SH SYNOPSIS
-citgm [options] <module> [custom-test-script]
+citgm-all [options]
 .SH DESCRIPTION
 citgm is a tool for testing Node.js modules against different Node.js builds.
 Specifically, it automates the 'npm install' and 'npm test' steps and reports
-back the status.
+back the status. citgm-all will run tests on all modules in the lookup table.
 .SH OPTIONS
 .TP
 .BR \-h ", " \-\-help
@@ -19,9 +19,6 @@ output the version number
 .TP
 .BR \-v ", " \-\-verbose " " \fI[silly|verbose|info|warn|error]\fR
 Verbose output (silly,verbose,info,warn,error)
-.TP
-.BR \-k ", " \-\-hmac " " \fIkey\fR
-HMAC Key for Script Verification
 .TP
 .BR \-l ", " \-\-lookup " " \fI<path>\fR
 Use the lookup table provided at <path>
@@ -35,36 +32,19 @@ Turns off colorized output
 .BR \-s ", " \-\-su
 Allow running the tool as root
 .TP
+.BR \-m ", " \-\-markdown
+Output results in markdown
+.TP
 .BR \-u ", " \-\-uid " " \fIuid\fR
 Set the uid (posix only)
 .TP
 .BR \-g ", " \-\-gid " " \fIuid\fR
 Set the gid (posix only)
-.SH EXAMPLES
-Test the latest underscore module:
-
-  citgm underscore@latest
-
-Test a local module:
-
-  citgm ./my-module
-
-Test using a custom script:
-
-  citgm ./my-module ./my-custom-test.js
-
-Test using a custom remote script:
-
-  citgm -k hmackey ./my-module http://example.org/my-custom-test.js
-
-Test using a tar.gz from Github:
-
-  citgm http://github.com/jasnell/activitystrea.ms/archive/master.tar.gz
 
 .SH SEE ALSO
-citgm-all
+citgm
 .SH AUTHOR
-James M Snell <jasnell@gmail.com>
+Myles Borins <mborins@us.ibm.com>
 .SH COPYRIGHT
 Copyright (c) 2015 citgm contributors
 .SH LICENSE

--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
   "preferGlobal": true,
   "bin": {
     "citgm": "./bin/citgm",
-    "citgm-dockerify": "./bin/citgm-dockerify"
+    "citgm-dockerify": "./bin/citgm-dockerify",
+    "citgm-all": "./bin/citgm-all"
   },
   "scripts": {
     "test": "npm run lint && npm run tap",
-    "tap": "tap test/test-*.js",
+    "tap": "TAP_TIMEOUT=90 tap test/test-*.js",
     "lint": "eslint bin/* lib/ test/",
     "watch": "nodemon --ignore node_modules/ -e js,json --exec 'npm run tap'"
   },

--- a/test/fixtures/custom-lookup-fail.json
+++ b/test/fixtures/custom-lookup-fail.json
@@ -1,0 +1,8 @@
+{
+  "omg-i-pass": {
+    "replace": true
+  },
+  "omg-i-fail": {
+    "replace": false
+  }
+}

--- a/test/fixtures/custom-lookup-skip.json
+++ b/test/fixtures/custom-lookup-skip.json
@@ -1,0 +1,9 @@
+{
+  "omg-i-pass": {
+    "replace": false
+  },
+  "omg-i-fail": {
+    "replace": false,
+    "skip": true
+  }
+}

--- a/test/fixtures/custom-lookup.json
+++ b/test/fixtures/custom-lookup.json
@@ -2,7 +2,8 @@
   "omg-i-pass": {
     "replace": false
   },
-  "rim-raf": {
-    "replace": true
+  "rimraf": {
+    "replace": true,
+    "prefix": "v"
   }
 }

--- a/test/fixtures/pretty-print.json
+++ b/test/fixtures/pretty-print.json
@@ -1,0 +1,14 @@
+{
+  "chalk": {
+    "replace": true,
+    "prefix": "v"
+  },
+  "colors": {
+    "replace": true,
+    "prefix": "v"
+  },
+  "yosay": {
+    "replace": true,
+    "prefix": "v"
+  }
+}

--- a/test/test-citgm-all.js
+++ b/test/test-citgm-all.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var path = require('path');
+
+var test = require('tap').test;
+
+var spawn = require('../lib/spawn');
+
+var citgmAllPath = path.resolve(__dirname, '..', 'bin', 'citgm-all');
+
+test('citgm-all:', function (t) {
+  t.plan(1);
+  var proc = spawn(citgmAllPath, ['-l', 'test/fixtures/custom-lookup.json']);
+  proc.on('error', function(err) {
+    t.error(err);
+    t.fail('we should not get an error testing omg-i-pass');
+  });
+  proc.on('close', function (code) {
+    t.equals(code, 0, 'citgm-all should run all the tests in the lookup');
+  });
+});
+
+test('citgm-all: fail', function (t) {
+  t.plan(1);
+  var proc = spawn(citgmAllPath, ['-l', 'test/fixtures/custom-lookup-fail.json']);
+  proc.on('error', function(err) {
+    t.error(err);
+  });
+  proc.on('close', function (code) {
+    t.equals(code, 1, 'citgm-all should have failed');
+  });
+});

--- a/test/test-citgm-all.js
+++ b/test/test-citgm-all.js
@@ -30,3 +30,14 @@ test('citgm-all: fail', function (t) {
     t.equals(code, 1, 'citgm-all should have failed');
   });
 });
+
+test('citgm-all: skip', function (t) {
+  t.plan(1);
+  var proc = spawn(citgmAllPath, ['-l', 'test/fixtures/custom-lookup-skip.json']);
+  proc.on('error', function(err) {
+    t.error(err);
+  });
+  proc.on('close', function (code) {
+    t.equals(code, 0, 'it should run omg-i-pass and skip omg-i-fail');
+  });
+});

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -65,8 +65,9 @@ test('lookup[getLookupTable]: custom table', function (t) {
     'omg-i-pass': {
       replace: false
     },
-    'rim-raf': {
-      replace: true
+    'rimraf': {
+      replace: true,
+      prefix: 'v'
     }
   }, 'we should receive the expected lookup table from the fixtures folder');
   t.end();


### PR DESCRIPTION
This PR adds a new bin to the project ```citgm-all```

By default ```citgm-all``` will run the test suite of every package in the lookup table. If a custom lookup table is provided it will iterate across that instead.

TODO:
- [x] ~~add more modules to the lookup table~~
- [x] ~~ensure every package in lookup works(ish)~~
- [x] ~~#26 needs to land~~
- [x] ~~update documentation~~
- [x] ~~report versions tested~~