### PR TITLE
lookup: label request flaky

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -9,7 +9,8 @@
   },
   "request": {
     "replace": true,
-    "prefix": "v"
+    "prefix": "v",
+    "flakey": true
   },
   "commander": {
     "replace": true,


### PR DESCRIPTION
as documented in #47 request is being flaky on certain systems. This changes the flag to make CI pass for now