### PR TITLE
lookup: mark lodash as flaky

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -1,7 +1,8 @@
 {
   "lodash": {
     "replace": true,
-    "master": true
+    "master": true,
+    "flaky": true
   },
   "underscore": {
     "replace": true,


### PR DESCRIPTION
Lodash v4.0.0 is missing files from the tar ball that is
causing citgm to fail.

This is being tracked in #61