### PR TITLE
bin: remove option for test in citgm

### DIFF
--- a/bin/citgm
+++ b/bin/citgm
@@ -7,7 +7,7 @@ var app = require('commander');
 
 var pkg = require('../package.json');
 
-var mod, test;
+var mod;
 app
   .version(pkg.version)
   .arguments('<module>')


### PR DESCRIPTION
this was missed in the deprecation of scripts / hmac

/cc @jasnell 