### PR TITLE
lookup: explicitly state jade repo

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -41,7 +41,8 @@
     "prefix": "v"
   },
   "jade": {
-    "replace": true
+    "replace": true,
+    "repo": "https://github.com/pugjs/jade"
   },
   "socket.io": {
     "replace": true,


### PR DESCRIPTION
Jade has recently switched orgs to pugjs, but the package.json does not reflect this

As such our resolving algorithm for tarballs is borking.

Manually specify repo until they update the package.json upstream

/cc @jasnell @Fishrock123 @nodejs/smoke-test 