### PR TITLE
 	bin: add --npm-loglevel flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,16 @@ Usage: citgm [options] <module>
 
 Options:
 
-  -h, --help           output usage information
-  -V, --version        output the version number
-  -v, --verbose        Verbose output
-  -l, --lookup [path]  Use the lookup table. Optional [path] for alternate
-                       json file
-  -d, --nodedir <path> Path to the node source to use when compiling native
-                       addons
-  -n, --no-color       Turns off colorized output
-  -s, --su             Allow running the tool as root
-  -u, --uid <uid>      Set the uid (posix only)
-  -g, --gid <uid>      Set the gid (posix only)
+  -h, --help                 output usage information
+  -V, --version              output the version number
+  -v, --verbose [level]      Verbose output (silly, verbose, info, warn, error)
+  -q, --npm-loglevel [level]  Verbose output (silent, error, warn, http, info, verbose, silly)
+  -l, --lookup <path>        Use the lookup table provided at <path>
+  -d, --nodedir <path>       Path to the node source to use when compiling native addons
+  -n, --no-color             Turns off colorized output
+  -s, --su                   Allow running the tool as root.
+  -u, --uid <uid>            Set the uid (posix only)
+  -g, --gid <uid>            Set the gid (posix only)
 ```
 
 The tool requires online access to the npm registry to run. If you want to
@@ -62,16 +61,17 @@ Usage: citgm-all [options]
 
 Options:
 
-  -h, --help             output usage information
-  -V, --version          output the version number
-  -v, --verbose [level]  Verbose output (silly, verbose, info, warn, error)
-  -l, --lookup <path>    Use the lookup table provided at <path>
-  -d, --nodedir <path>   Path to the node source to use when compiling native addons
-  -n, --no-color         Turns off colorized output
-  -s, --su               Allow running the tool as root.
-  -m, --markdown         Output results in markdown
-  -u, --uid <uid>        Set the uid (posix only)
-  -g, --gid <uid>        Set the gid (posix only)
+  -h, --help                 output usage information
+  -V, --version              output the version number
+  -v, --verbose [level]      Verbose output (silly, verbose, info, warn, error)
+  -q, --npm-loglevel [level]  Verbose output (silent, error, warn, http, info, verbose, silly)
+  -l, --lookup <path>        Use the lookup table provided at <path>
+  -d, --nodedir <path>       Path to the node source to use when compiling native addons
+  -n, --no-color             Turns off colorized output
+  -s, --su                   Allow running the tool as root.
+  -m, --markdown             Output results in markdown
+  -u, --uid <uid>            Set the uid (posix only)
+  -g, --gid <uid>            Set the gid (posix only)
 ```
 
 ## Testing

--- a/bin/citgm
+++ b/bin/citgm
@@ -19,6 +19,10 @@ app
     'Verbose output (silly, verbose, info, warn, error)',
     /^(silly|verbose|info|warn|error)$/i, 'info')
   .option(
+    '-q, --npm-loglevel [level]',
+    'Verbose output (silent, error, warn, http, info, verbose, silly)',
+    /^(silent|error|warn|http|info|verbose|silly)$/i, 'error')
+  .option(
     '-l, --lookup <path>',
     'Use the lookup table provided at <path>'
   )
@@ -66,7 +70,8 @@ if (!app.su) {
 var options = {
   lookup: app.lookup,
   nodedir: app.nodedir,
-  level: app.verbose
+  level: app.verbose,
+  npmLevel: app.npmLoglevel
 };
 
 if (!citgm.windows) {

--- a/bin/citgm-all
+++ b/bin/citgm-all
@@ -21,6 +21,10 @@ app
     'Verbose output (silly, verbose, info, warn, error)',
     /^(silly|verbose|info|warn|error)$/i, 'info')
   .option(
+    '-q, --npm-loglevel [level]',
+    'Verbose output (silent, error, warn, http, info, verbose, silly)',
+    /^(silent|error|warn|http|info|verbose|silly)$/i, 'error')
+  .option(
     '-l, --lookup <path>',
       'Use the lookup table provided at <path>'
   )
@@ -66,7 +70,8 @@ if (!app.su) {
 var options = {
   lookup: app.lookup,
   nodedir: app.nodedir,
-  level: app.verbose
+  level: app.verbose,
+  npmLevel: app.npmLoglevel
 };
 
 var lookup = getLookup(options);

--- a/lib/npm/setup.js
+++ b/lib/npm/setup.js
@@ -12,7 +12,7 @@ function setup(context, next) {
   var options =
     createOptions(
       path.join(context.path, context.module.name), context);
-  var args = ['install', '--loglevel=error'];
+  var args = ['install', '--loglevel=' + context.options.npmLevel];
   context.emit('data', 'info', 'npm:', 'install started');
   if (context.options.nodedir) {
     var nodedir = path.resolve(process.cwd(),context.options.nodedir);

--- a/lib/npm/test.js
+++ b/lib/npm/test.js
@@ -41,7 +41,7 @@ function test(context, next) {
     }
 
     var options = createOptions(wd, context);
-    var proc = spawn('npm', ['test'], options);
+    var proc = spawn('npm', ['test', '--loglevel=' + context.options.npmLevel], options);
     proc.stdout.on('data', function (data) {
       context.emit('data', 'verbose', 'npm-test:', data.toString());
     });

--- a/man/citgm-all.1
+++ b/man/citgm-all.1
@@ -17,8 +17,11 @@ output usage information
 .BR \-V ", " \-\-version
 output the version number
 .TP
-.BR \-v ", " \-\-verbose " " \fI[silly|verbose|info|warn|error]\fR
+.BR \-v ", " \-\-verbose " " \fI[level]\fR
 Verbose output (silly,verbose,info,warn,error)
+.TP
+.BR \-q ", " \-\-npm-loglevel " " \fI[level]\fR
+Verbose output (silent, error, warn, http, info, verbose, silly)
 .TP
 .BR \-l ", " \-\-lookup " " \fI<path>\fR
 Use the lookup table provided at <path>

--- a/man/citgm.1
+++ b/man/citgm.1
@@ -17,8 +17,11 @@ output usage information
 .BR \-V ", " \-\-version
 output the version number
 .TP
-.BR \-v ", " \-\-verbose " " \fI[silly|verbose|info|warn|error]\fR
+.BR \-v ", " \-\-verbose " " \fI[level]\fR
 Verbose output (silly,verbose,info,warn,error)
+.TP
+.BR \-q ", " \-\-npm-loglevel " " \fI[level]\fR
+Verbose output (silent, error, warn, http, info, verbose, silly)
 .TP
 .BR \-l ", " \-\-lookup " " \fI<path>\fR
 Use the lookup table provided at <path>


### PR DESCRIPTION
You can now pass a verbosity level to npm. Data!

- [x] ~~update `lib/npm` to use new option~~
- [x] ~~add option to `citgm` / `citgm-all` /w default *(error)*~~
- [x] ~~update README~~
- [x] ~~update man~~

Closes #56