### PR TITLE
Add tap reporter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,27 +1,24 @@
 {
-    "rules": {
-        "indent": [
-            2,
-            2
-        ],
-        "quotes": [
-            2,
-            "single"
-        ],
-        "linebreak-style": [
-            2,
-            "unix"
-        ],
-        "semi": [
-            2,
-            "always"
-        ]
-    },
-    "env": {
-        "node": true
-    },
-    "extends": "eslint:recommended",
-    "ecmaFeatures": {
-        "blockBindings": true
-    }
+  "rules": {
+    "indent": [
+      2,
+      2
+    ],
+    "quotes": [
+      2,
+      "single"
+    ],
+    "linebreak-style": [
+      2,
+      "unix"
+    ],
+    "semi": [
+      2,
+      "always"
+    ]
+  },
+  "env": {
+    "node": true
+  },
+  "extends": "eslint:recommended"
 }

--- a/README.md
+++ b/README.md
@@ -18,21 +18,22 @@ bin/citgm --help
 
 (If citgm is installed globally, you can also `man citgm`)
 
-```
+```bash
 Usage: citgm [options] <module>
 
 Options:
 
-  -h, --help                 output usage information
-  -V, --version              output the version number
-  -v, --verbose [level]      Verbose output (silly, verbose, info, warn, error)
+  -h, --help                  output usage information
+  -V, --version               output the version number
+  -v, --verbose [level]       Verbose output (silly, verbose, info, warn, error)
   -q, --npm-loglevel [level]  Verbose output (silent, error, warn, http, info, verbose, silly)
-  -l, --lookup <path>        Use the lookup table provided at <path>
-  -d, --nodedir <path>       Path to the node source to use when compiling native addons
-  -n, --no-color             Turns off colorized output
-  -s, --su                   Allow running the tool as root.
-  -u, --uid <uid>            Set the uid (posix only)
-  -g, --gid <uid>            Set the gid (posix only)
+  -l, --lookup <path>         Use the lookup table provided at <path>
+  -d, --nodedir <path>        Path to the node source to use when compiling native addons
+  -n, --no-color              Turns off colorized output
+  -s, --su                    Allow running the tool as root.
+  -m, --markdown              Output results in markdown
+  -u, --uid <uid>             Set the uid (posix only)
+  -g, --gid <uid>             Set the gid (posix only)
 ```
 
 The tool requires online access to the npm registry to run. If you want to
@@ -56,22 +57,22 @@ table use citgm-all. It will automate the running of all tests and give
 itemized results at the end. It has all the same options as citgm except
 for the added markdown option which will print the results in markdown.
 
-```
+```bash
 Usage: citgm-all [options]
 
 Options:
 
-  -h, --help                 output usage information
-  -V, --version              output the version number
-  -v, --verbose [level]      Verbose output (silly, verbose, info, warn, error)
+  -h, --help                  output usage information
+  -V, --version               output the version number
+  -v, --verbose [level]       Verbose output (silly, verbose, info, warn, error)
   -q, --npm-loglevel [level]  Verbose output (silent, error, warn, http, info, verbose, silly)
-  -l, --lookup <path>        Use the lookup table provided at <path>
-  -d, --nodedir <path>       Path to the node source to use when compiling native addons
-  -n, --no-color             Turns off colorized output
-  -s, --su                   Allow running the tool as root.
-  -m, --markdown             Output results in markdown
-  -u, --uid <uid>            Set the uid (posix only)
-  -g, --gid <uid>            Set the gid (posix only)
+  -l, --lookup <path>         Use the lookup table provided at <path>
+  -d, --nodedir <path>        Path to the node source to use when compiling native addons
+  -n, --no-color              Turns off colorized output
+  -s, --su                    Allow running the tool as root.
+  -m, --markdown              Output results in markdown
+  -u, --uid <uid>             Set the uid (posix only)
+  -g, --gid <uid>             Set the gid (posix only)
 ```
 
 You can also test your own list of modules:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Options:
   -n, --no-color              Turns off colorized output
   -s, --su                    Allow running the tool as root.
   -m, --markdown              Output results in markdown
+  -t, --tap [path]            Output results in tap with optional file path
   -u, --uid <uid>             Set the uid (posix only)
   -g, --gid <uid>             Set the gid (posix only)
 ```
@@ -71,6 +72,7 @@ Options:
   -n, --no-color              Turns off colorized output
   -s, --su                    Allow running the tool as root.
   -m, --markdown              Output results in markdown
+  -t, --tap [path]            Output results in tap with optional file path
   -u, --uid <uid>             Set the uid (posix only)
   -g, --gid <uid>             Set the gid (posix only)
 ```
@@ -89,6 +91,7 @@ For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
 "flaky": true                Ignore failures
 "skip": true                 Completely skip the module
 "repo": "https://github.com/pugjs/jade" - Use a different github repo
+"skipAnsi": true             Strip ansi data from output stream of npm
 ```
 ## Testing
 

--- a/bin/citgm
+++ b/bin/citgm
@@ -3,6 +3,7 @@
 var update = require('../lib/update');
 var citgm = require('../lib/citgm');
 var logger = require('../lib/out');
+var reporter = require('../lib/reporter');
 var app = require('commander');
 
 var pkg = require('../package.json');
@@ -35,6 +36,9 @@ app
   )
   .option(
     '-s, --su', 'Allow running the tool as root.'
+  )
+  .option(
+    '-m, --markdown', 'Output results in markdown'
   );
 
 if (!citgm.windows) {
@@ -96,11 +100,12 @@ function launch(mod, options) {
   }).on('data', function(type, key, message) {
     log[type](key, message);
   }).on('end', function(module) {
-    if (module.error) {
-      process.exitCode = 1;
-      log.error('done', 'The test suite for ' + module.name + ' version ' + module.version + ' failed');
-      process.exit();
+    reporter.logger(log, module);
+
+    if (app.markdown) {
+      reporter.markdown(log.bypass, module);
     }
-    log.info('done', 'The test suite for ' + module.name + ' version ' + module.version + ' passed.');
+
+    process.exit(module.error ? 1 : 0);
   }).run();
 }

--- a/bin/citgm
+++ b/bin/citgm
@@ -9,6 +9,7 @@ var app = require('commander');
 var pkg = require('../package.json');
 
 var mod;
+
 app
   .version(pkg.version)
   .arguments('<module>')
@@ -39,6 +40,9 @@ app
   )
   .option(
     '-m, --markdown', 'Output results in markdown'
+  )
+  .option(
+    '-t, --tap [path]', 'Output results in tap with optional file path'
   );
 
 if (!citgm.windows) {
@@ -104,6 +108,14 @@ function launch(mod, options) {
 
     if (app.markdown) {
       reporter.markdown(log.bypass, module);
+    }
+
+    if (app.tap) {
+      // if tap is a string it should be a path to write output to
+      // if not use `log.bypass` which is currently process.stdout.write
+      // TODO check that we can write to that path, perhaps require a flag to overwrite
+      var tap = (typeof app.tap === 'string') ? app.tap : log.bypass;
+      reporter.tap(tap, module);
     }
 
     process.exit(module.error ? 1 : 0);

--- a/bin/citgm-all
+++ b/bin/citgm-all
@@ -39,6 +39,9 @@ app
   )
   .option(
     '-m, --markdown', 'Output results in markdown'
+  )
+  .option(
+    '-t, --tap [path]', 'Output results in tap with optional file path'
   );
 
 if (!citgm.windows) {
@@ -103,14 +106,15 @@ function runCitgm (mod, name, next) {
     log.error('failure', err.message);
   }).on('data', function(type,key,message) {
     log[type](key, message);
-  }).on('end', function(module) {
-    if (module.error) {
-      log.error('done', 'The test suite for ' + module.name + ' version ' + module.version + ' failed');
+  }).on('end', function(result) {
+    if (result.error) {
+      log.error('done', 'The test suite for ' + result.name + ' version ' + result.version + ' failed');
     }
     else {
-      log.info('done', 'The test suite for ' + module.name + ' version ' + module.version + ' passed.');
+      log.info('done', 'The test suite for ' + result.name + ' version ' + result.version + ' passed.');
     }
-    modules.push(module);
+    result.flaky = mod.flaky;
+    modules.push(result);
     next(null);
   }).run();
 }
@@ -125,6 +129,14 @@ function launch() {
 
     if (app.markdown) {
       reporter.markdown(log.bypass, modules);
+    }
+    
+    if (app.tap) {
+      // if tap is a string it should be a path to write output to
+      // if not use `log.bypass` which is currently process.stdout.write
+      // TODO check that we can write to that path, perhaps require a flag to overwrite
+      var tap = (typeof app.tap === 'string') ? app.tap : log.bypass;
+      reporter.tap(tap, modules);
     }
 
     process.exit(reporter.util.hasFailures(modules));

--- a/bin/citgm-all
+++ b/bin/citgm-all
@@ -2,12 +2,11 @@
 'use strict';
 var app = require('commander');
 var async = require('async');
-var _ = require('lodash');
-var chalk = require('chalk');
 
 var update = require('../lib/update');
 var citgm = require('../lib/citgm');
 var logger = require('../lib/out');
+var reporter = require('../lib/reporter');
 var getLookup = require('../lib/lookup').get;
 
 var pkg = require('../package.json');
@@ -26,11 +25,11 @@ app
     /^(silent|error|warn|http|info|verbose|silly)$/i, 'error')
   .option(
     '-l, --lookup <path>',
-      'Use the lookup table provided at <path>'
+    'Use the lookup table provided at <path>'
   )
   .option(
-      '-d, --nodedir <path>',
-      'Path to the node source to use when compiling native addons'
+    '-d, --nodedir <path>',
+    'Path to the node source to use when compiling native addons'
   )
   .option(
     '-n, --no-color', 'Turns off colorized output'
@@ -89,10 +88,7 @@ if (!citgm.windows) {
   launch(options);
 }
 
-var exitCode = 0;
-var failed = [];
-var passed = [];
-var flaky = [];
+var modules = [];
 
 function runCitgm (mod, name, next) {
   if (mod.skip) {
@@ -110,90 +106,27 @@ function runCitgm (mod, name, next) {
   }).on('end', function(module) {
     if (module.error) {
       log.error('done', 'The test suite for ' + module.name + ' version ' + module.version + ' failed');
-      // TODO the module should likely mark itself flaky on error
-      //       but currently all flaky logic lives in citgm-all
-      if (mod.flaky || module.error.message === 'No project downloaded') {
-        flaky.push(module);
-      }
-      else {
-        exitCode = 1;
-        failed.push(module);
-      }
     }
     else {
-      passed.push(module);
       log.info('done', 'The test suite for ' + module.name + ' version ' + module.version + ' passed.');
     }
-    next();
+    modules.push(module);
+    next(null);
   }).run();
 }
 
-function printModule(logType, module) {
-  log[logType](chalk.yellow('module name:'), module.name);
-  log[logType](chalk.yellow('version:'), module.version);
-  if (module.error) {
-    log[logType]('error', module.error.message);
-  }
-}
-
-function printModules(logType, modules) {
-  _.each(modules, function (module) {
-    printModule(logType, module);
-  });
-}
-
-function printModulesMarkdown(title, modules) {
-  /*eslint-disable no-console*/
-  if (modules.length > 0) {
-    console.log('### ' + title + ' Modules');
-    _.each(modules, function (module) {
-      console.log('* ' + module.name);
-      console.log('  - version ' + module.version);
-      if (module.error) {
-        console.log('  * ' + module.error.message);
-      }
-    });
-    console.log('');
-  }
-  /*eslint-enable no-console*/
-}
-
-function printMarkdown() {
-  /*eslint-disable no-console*/
-  if (failed.length === 0) {
-    console.log('## 🎉🎉 CITGM Passed 🎉🎉');
-  }
-  else {
-    console.log('## 🔥⚠️🔥 CITGM FAILED 🔥⚠️🔥');
-  }
-  /*eslint-enable no-console*/
-  printModulesMarkdown('Passing', passed);
-  printModulesMarkdown('Flaky', flaky);
-  printModulesMarkdown('Failing', failed);
-}
-
 function launch() {
-  async.forEachOfSeries(lookup, runCitgm, function done () {
-    if (passed.length > 0) {
-      log.info('passing modules');
-      printModules('info', passed);
+  async.forEachOfSeries(lookup, runCitgm, function done (err) {
+    if (err) {
+      log.error('citgm-all failure:', err.message);
     }
-    if (flaky.length > 0) {
-      log.warn('flaky modules');
-      printModules('warn', flaky);
-    }
-    if (failed.length > 0) {
-      process.exitCode = exitCode;
-      log.error('failing modules');
-      printModules('error', failed);
-      log.error('done', 'citgm-all failed');
-    }
-    else {
-      log.info('done', 'citgm-all passed.');
-    }
+
+    reporter.logger(log, modules);
+
     if (app.markdown) {
-      printMarkdown();
+      reporter.markdown(log.bypass, modules);
     }
-    process.exit(exitCode);
+
+    process.exit(reporter.util.hasFailures(modules));
   });
 }

--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -129,7 +129,10 @@ Tester.prototype.run = function() {
       };
       if (err) {
         self.emit('fail', err);
-        payload.error = new Error(err);
+        payload.error = err;
+      }
+      if (self.module.testOutput) {
+        payload.testOutput = self.module.testOutput;
       }
       tempDirectory.remove(self, function() {
         self.emit('end', payload);

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -62,6 +62,9 @@ function resolve(context, next) {
     var rep = lookup[detail.name];
     context.module.version = meta.version;
     if (rep) {
+      if (rep.stripAnsi) {
+        context.module.stripAnsi = rep.stripAnsi;
+      }
       if (rep.replace) {
         if (!rep.repo && !meta.repository) {
           next(new Error('no-repository-field in package.json'));

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -29,7 +29,8 @@
   },
   "through2": {
     "replace": true,
-    "prefix": "v"
+    "prefix": "v",
+    "stripAnsi": true
   },
   "glob": {
     "replace": true,
@@ -134,7 +135,8 @@
   },
   "throughv": {
     "replace": true,
-    "prefix": "v"
+    "prefix": "v",
+    "stripAnsi": true
   },
   "duplexer2": {
     "replace": true,
@@ -142,7 +144,8 @@
   },
   "bl": {
     "replace": true,
-    "prefix": "v"
+    "prefix": "v",
+    "stripAnsi": true
   },
   "binary-split": {
     "replace": true,

--- a/lib/npm/test.js
+++ b/lib/npm/test.js
@@ -5,6 +5,7 @@ var path = require('path');
 
 // npm modules
 var readPackage = require('read-package-json');
+var stripAnsi = require('strip-ansi');
 
 // local modules
 var spawn = require('../spawn');
@@ -26,7 +27,7 @@ function test(context, next) {
   context.emit('data', 'info', 'npm:', 'test suite started');
   readPackage(path.join(wd,'package.json'),false,function(err,data) {
     if (err) {
-      next(Error('Package.json Could not be found'));
+      next(new Error('Package.json Could not be found'));
       return;
     }
     if (data.scripts === undefined ||
@@ -36,13 +37,19 @@ function test(context, next) {
           'Please contact the module developer to request adding npm' +
           ' test support: ' + authorName(data.author));
       }
-      next(Error('Module does not support npm-test!'));
+      next(new Error('Module does not support npm-test!'));
       return;
     }
 
     var options = createOptions(wd, context);
+    var output = '';
     var proc = spawn('npm', ['test', '--loglevel=' + context.options.npmLevel], options);
     proc.stdout.on('data', function (data) {
+      if (context.module.stripAnsi) {
+        data = stripAnsi(data.toString());
+        data = data.replace(/\r/g, '\n');
+      }
+      output += data;
       context.emit('data', 'verbose', 'npm-test:', data.toString());
     });
     var error = '';
@@ -50,14 +57,17 @@ function test(context, next) {
       error += chunk;
     });
     proc.on('error', function() {
-      next(Error('Tests Failed'));
+      next(new Error('Tests Failed'));
     });
     proc.on('close', function(code) {
       if (error) {
         context.emit('data', 'verbose', 'npm:', error);
       }
+      if (output.length > 0) {
+        context.module.testOutput = output + '\n' + error;
+      }
       if (code > 0) {
-        next(Error('The canary is dead.'));
+        next(new Error('The canary is dead:'));
         return;
       }
       next(null, context);

--- a/lib/out.js
+++ b/lib/out.js
@@ -65,6 +65,9 @@ module.exports = function(options) {
     error: function(tag, message) {
       if (colorize) tag = chalk.red(tag);
       output(tag, message, logger.error);
+    },
+    bypass: function(messgage) {
+      process.stdout.write(messgage + '\n');
     }
   };
 };

--- a/lib/reporter/index.js
+++ b/lib/reporter/index.js
@@ -1,0 +1,12 @@
+'use strict';
+
+// local modules
+var markdown = require('./markdown');
+var logger = require('./logger');
+var util = require('./util');
+
+module.exports = {
+  markdown: markdown,
+  logger: logger,
+  util: util
+};

--- a/lib/reporter/index.js
+++ b/lib/reporter/index.js
@@ -4,9 +4,11 @@
 var markdown = require('./markdown');
 var logger = require('./logger');
 var util = require('./util');
+var tap = require('./tap');
 
 module.exports = {
   markdown: markdown,
   logger: logger,
-  util: util
+  util: util,
+  tap: tap
 };

--- a/lib/reporter/logger.js
+++ b/lib/reporter/logger.js
@@ -1,0 +1,48 @@
+'use strict';
+
+var _ = require('lodash');
+var chalk = require('chalk');
+
+var util = require('./util');
+
+function logModule(log, logType, module) {
+  log[logType](chalk.yellow('module name:'), module.name);
+  log[logType](chalk.yellow('version:'), module.version);
+  if (module.error) {
+    log[logType]('error', module.error.message);
+  }
+}
+
+function logModules(log, logType, modules) {
+  _.each(modules, function (module) {
+    logModule(log, logType, module);
+  });
+}
+
+function logger(log, modules) {
+  if (!(modules instanceof Array)) {
+    modules = [modules];
+  }
+  var passed = util.getPassing(modules);
+  var flaky = util.getFlakyFails(modules);
+  var failed = util.getFails(modules);
+  
+  if (passed.length > 0) {
+    log.info('passing module(s)');
+    logModules('info', passed);
+  }
+  if (flaky.length > 0) {
+    log.warn('failing flaky module(s)');
+    logModules('warn', flaky);
+  }
+  if (failed.length > 0) {
+    log.error('failing module(s)');
+    logModules('error', failed);
+    log.error('done', 'The smoke test has failed.');
+  }
+  else {
+    log.info('done', 'The smoke test has passed.');
+  }
+}
+
+module.exports = logger;

--- a/lib/reporter/logger.js
+++ b/lib/reporter/logger.js
@@ -10,6 +10,7 @@ function logModule(log, logType, module) {
   log[logType](chalk.yellow('version:'), module.version);
   if (module.error) {
     log[logType]('error', module.error.message);
+    log[logType]('error', module.testOutput);
   }
 }
 
@@ -29,15 +30,15 @@ function logger(log, modules) {
   
   if (passed.length > 0) {
     log.info('passing module(s)');
-    logModules('info', passed);
+    logModules(log, 'info', passed);
   }
   if (flaky.length > 0) {
-    log.warn('failing flaky module(s)');
-    logModules('warn', flaky);
+    log.warn('flaky module(s)');
+    logModules(log, 'warn', flaky);
   }
   if (failed.length > 0) {
     log.error('failing module(s)');
-    logModules('error', failed);
+    logModules(log, 'error', failed);
     log.error('done', 'The smoke test has failed.');
   }
   else {

--- a/lib/reporter/markdown.js
+++ b/lib/reporter/markdown.js
@@ -7,11 +7,13 @@ var util = require('./util');
 function printModulesMarkdown(logger, title, modules) {
   if (modules.length > 0) {
     logger('### ' + title + ' Modules');
-    _.each(modules, function (module) {
-      logger('* ' + module.name);
-      logger('  - version ' + module.version);
-      if (module.error) {
-        logger('  * ' + module.error.message);
+    _.each(modules, function (mod) {
+      logger('  * ' + mod.name + ' v' + mod.version);
+      if (mod.error) {
+        logger('    - ' + mod.error.message);
+      }
+      if (mod.error && mod.testOutput) {
+        logger(util.sanitizeOutput(mod.testOutput, '    - '));
       }
     });
     logger('');

--- a/lib/reporter/markdown.js
+++ b/lib/reporter/markdown.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var _ = require('lodash');
+
+var util = require('./util');
+
+function printModulesMarkdown(logger, title, modules) {
+  if (modules.length > 0) {
+    logger('### ' + title + ' Modules');
+    _.each(modules, function (module) {
+      logger('* ' + module.name);
+      logger('  - version ' + module.version);
+      if (module.error) {
+        logger('  * ' + module.error.message);
+      }
+    });
+    logger('');
+  }
+}
+
+function markdown(logger, modules) {
+  if (!(modules instanceof Array)) {
+    modules = [modules];
+  }
+
+  var passed = util.getPassing(modules);
+  var flaky = util.getFlakyFails(modules);
+  var failed = util.getFails(modules);
+
+  if (failed.length === 0) {
+    logger('## 🎉🎉 CITGM Passed 🎉🎉');
+    if (flaky.length > 0) {
+      logger('## 📛 But with Flaky Failures 📛');
+    }
+  }
+  else {
+    logger('## 🔥⚠️🔥 CITGM FAILED 🔥⚠️🔥');
+  }
+
+  printModulesMarkdown(logger, 'Passing', passed);
+  printModulesMarkdown(logger, 'Flaky', flaky);
+  printModulesMarkdown(logger, 'Failing', failed);
+}
+
+module.exports = markdown;

--- a/lib/reporter/tap.js
+++ b/lib/reporter/tap.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var fs = require('fs');
+
+var _ = require('lodash');
+
+var util = require('./util');
+
+function generateTest(mod, count) {
+  var result = (!mod.error || mod.flaky) ? 'ok' : 'not ok';
+  var directive = (mod.flaky && mod.error) ? '# SKIP' : '';
+  var error = mod.error ? ['', directive, mod.error].join(' ') : '';
+  var output = mod.testOutput ? '\n' + util.sanitizeOutput(mod.testOutput, '# ') : '';
+  return [result, count + 1, '-', mod.name, 'v' + mod.version + error + output].join(' ');
+}
+
+function generateTap(modules) {
+  var modulesTap = _.map(modules, generateTest).join('\n');
+  return 'TAP version 13\n' + modulesTap + '\n1..' + modules.length;
+}
+
+function tap(logger, modules) {
+  if (!(modules instanceof Array)) {
+    modules = [modules];
+  }
+  var payload = generateTap(modules);
+  if (typeof logger === 'string') {
+    fs.writeFileSync(logger, payload + '\n');
+  }
+  else {
+    logger(payload);
+  }
+}
+
+module.exports = tap;

--- a/lib/reporter/util.js
+++ b/lib/reporter/util.js
@@ -25,9 +25,18 @@ function hasFailures(modules) {
   });
 }
 
+function sanitizeOutput(output, delimiter) {
+  return _(output.split('\n')).filter(function (item) {
+    return item.length && item !== '\n';
+  }).map(function (item) {
+    return [delimiter, item].join(' ');
+  }).value().join('\n');
+}
+
 module.exports = {
   getPassing: getPassing,
   getFails: getFails,
   getFlakyFails: getFlakyFails,
-  hasFailures: hasFailures
+  hasFailures: hasFailures,
+  sanitizeOutput: sanitizeOutput
 };

--- a/lib/reporter/util.js
+++ b/lib/reporter/util.js
@@ -1,0 +1,33 @@
+'use strict';
+var _ = require('lodash');
+
+function getPassing(modules) {
+  return _.filter(modules, function (mod) {
+    return !mod.error;
+  });
+}
+
+function getFlakyFails(modules) {
+  return _.filter(modules, function (mod) {
+    return (mod.error && mod.flaky);
+  });
+}
+
+function getFails(modules) {
+  return _.filter(modules, function (mod) {
+    return (mod.error && !mod.flaky);
+  });
+}
+
+function hasFailures(modules) {
+  return _.some(modules, function (mod) {
+    return (mod.error && !mod.flaky);
+  });
+}
+
+module.exports = {
+  getPassing: getPassing,
+  getFails: getFails,
+  getFlakyFails: getFlakyFails,
+  hasFailures: hasFailures
+};

--- a/man/citgm-all.1
+++ b/man/citgm-all.1
@@ -38,6 +38,9 @@ Allow running the tool as root
 .BR \-m ", " \-\-markdown
 Output results in markdown
 .TP
+.BR \-t ", " \-\-tap " " \fI[path]\fR
+Output results in tap
+.TP
 .BR \-u ", " \-\-uid " " \fIuid\fR
 Set the uid (posix only)
 .TP

--- a/man/citgm.1
+++ b/man/citgm.1
@@ -35,6 +35,12 @@ Turns off colorized output
 .BR \-s ", " \-\-su
 Allow running the tool as root
 .TP
+.BR \-m ", " \-\-markdown
+Output results in markdown
+.TP
+.BR \-t ", " \-\-tap " " \fI[path]\fR
+Output results in tap
+.TP
 .BR \-u ", " \-\-uid " " \fIuid\fR
 Set the uid (posix only)
 .TP

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "rimraf": "^2.4.2",
     "root-check": "^1.0.0",
     "semver": "^5.0.1",
+    "strip-ansi": "^3.0.1",
     "supports-color": "^3.1.0",
     "tar": "^2.1.1",
     "uid-number": "0.0.6",

--- a/test/fixtures/custom-lookup-fail.json
+++ b/test/fixtures/custom-lookup-fail.json
@@ -1,6 +1,7 @@
 {
   "omg-i-pass": {
-    "replace": true
+    "replace": true,
+    "flaky": true
   },
   "omg-i-fail": {
     "replace": false

--- a/test/fixtures/reporter-util-fixtures.json
+++ b/test/fixtures/reporter-util-fixtures.json
@@ -1,0 +1,22 @@
+{
+  "iPass": {
+    "name": "iPass",
+    "version": "4.2.2"
+  },
+  "iFail": {
+    "name": "iFail",
+    "version": "3.0.1",
+    "error": "I dun wurk"
+  },
+  "iFlakyPass": {
+    "name": "iFlakyPass",
+    "version": "3.0.1",
+    "flaky": true
+  },
+  "iFlakyFail": {
+    "name": "iFlakyFail",
+    "version": "3.3.3",
+    "flaky": true,
+    "error": "I dun wurk"
+  }
+}

--- a/test/fixtures/test-out-failing.txt
+++ b/test/fixtures/test-out-failing.txt
@@ -1,0 +1,4 @@
+TAP version 13
+ok 1 - omg-i-pass v1.2.3
+not ok 2 - lodash v2.2.2  Error: I do not work
+1..2

--- a/test/fixtures/test-out-passing.txt
+++ b/test/fixtures/test-out-passing.txt
@@ -1,0 +1,4 @@
+TAP version 13
+ok 1 - omg-i-pass v1.2.3
+ok 2 - lodash v2.2.2
+1..2

--- a/test/test-reporter-util.js
+++ b/test/test-reporter-util.js
@@ -1,0 +1,68 @@
+'use strict';
+var test = require('tap').test;
+
+var util = require('../lib/reporter/util');
+var fixtures = require('./fixtures/reporter-util-fixtures');
+
+var noPassing = [
+  fixtures.iFail,
+  fixtures.iFail,
+  fixtures.iFail,
+  fixtures.iFlakyFail,
+  fixtures.iFlakyFail,
+  fixtures.iFlakyFail,
+  fixtures.iFlakyFail
+];
+
+var somePassing = [
+  fixtures.iPass,
+  fixtures.iFlakyPass,
+  fixtures.iFlakyFail,
+  fixtures.iFail
+];
+
+var allPassing = [
+  fixtures.iPass,
+  fixtures.iFlakyPass,
+  fixtures.iPass
+];
+
+var flakeCityUsa = [
+  fixtures.iFlakyFail,
+  fixtures.iFlakyFail,
+  fixtures.iFlakyPass,
+  fixtures.iFlakyPass,
+  fixtures.iFlakyPass
+];
+
+test('getPassing:', function (t) {
+  t.equals(util.getPassing(noPassing).length, 0, 'there should be no passing modules in the noPassing list');
+  t.equals(util.getPassing(somePassing).length, 2, 'there should be two passing modules in the somePassing list');
+  t.equals(util.getPassing(allPassing).length, 3, 'there should be three passing modules in the allPassing list');
+  t.equals(util.getPassing(flakeCityUsa).length, 3, 'there should be two passing modules in the flakeCityUsa list');
+  t.end();
+});
+
+test('getFlakyFails:', function (t) {
+  t.equals(util.getFlakyFails(noPassing).length, 4, 'there should be two flaky failing modules in the noPassing list');
+  t.equals(util.getFlakyFails(somePassing).length, 1, 'there should be one flaky failing modules in the somePassing list');
+  t.equals(util.getFlakyFails(allPassing).length, 0, 'there should be no flaky failing modules in the allPassing list');
+  t.equals(util.getFlakyFails(flakeCityUsa).length, 2, 'there should be two flaky failing modules in the flakeCityUsa list');
+  t.end();
+});
+
+test('getFails:', function (t) {
+  t.equals(util.getFails(noPassing).length, 3, 'there should be three failing modules in the noPassing list');
+  t.equals(util.getFails(somePassing).length, 1, 'there should be one failing modules in the somePassing list');
+  t.equals(util.getFails(allPassing).length, 0, 'there should be no failing modules in the allPassing list');
+  t.equals(util.getFails(flakeCityUsa).length, 0, 'there should be no failing modules in the flakeCityUsa list');
+  t.end();
+});
+
+test('hasFailures:', function (t) {
+  t.ok(util.hasFailures(noPassing), 'there should be failures in the noPassing list');
+  t.ok(util.hasFailures(somePassing), 'there should be failures in the somePassing list');
+  t.notok(util.hasFailures(allPassing), 'there should be no failures in the allPassing list');
+  t.notok(util.hasFailures(flakeCityUsa), 'there should be no failures in the flakeCityUsa list');
+  t.end();
+});

--- a/test/test-reporter.js
+++ b/test/test-reporter.js
@@ -1,0 +1,17 @@
+// TODO this test does not test any functionality currently
+'use strict';
+var test = require('tap').test;
+
+var reporter = require('../lib/reporter');
+
+test('reporter.markdown():', function (t) {
+  t.ok(reporter.markdown, 'it should have a markdown reporter');
+  t.equals(typeof reporter.markdown, 'function', 'markdown is a function');
+  t.end();
+});
+
+test('reporter.logger():', function (t) {
+  t.ok(reporter.logger, 'it should have a logger reporter');
+  t.equals(typeof reporter.logger, 'function', 'logger is a function');
+  t.end();
+});

--- a/test/test-reporter.js
+++ b/test/test-reporter.js
@@ -15,3 +15,9 @@ test('reporter.logger():', function (t) {
   t.equals(typeof reporter.logger, 'function', 'logger is a function');
   t.end();
 });
+
+test('reporter.tap():', function (t) {
+  t.ok(reporter.logger, 'it should have a tap reporter');
+  t.equals(typeof reporter.logger, 'function', 'tap is a function');
+  t.end();
+});

--- a/test/test-tap-reporter.js
+++ b/test/test-tap-reporter.js
@@ -1,0 +1,92 @@
+// TODO this test does not test any functionality currently
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var os = require('os');
+
+var test = require('tap').test;
+var mkdirp = require('mkdirp');
+var rimraf = require('rimraf');
+
+var tap = require('../lib/reporter/tap');
+
+var sandbox = path.join(os.tmpdir(), 'citgm-' + Date.now());
+var outputFile = path.join(sandbox, 'test.tap');
+
+var passingInput = [{
+  name: 'omg-i-pass',
+  version: '1.2.3'
+}, {
+  name: 'lodash',
+  version: '2.2.2'
+}];
+
+var passingExpectedPath = path.join(
+  __dirname,
+  'fixtures',
+  'test-out-passing.txt'
+);
+
+var passingExpected = fs.readFileSync(passingExpectedPath, 'utf-8');
+
+var failingInput = [{
+  name: 'omg-i-pass',
+  version: '1.2.3'
+}, {
+  name: 'lodash',
+  version: '2.2.2',
+  error: 'Error: I do not work'
+}];
+
+var failingExpectedPath = path.join(
+  __dirname,
+  'fixtures',
+  'test-out-failing.txt'
+);
+
+var failingExpected = fs.readFileSync(failingExpectedPath, 'utf-8');
+
+test('reporter.tap(): setup', function (t) {
+  mkdirp(sandbox, function (err) {
+    t.error(err);
+    t.done();
+  });
+});
+
+test('reporter.tap(): passing', function (t) {
+  var output = '';
+  function logger(message) {
+    output += message;
+    output += '\n';
+  }
+
+  tap(logger, passingInput);
+  t.equals(output, passingExpected, 'we should get expected output when all modules pass');
+  t.end();
+});
+
+test('reporter.tap(): failing', function (t) {
+  var output = '';
+  function logger(message) {
+    output += message;
+    output += '\n';
+  }
+
+  tap(logger, failingInput);
+  t.equals(output, failingExpected), 'we should get the expected output when a module fails';
+  t.end();
+});
+
+test('reporter.tap(): write to disk', function (t) {
+  tap(outputFile, passingInput);
+  var expected = fs.readFileSync(outputFile, 'utf8');
+  t.equals(expected, passingExpected), 'the file on disk should match the expected output';
+  t.end();
+});
+
+test('reporter.tap(): teardown', function (t) {
+  rimraf(sandbox, function (err) {
+    t.error(err);
+    t.done();
+  });
+});


### PR DESCRIPTION
This is a first pass at adding a tap-reporter to citgm. The reporter is exposes through a command line flag `-t <filepath>`, where if the optional file path is not provided it simply logs directly to STDOUT.

In order to support this reporter there has been a refactor of the general post process reporting that we have done. Outputting the results via the default logger, markdown, or tap are now all sharing the same basic abstraction for the most part.

This has yet to be tested in CI, but it should in theory allow us to start looking at tap output for a basic idea of the results of a run.

Other than the basic error propagated by citgm there is no additional information currently included. I think this is something we can try to improve in a future iteration, if we can find a better way of extrapolating error information from tests run in child processes.