### PR TITLE
tools: add nyc for code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 test/scaffold/*/node_modules
 test/.*
+coverage/
+.nyc_output/

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "scripts": {
     "test": "npm run lint && npm run tap",
     "tap": "TAP_TIMEOUT=90 tap test/test-*.js",
+    "coverage": "TAP_TIMEOUT=90 nyc tap test/test-*.js",
+    "coverage-html": "TAP_TIMEOUT=90 nyc --reporter=html tap test/test-*.js && opener coverage/index.html",
     "lint": "eslint bin/* lib/ test/",
     "watch": "nodemon --ignore node_modules/ -e js,json --exec 'npm run tap'"
   },
@@ -57,6 +59,8 @@
   "devDependencies": {
     "mkdirp": "^0.5.1",
     "nodemon": "^1.8.0",
+    "nyc": "^5.6.0",
+    "opener": "^1.4.1",
     "rewire": "^2.4.0",
     "tap": "^2.2.0"
   }


### PR DESCRIPTION
introduces two new scripts
  * npm run coverage # output coverage in terminal
  * npm run coverage-html # output coverage in html to coverage/ and open in browser

<img width="607" alt="screen shot 2016-02-26 at 6 18 27 pm" src="https://cloud.githubusercontent.com/assets/498775/13370500/01460a2c-dcbe-11e5-8176-366f46b38345.png">
