### PR TITLE
citgm: fix for v0.10 support 

### DIFF
--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -2,7 +2,7 @@
 
 // node modules
 var util = require('util');
-var EventEmitter = require('events');
+var EventEmitter = require('events').EventEmitter;
 
 // npm modules
 var async = require('async');
@@ -87,7 +87,7 @@ function Tester(mod, options) {
   this.module = extractDetail(mod);
   this.options = options;
 }
-util.inherits(Tester,EventEmitter);
+util.inherits(Tester, EventEmitter);
 
 Tester.prototype.run = function() {
   this.emit('start', this.module.raw, this.options);


### PR DESCRIPTION
A small change to the way events is used allows us to supoprt
v0.10.