### PR TITLE
add custom script support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ bin/citgm --help
 (If citgm is installed globally, you can also `man citgm`)
 
 ```bash
-Usage: citgm [options] <module>
+Usage: citgm [options] <module> [script]
 
 Options:
 
@@ -92,6 +92,7 @@ For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
 "skip": true                 Completely skip the module
 "repo": "https://github.com/pugjs/jade" - Use a different github repo
 "skipAnsi": true             Strip ansi data from output stream of npm
+"script": /path/to/script | https://url/to/script - Use a custom test script
 ```
 ## Testing
 

--- a/bin/citgm
+++ b/bin/citgm
@@ -9,12 +9,14 @@ var app = require('commander');
 var pkg = require('../package.json');
 
 var mod;
+var script;
 
 app
   .version(pkg.version)
-  .arguments('<module>')
-  .action(function(m) {
+  .arguments('<module> [script]')
+  .action(function(m, s) {
     mod = m;
+    script = s;
   })
   .option(
     '-v, --verbose [level]',
@@ -76,6 +78,7 @@ if (!app.su) {
 }
 
 var options = {
+  script: script,
   lookup: app.lookup,
   nodedir: app.nodedir,
   level: app.verbose,

--- a/lib/npm/script/fetch.js
+++ b/lib/npm/script/fetch.js
@@ -1,0 +1,36 @@
+// node modules
+var path = require('path');
+var fs = require('fs');
+var url = require('url');
+
+// npm modules
+var uuid = require('node-uuid');
+var request = require('request');
+
+function fetchScript(context, script, next) {
+  script = String(script);
+  var dest = path.resolve(context.path, uuid.v4());
+  var res = url.parse(script);
+  var readStream;
+  if (res.protocol !== 'http:' && res.protocol !== 'https:') {
+    var _path = path.resolve(process.cwd(), script);
+    readStream = fs.createReadStream(_path);
+  }
+  else {
+    context.emit('data', 'silly', 'fetch-script-start', script);
+    readStream = request(res.href);
+  }
+  
+  readStream.on('error', function(err) {
+    next(err);
+  });
+
+  readStream.on('end', function() {
+    context.emit('data', 'silly', 'fetch-script-end', dest);
+    next(null, dest);
+  });
+
+  readStream.pipe(fs.createWriteStream(dest)); // todo add verification
+}
+
+module.exports = fetchScript;

--- a/lib/npm/script/index.js
+++ b/lib/npm/script/index.js
@@ -1,0 +1,7 @@
+var fetch = require('./fetch');
+var run = require('./run');
+
+module.exports = {
+  fetch: fetch,
+  run: run
+};

--- a/lib/npm/script/run.js
+++ b/lib/npm/script/run.js
@@ -1,0 +1,59 @@
+// node modules
+var path = require('path');
+var fs = require('fs');
+var util = require('util');
+
+// npm modules
+var stripAnsi = require('strip-ansi');
+
+// local modules
+var createOptions = require('../../create-options');
+var spawn = require('../../spawn');
+
+function runScript(context, script, msg, next) {
+  var _path = path.resolve(process.cwd(), script);
+  if (typeof msg === 'function') {
+    next = msg;
+    msg = util.format('Script %s failed', _path);
+  }
+  context.emit('data', 'verbose','script-start', _path);
+  fs.stat(_path, function(err, stat) {
+    if (err || !stat.isFile()) {
+      return next(err);
+    }
+    var options =
+      createOptions(context.path, context);
+    var output = '';
+    var proc = spawn(_path, [], options);
+    proc.stdout.on('data', function (data) {
+      if (context.module.stripAnsi) {
+        data = stripAnsi(data.toString());
+        data = data.replace(/\r/g, '\n');
+      }
+      output += data;
+      context.emit('data', 'verbose', 'npm-test:', data.toString());
+    });
+    var error = '';
+    proc.stderr.on('data', function (chunk) {
+      error += chunk;
+    });
+    proc.on('error', function(err) {
+      next(err);
+    });
+    proc.on('close', function(code) {
+      if (error) {
+        context.emit('data', 'verbose', 'npm-error:', error);
+      }
+      if (output.length > 0) {
+        context.module.testOutput = output + '\n' + error;
+      }
+      if (code > 0) {
+        return next(Error(msg));
+      }
+      context.emit('data', 'verbose','script-end', _path);
+      return next(null, context);
+    });
+  });
+}
+
+module.exports = runScript;

--- a/lib/npm/test.js
+++ b/lib/npm/test.js
@@ -2,6 +2,7 @@
 
 // node modules
 var path = require('path');
+var fs = require('fs');
 
 // npm modules
 var readPackage = require('read-package-json');
@@ -10,19 +11,34 @@ var stripAnsi = require('strip-ansi');
 // local modules
 var spawn = require('../spawn');
 var createOptions = require('../create-options');
+var script = require('./script');
+
+var windows = (process.platform === 'win32');
 
 function authorName(author) {
   if (typeof author === 'string') return author;
-  else {
-    var parts = [];
-    if (author.name) parts.push(author.name);
-    if (author.email) parts.push('<' + author.email + '>');
-    if (author.url) parts.push('(' + author.url + ')');
-    return parts.join(' ');
-  }
+  var parts = [];
+  if (author.name) parts.push(author.name);
+  if (author.email) parts.push('<' + author.email + '>');
+  if (author.url) parts.push('(' + author.url + ')');
+  return parts.join(' ');
 }
 
 function test(context, next) {
+  if (context.options.script) {
+
+    script.fetch(context, context.options.script, function(err, file) {
+      if (err) {
+        return next(err);
+      }
+      if (!windows) {
+        fs.chmodSync(file, '755');
+      }
+      script.run(context, file, 'The canary is dead.', next);
+    });
+
+    return;
+  }
   var wd = path.join(context.path, context.module.name);
   context.emit('data', 'info', 'npm:', 'test suite started');
   readPackage(path.join(wd,'package.json'),false,function(err,data) {

--- a/man/citgm.1
+++ b/man/citgm.1
@@ -4,7 +4,7 @@
 .SH NAME
 citgm \- Canary in the Goldmine
 .SH SYNOPSIS
-citgm [options] <module>
+citgm [options] <module> [script]
 .SH DESCRIPTION
 citgm is a tool for testing Node.js modules against different Node.js builds.
 Specifically, it automates the 'npm install' and 'npm test' steps and reports

--- a/test/fixtures/custom-lookup-script.json
+++ b/test/fixtures/custom-lookup-script.json
@@ -1,0 +1,9 @@
+{
+  "omg-i-pass": {
+    "replace": false
+  },
+  "omg-i-pass-too": {
+    "replace": true,
+    "prefix": "v"
+  }
+}

--- a/test/fixtures/example-test-script-failing.sh
+++ b/test/fixtures/example-test-script-failing.sh
@@ -1,0 +1,3 @@
+echo I FAIL
+>&2 echo "error"
+exit 1

--- a/test/fixtures/example-test-script-passing.sh
+++ b/test/fixtures/example-test-script-passing.sh
@@ -1,0 +1,2 @@
+ECHO I PASS
+exit 0

--- a/test/fixtures/request-mock.js
+++ b/test/fixtures/request-mock.js
@@ -1,0 +1,16 @@
+var EventEmitter = require('events').EventEmitter;
+var util = require('util');
+
+function RequestMock() {
+  if (!(this instanceof RequestMock))
+    return new RequestMock;
+  EventEmitter.call(this);
+}
+
+util.inherits(RequestMock, EventEmitter);
+
+RequestMock.prototype.pipe = function() {
+  this.emit('error', new Error('I am broken'));
+};
+
+module.exports = RequestMock;

--- a/test/test-npm-script-fetch.js
+++ b/test/test-npm-script-fetch.js
@@ -1,0 +1,101 @@
+'use strict';
+
+var path = require('path');
+var fs = require('fs');
+var os = require('os');
+
+var test = require('tap').test;
+var mkdirp = require('mkdirp');
+var rimraf = require('rimraf');
+var rewire = require('rewire');
+
+var fetch = rewire('../lib/npm/script/fetch');
+var RequestMock = require('./fixtures/request-mock');
+
+var passing = path.join(__dirname, 'fixtures', 'example-test-script-passing.sh');
+var uriHttp = 'http://gist.githubusercontent.com/TheAlphaNerd/0bf45af05c7580c4d80f/raw/08e52f1a64410e91203c909a6a90255d48273b75/example-test-script-passing.sh';
+var uriHttps = 'https://gist.githubusercontent.com/TheAlphaNerd/0bf45af05c7580c4d80f/raw/08e52f1a64410e91203c909a6a90255d48273b75/example-test-script-passing.sh';
+
+var sandbox = path.join(os.tmpdir(), 'citgm-' + Date.now());
+
+test('fetch: setup', function (t) {
+  mkdirp(sandbox, function (err) {
+    t.error(err);
+    t.done();
+  });
+});
+
+test('fetch: given a file path', function (t) {
+  var context = {
+    path: sandbox,
+    emit: function () {}
+  };
+  fetch(context, passing, function (err, _path)  {
+    t.error(err);
+    t.match(_path, context.path, 'the resolved path should be in the context path');
+    fs.stat(_path, function (e, stats) {
+      t.error(err);
+      t.ok(stats.isFile(), 'The script should exist on the system');
+      fs.unlinkSync(_path);
+      t.end();
+    });
+  });
+});
+
+test('fetch: given a uri with http', function (t) {
+  var context = {
+    path: sandbox,
+    emit: function () {}
+  };
+  fetch(context, uriHttp, function (err, _path) {
+    t.error(err);
+    fs.stat(_path, function (e, stats) {
+      t.error(err);
+      t.ok(stats.isFile(), 'The script should exist on the system');
+      fs.unlinkSync(_path);
+      t.end();
+    });
+  });
+});
+
+test('fetch: given a uri with https', function (t) {
+  var context = {
+    path: sandbox,
+    emit: function () {}
+  };
+  fetch(context, uriHttps, function (err, _path) {
+    t.error(err);
+    fs.stat(_path, function (e, stats) {
+      t.error(err);
+      t.ok(stats.isFile(), 'The script should exist on the system');
+      fs.unlinkSync(_path);
+      t.end();
+    });
+  });
+});
+
+test('fetch: properly handle errors from request', function (t) {
+  var context = {
+    path: sandbox,
+    emit: function () {}
+  };
+
+  var request = fetch.__get__('request');
+  var fs = fetch.__get__('fs');
+  var createWriteStream = fs.createWriteStream;
+  fs.createWriteStream = function () {};
+  fetch.__set__('request', RequestMock);
+  fetch(context, 'http://do-nothing.com', function (err) {
+    t.equals(err.message, 'I am broken');
+    fetch.__set__('request', request);
+    fs.createWriteStream = createWriteStream;
+    t.end();
+  });
+});
+
+test('fetch: teardown', function (t) {
+  rimraf(sandbox, function (err) {
+    t.error(err);
+    t.done();
+  });
+});

--- a/test/test-npm-script-run.js
+++ b/test/test-npm-script-run.js
@@ -1,0 +1,90 @@
+var test = require('tap').test;
+var path = require('path');
+var os = require('os');
+
+var mkdirp = require('mkdirp');
+var rimraf = require('rimraf');
+var rewire = require('rewire');
+
+var run = rewire('../lib/npm/script/run');
+
+var passingScript = path.join(__dirname, 'fixtures', 'example-test-script-passing.sh');
+var failingScript = path.join(__dirname, 'fixtures', 'example-test-script-failing.sh');
+var badPath = path.join(__dirname, 'fixtures', 'example-test-script-does-not-exist');
+
+var sandbox = path.join(os.tmpdir(), 'citgm-' + Date.now(), 'run-test');
+
+test('npm.script.run: setup', function (t) {
+  mkdirp(sandbox, function (err) {
+    t.error(err);
+    t.done();
+  });
+});
+
+test('npm.script.run: should pass with passing script', function (t) {
+  var context = {
+    path: sandbox,
+    emit: function () {},
+    module: {
+      name: 'run-test'
+    },
+    options: {}
+  };
+  run(context, passingScript, 'the canary is dead', function (err) {
+    t.error(err);
+    t.done();
+  });
+});
+
+test('npm.script.run: should fail with failing script', function (t) {
+  var context = {
+    path: sandbox,
+    emit: function () {},
+    module: {
+      name: 'run-test'
+    },
+    options: {}
+  };
+  var failingMsg = 'the canary is dead';
+  run(context, failingScript, failingMsg, function (err) {
+    t.equals(err.message, failingMsg);
+    t.done();
+  });
+});
+
+test('npm.script.run: should fail with failing script (no msg)', function (t) {
+  var context = {
+    path: sandbox,
+    emit: function () {},
+    module: {
+      name: 'run-test'
+    },
+    options: {}
+  };
+  run(context, failingScript, function (err) {
+    t.match(err.message, /failed/);
+    t.done();
+  });
+});
+
+test('npm.script.run: should fail with a bad path', function (t) {
+  var context = {
+    path: sandbox,
+    emit: function () {},
+    module: {
+      name: 'run-test'
+    },
+    options: {}
+  };
+  run(context, badPath, 'the canary is dead', function (err) {
+    t.match(err.message, /ENOENT/, 'we should receive a ENOENT warning');
+    t.done();
+  });
+});
+
+test('npm.script.run: teardown', function (t) {
+  rimraf(sandbox, function (err) {
+    t.error(err);
+    t.done();
+  });
+});


### PR DESCRIPTION
This pr adds back to feature that allows CITGM to be given an
optional second argument that specifies a file path or link to an
alternative script to be run for testing.

This feature also supports a new option in the manifest "script",
which will allow individuals to specify custom scripts to be used
whenever a module is run (including with citgm-all)

This patch is coming in fully testing with close to 100% coverage.
Currently sitting around 90% on average

There is currently quite a bit of overlap between `lib/npm/test`
and `lib/npm/run`, but I think refactoring that would make sense
to happen later, as there is quite a bit of repeated code between
all Child Process stuff, and this could likely be improved.