### PR TITLE
custom-script: fix using custom script in lookup

### DIFF
--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -79,6 +79,10 @@ function resolve(context, next) {
         context.emit('info','lookup-replace',url);
         context.module.raw = url;
       }
+      if (rep.script) {
+        context.emit('info','lookup-script',rep.script);
+        context.options.script = rep.script;
+      }
     } else {
       context.emit('info','lookup-notfound',detail.name);
     }

--- a/lib/npm/script/fetch.js
+++ b/lib/npm/script/fetch.js
@@ -13,7 +13,13 @@ function fetchScript(context, script, next) {
   var res = url.parse(script);
   var readStream;
   if (res.protocol !== 'http:' && res.protocol !== 'https:') {
-    var _path = path.resolve(process.cwd(), script);
+    var _path;
+    if (context.options && context.options.lookup && script[0] !== '/') {
+      _path = path.resolve(path.dirname(context.options.lookup), script);
+    }
+    else {
+      _path = path.resolve(process.cwd(), script);
+    }
     readStream = fs.createReadStream(_path);
   }
   else {

--- a/test/fixtures/custom-lookup-script.json
+++ b/test/fixtures/custom-lookup-script.json
@@ -1,9 +1,11 @@
 {
   "omg-i-pass": {
-    "replace": false
+    "replace": false,
+    "script": "./example-test-script-passing.sh"
   },
-  "omg-i-pass-too": {
-    "replace": true,
-    "prefix": "v"
+  "omg-i-have-script": {
+    "prefix": "v",
+    "script": "./example-test-script-passing.sh",
+    "stripAnsi": true
   }
 }

--- a/test/test-bin.js
+++ b/test/test-bin.js
@@ -32,6 +32,18 @@ test('bin: omg-i-fail /w markdown output /w nodedir', function (t) {
   });
 });
 
+test('bin: omg-i-have-script /w custom script', function (t) {
+  t.plan(1);
+  var proc = spawn(citgmPath, ['omg-i-pass', '-l', './fixtures/custom-lookup-script.json']);
+  proc.on('error', function(err) {
+    t.error(err);
+    t.fail('we should not get an error testing omg-i-pass');
+  });
+  proc.on('close', function (code) {
+    t.equal(code, 1, 'omg-i-fail should fail and exit with a code of one');
+  });
+});
+
 test('bin: no module /w root check', function (t) {
   t.plan(1);
   var proc = spawn(citgmPath, ['-s']);

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -113,8 +113,7 @@ test('lookup: module in table', function (t) {
     lookup: null,
     module: {
       name: 'lodash',
-      raw: null,
-      lookup: 'test/fixtures/custom-lookup.js'
+      raw: null
     },
     meta: {
       repository: {
@@ -165,6 +164,29 @@ test('lookup: replace with no repo', function (t) {
 
   lookup(context, function (err) {
     t.equals(err.message, 'no-repository-field in package.json');
+    t.done();
+  });
+});
+
+test('lookup: lookup with script', function (t) {
+  var context = {
+    module: {
+      name: 'omg-i-have-script',
+      raw: null
+    },
+    meta: {
+      repository: '/dev/null',
+      version: '0.1.1'
+    },
+    options: {
+      lookup: 'test/fixtures/custom-lookup-script.json'
+    },
+    emit: function () {}
+  };
+
+  lookup(context, function (err) {
+    t.error(err);
+    t.equals(context.options.script, './example-test-script-passing.sh');
     t.done();
   });
 });

--- a/test/test-npm-script-fetch.js
+++ b/test/test-npm-script-fetch.js
@@ -42,6 +42,26 @@ test('fetch: given a file path', function (t) {
   });
 });
 
+test('fetch: given a custom lookup table and relative path', function (t) {
+  var context = {
+    path: sandbox,
+    emit: function () {},
+    options: {
+      lookup: path.join(__dirname, 'fixtures', 'custom-lookup-script.json')
+    }
+  };
+  fetch(context, './example-test-script-passing.sh', function (err, _path)  {
+    t.error(err);
+    t.match(_path, context.path, 'the resolved path should be in the context path');
+    fs.stat(_path, function (e, stats) {
+      t.error(err);
+      t.ok(stats.isFile(), 'The script should exist on the system');
+      fs.unlinkSync(_path);
+      t.end();
+    });
+  });
+});
+
 test('fetch: given a uri with http', function (t) {
   var context = {
     path: sandbox,


### PR DESCRIPTION
The current logic was only resolving custom scripts relative
to the process. That logic does not really work if you include
a relative path inside of a lookup table.

This fix updates the logic for fetching scripts to resolve paths
found in a lookup table relative to the table if needed

/cc @jasnell 