### PR TITLE
npm: add stdout output from npm install

### DIFF
--- a/lib/npm/setup.js
+++ b/lib/npm/setup.js
@@ -25,6 +25,11 @@ function setup(context, next) {
   proc.stderr.on('data', function (chunk) {
     context.emit('data', 'warn', 'npm-install:', chunk.toString());
   });
+  if (context.options.npmLevel !== 'error' && context.options.npmLevel !== 'silent') {
+    proc.stdout.on('data', function (chunk) {
+      context.emit('data', 'info', 'npm-install:', chunk.toString());
+    });
+  }
   proc.on('error', function() {
     bailed = true;
     context.emit('data', 'error', 'npm-install:', 'Install Failed');


### PR DESCRIPTION
Currently we are only logging the output of stderr
If you set the npm logging level higher than error
an extra listener is created.