### PR TITLE
npm: don't chunk the stderr output of npm install

### DIFF
--- a/lib/npm/setup.js
+++ b/lib/npm/setup.js
@@ -16,15 +16,14 @@ function setup(context, next) {
   var args = ['install', '--loglevel', context.options.npmLevel];
   context.emit('data', 'info', 'npm:', 'install started');
   if (context.options.nodedir) {
-    var nodedir = path.resolve(process.cwd(),context.options.nodedir);
+    var nodedir = path.resolve(process.cwd(), context.options.nodedir);
     options.env.npm_config_nodedir = nodedir;
     args.push('--nodedir="' + nodedir + '"');
     context.emit('data', 'verbose','nodedir', 'Using --nodedir="' + nodedir + '"');
   }
   var proc = spawn('npm', args, options);
-  var error = '';
   proc.stderr.on('data', function (chunk) {
-    error += chunk;
+    context.emit('data', 'warn', 'npm-install:', chunk.toString());
   });
   proc.on('error', function() {
     bailed = true;
@@ -33,9 +32,6 @@ function setup(context, next) {
     return next(Error('Install Failed'));
   });
   proc.on('close', function() {
-    if (error) {
-      context.emit('data', 'error', 'npm-install:', error);
-    }
     if (!bailed) {
       context.emit('data', 'info', 'npm:', 'install successfully completed');
       return next(null, context);


### PR DESCRIPTION
This is causing the process in node v5.x to halt.

This is definitely a better approach, but I will investigate the
crash to make sure it isn't a regression in node itself

/cc @jasnell 