### PR TITLE
fix: remove event listeners on process when done

### DIFF
--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -126,6 +126,9 @@ Tester.prototype.run = function() {
     npm.setup,
     npm.test
   ], function(err) {
+    process.removeListener('SIGINT', cleanup);
+    process.removeListener('SIGHUP', cleanup);
+    process.removeListener('SIGBREAK', cleanup);
     if (!cleanexit) {
       var payload = {
         name: self.module.name || self.module.raw,


### PR DESCRIPTION
currently `lib/citgm` adds listeners on the process object for `SIGINT`
`SIGHUP` and `SIGBREAK`. These listeners were not being removed when a
job was completed successfully. This was not a problem at first, but now
that we have citgm-all this created a memory leak.

This commit removes the listeners when the job is successfully completed

/cc @jasnell 