### PR TITLE
npm: do not put big strings through event emitter

### DIFF
--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -87,6 +87,8 @@ function Tester(mod, options) {
   EventEmitter.call(this);
   this.module = extractDetail(mod);
   this.options = options;
+  this.testOutput = '';
+  this.testError = '';
 }
 
 util.inherits(Tester, EventEmitter);
@@ -132,14 +134,18 @@ Tester.prototype.run = function() {
     if (!cleanexit) {
       var payload = {
         name: self.module.name || self.module.raw,
-        version: self.module.version
+        version: self.module.version,
+        testOutput: ''
       };
       if (err) {
         self.emit('fail', err);
         payload.error = err;
       }
-      if (self.module.testOutput) {
-        payload.testOutput = self.module.testOutput;
+      if (self.testOutput !== '') {
+        payload.testOutput += self.testOutput + '\n';
+      }
+      if (self.testError !== '') {
+        payload.testOutput += self.testError + '\n';
       }
       tempDirectory.remove(self, function() {
         self.emit('end', payload);

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -88,7 +88,7 @@
   },
   "stylus": {
     "replace": true,
-    "master": true
+    "flaky": true
   },
   "level": {
     "replace": true,

--- a/lib/npm/script/run.js
+++ b/lib/npm/script/run.js
@@ -21,32 +21,24 @@ function runScript(context, script, msg, next) {
     if (err || !stat.isFile()) {
       return next(err);
     }
-    var options =
-      createOptions(context.path, context);
-    var output = '';
+    var options = createOptions(context.path, context);
     var proc = spawn(_path, [], options);
     proc.stdout.on('data', function (data) {
       if (context.module.stripAnsi) {
         data = stripAnsi(data.toString());
         data = data.replace(/\r/g, '\n');
       }
-      output += data;
+      context.testOutput += data;
       context.emit('data', 'verbose', 'npm-test:', data.toString());
     });
-    var error = '';
-    proc.stderr.on('data', function (chunk) {
-      error += chunk;
+    proc.stderr.on('data', function (data) {
+      context.testError += data;
+      context.emit('data', 'verbose', 'npm-error:', data);
     });
     proc.on('error', function(err) {
       next(err);
     });
     proc.on('close', function(code) {
-      if (error) {
-        context.emit('data', 'verbose', 'npm-error:', error);
-      }
-      if (output.length > 0) {
-        context.module.testOutput = output + '\n' + error;
-      }
       if (code > 0) {
         return next(Error(msg));
       }

--- a/lib/npm/test.js
+++ b/lib/npm/test.js
@@ -58,35 +58,27 @@ function test(context, next) {
     }
 
     var options = createOptions(wd, context);
-    var output = '';
     var proc = spawn('npm', ['test', '--loglevel=' + context.options.npmLevel], options);
     proc.stdout.on('data', function (data) {
       if (context.module.stripAnsi) {
         data = stripAnsi(data.toString());
         data = data.replace(/\r/g, '\n');
       }
-      output += data;
+      context.testOutput += data;
       context.emit('data', 'verbose', 'npm-test:', data.toString());
     });
-    var error = '';
-    proc.stderr.on('data', function (chunk) {
-      error += chunk;
+    proc.stderr.on('data', function (data) {
+      context.testError += data;
+      context.emit('data', 'verbose', 'npm:', data);
     });
     proc.on('error', function() {
       next(new Error('Tests Failed'));
     });
     proc.on('close', function(code) {
-      if (error) {
-        context.emit('data', 'verbose', 'npm:', error);
-      }
-      if (output.length > 0) {
-        context.module.testOutput = output + '\n' + error;
-      }
       if (code > 0) {
-        next(new Error('The canary is dead:'));
-        return;
+        return next(new Error('The canary is dead:'));
       }
-      next(null, context);
+      return next(null, context);
     });
 
   });


### PR DESCRIPTION
Currently we are creating giant strings and pushing them through the
eventEmitter. By emitting chunks we can stop the application from
halting at certain times.