### PR TITLE
npm: add ls to the pipeline

### DIFF
--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -126,6 +126,7 @@ Tester.prototype.run = function() {
     grabProject,
     unpack,
     npm.install,
+    npm.ls,
     npm.test
   ], function(err) {
     process.removeListener('SIGINT', cleanup);

--- a/lib/npm/index.js
+++ b/lib/npm/index.js
@@ -3,8 +3,10 @@
 // local modules
 var test = require('./test');
 var install = require('./install');
+var ls = require('./ls');
 
 module.exports = {
   install: install,
+  ls: ls,
   test: test
 };

--- a/lib/npm/ls.js
+++ b/lib/npm/ls.js
@@ -1,0 +1,38 @@
+'use strict';
+
+// node modules
+var path = require('path');
+
+// local modules
+var spawn = require('../spawn');
+var createOptions = require('../create-options');
+
+function ls(context, next) {
+  var options =
+    createOptions(
+      path.join(context.path, context.module.name), context);
+
+  var args = ['ls', '--loglevel', context.options.npmLevel];
+
+  context.emit('data', 'info', 'npm:', 'ls started');
+
+  var proc = spawn('npm', args, options);
+
+  proc.stderr.on('data', function (chunk) {
+    context.emit('data', 'warn', 'npm-ls:', chunk.toString());
+  });
+
+  proc.stdout.on('data', function (chunk) {
+    context.emit('data', 'info', 'npm-ls:', chunk.toString());
+  });
+
+  proc.on('close', function(code) {
+    if (code) {
+      return next(new Error('Dependency tree is incorrect.'));
+    }
+    context.emit('data', 'info', 'npm:', 'Dependency tree is correct');
+    return next(code, context);
+  });
+}
+
+module.exports = ls;

--- a/test/fixtures/npm-ls-fail/node_modules/a/package.json
+++ b/test/fixtures/npm-ls-fail/node_modules/a/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "a",
+  "version": "1.0.0",
+  "dependencies": {}
+}

--- a/test/fixtures/npm-ls-fail/package.json
+++ b/test/fixtures/npm-ls-fail/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "npm-ls-pass",
+  "version": "1.0.0",
+  "dependencies": {
+    "a": "1.0.0",
+    "b": "1.0.0"
+  }
+}

--- a/test/fixtures/npm-ls-pass/node_modules/a/package.json
+++ b/test/fixtures/npm-ls-pass/node_modules/a/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "a",
+  "version": "1.0.0",
+  "dependencies": {}
+}

--- a/test/fixtures/npm-ls-pass/node_modules/b/node_modules/c/package.json
+++ b/test/fixtures/npm-ls-pass/node_modules/b/node_modules/c/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "c",
+  "version": "1.0.0",
+  "dependencies": {}
+}

--- a/test/fixtures/npm-ls-pass/node_modules/b/package.json
+++ b/test/fixtures/npm-ls-pass/node_modules/b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "b",
+  "version": "1.0.0",
+  "dependencies": {
+    "c": "1.0.0"
+  }
+}

--- a/test/fixtures/npm-ls-pass/package.json
+++ b/test/fixtures/npm-ls-pass/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "npm-ls-pass",
+  "version": "1.0.0",
+  "dependencies": {
+    "a": "1.0.0",
+    "b": "1.0.0"
+  }
+}

--- a/test/test-npm-ls.js
+++ b/test/test-npm-ls.js
@@ -1,0 +1,95 @@
+'use strict';
+var os = require('os');
+var path = require('path');
+var fs = require('fs');
+
+var test = require('tap').test;
+var mkdirp = require('mkdirp');
+var rimraf = require('rimraf');
+var ncp = require('ncp');
+
+var ls = require('../lib/npm/ls');
+
+var sandbox = path.join(os.tmpdir(), 'citgm-' + Date.now());
+var fixtures = path.join(__dirname, 'fixtures');
+
+var passFixtures = path.join(fixtures, 'npm-ls-pass');
+var passTemp = path.join(sandbox, 'npm-ls-pass');
+
+var failFixtures = path.join(fixtures, 'npm-ls-fail');
+var failTemp = path.join(sandbox, 'npm-ls-fail');
+
+test('npm-test: setup', function (t) {
+  t.plan(5);
+  mkdirp(sandbox, function (err) {
+    t.error(err);
+    ncp(passFixtures, passTemp, function (e) {
+      t.error(e);
+      t.ok(fs.existsSync(path.join(passTemp, 'package.json')));
+    });
+    ncp(failFixtures, failTemp, function (e) {
+      t.error(e);
+      t.ok(fs.existsSync(path.join(failTemp, 'package.json')));
+    });
+  });
+});
+
+test('npm-test: basic module passing', function (t) {
+  var context = {
+    emit: function() {},
+    path: sandbox,
+    module: {
+      name: 'npm-ls-pass'
+    },
+    meta: {},
+    options: {
+      npmLevel: 'silly'
+    }
+  };
+  ls(context, function (err) {
+    t.error(err);
+    t.done();
+  });
+});
+
+test('npm-test: basic module failing', function (t) {
+  var context = {
+    emit: function() {},
+    path: sandbox,
+    module: {
+      name: 'npm-ls-fail'
+    },
+    meta: {},
+    options: {}
+  };
+  ls(context, function (err) {
+    t.equals(err.message, 'Dependency tree is incorrect.');
+    t.done();
+  });
+});
+
+// test('npm-test: custom script does not exist', function (t) {
+//   var context = {
+//     emit: function() {},
+//     path: sandbox,
+//     module: {
+//       name: 'omg-i-pass'
+//     },
+//     meta: {},
+//     options: {
+//       npmLevel: 'silly',
+//       script: './i/do/not/exist.lol'
+//     }
+//   };
+//   npmTest(context, function (err) {
+//     t.match(err, /ENOENT/, 'we should receive an error including ENOENT');
+//     t.done();
+//   });
+// });
+
+test('npm-test: teardown', function (t) {
+  rimraf(sandbox, function (err) {
+    t.error(err);
+    t.done();
+  });
+});


### PR DESCRIPTION
There is the possibility that `npm install` will not create the correct tree.
It is also possible that an incorrect tree could potentially cause a process
to hang and never exit while the tests are running.

This commit introduces a new feature to run `npm-ls` and verify the node_modules
tree before running `npm-test`.

All new code has 100% test coverage

/cc @jasnell 