### PR TITLE
npm: fix install error handling

### DIFF
--- a/lib/npm/install.js
+++ b/lib/npm/install.js
@@ -12,8 +12,8 @@ function install(context, next) {
   var options =
     createOptions(
       path.join(context.path, context.module.name), context);
-  var bailed = false;
   var args = ['install', '--loglevel', context.options.npmLevel];
+  var bailed = false;
   context.emit('data', 'info', 'npm:', 'install started');
   if (context.options.nodedir) {
     var nodedir = path.resolve(process.cwd(), context.options.nodedir);
@@ -36,11 +36,13 @@ function install(context, next) {
     proc.kill();
     return next(Error('Install Failed'));
   });
-  proc.on('close', function() {
-    if (!bailed) {
-      context.emit('data', 'info', 'npm:', 'install successfully completed');
-      return next(null, context);
+  proc.on('close', function(code) {
+    if (bailed) return;
+    if (code > 0) {
+      return next(Error('Install Failed'));
     }
+    context.emit('data', 'info', 'npm:', 'install successfully completed');
+    return next(null, context);
   });
 }
 

--- a/test/fixtures/omg-bad-tree/package.json
+++ b/test/fixtures/omg-bad-tree/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "omg-bad-tree",
+  "version": "1.0.0",
+  "description": "Test suite always passes",
+  "repository": "https://github.com/TheAlphaNerd/omg-i-pass",
+  "main": "index.js",
+  "scripts": {
+    "test": "exit 0"
+  },
+  "keywords": [
+    "always",
+    "passes"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "THIS-WILL-FAIL": "0.0.1"
+  }
+}

--- a/test/test-npm-install.js
+++ b/test/test-npm-install.js
@@ -14,14 +14,20 @@ var sandbox = path.join(os.tmpdir(), 'citgm-' + Date.now());
 var fixtures = path.join(__dirname, 'fixtures');
 var moduleFixtures = path.join(fixtures, 'omg-i-pass');
 var moduleTemp = path.join(sandbox, 'omg-i-pass');
+var badFixtures = path.join(fixtures, 'omg-bad-tree');
+var badTemp = path.join(sandbox, 'omg-bad-tree');
 
 test('npm-install: setup', function (t) {
+  t.plan(5);
   mkdirp(sandbox, function (err) {
     t.error(err);
     ncp(moduleFixtures, moduleTemp, function (e) {
       t.error(e);
       t.ok(fs.existsSync(path.join(moduleTemp, 'package.json')));
-      t.done();
+    });
+    ncp(badFixtures, badTemp, function (e) {
+      t.error(e);
+      t.ok(fs.existsSync(path.join(badTemp, 'package.json')));
     });
   });
 });
@@ -54,6 +60,24 @@ test('npm-install: no package.json', function (t) {
     meta: {},
     options: {
       npmLevel: 'silly'
+    }
+  };
+  npmInstall(context, function (err) {
+    t.equals(err.message, 'Install Failed');
+    t.done();
+  });
+});
+
+test('npm-install: failed install', function (t) {
+  var context = {
+    emit: function() {},
+    path: sandbox,
+    module: {
+      name: 'omg-bad-tree'
+    },
+    meta: {},
+    options: {
+      npmLevel: 'http'
     }
   };
   npmInstall(context, function (err) {


### PR DESCRIPTION
Prior to the code coverage we were checking codes on the exit on npm
install. I was mistaken about the way npm install handles error handling
and had removed the code handling. This brings it back and includes a
test to make sure we do not regress again.

This should solve the CI problems we are having with PPC.