### PR TITLE
npm: introduce timeout for npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Options:
   -s, --su                    Allow running the tool as root.
   -m, --markdown              Output results in markdown
   -t, --tap [path]            Output results in tap with optional file path
+  -o, --timeout <length>      Set timeout for npm install
   -u, --uid <uid>             Set the uid (posix only)
   -g, --gid <uid>             Set the gid (posix only)
 ```
@@ -73,6 +74,7 @@ Options:
   -s, --su                    Allow running the tool as root.
   -m, --markdown              Output results in markdown
   -t, --tap [path]            Output results in tap with optional file path
+  -o, --timeout <length>      Set timeout for npm install
   -u, --uid <uid>             Set the uid (posix only)
   -g, --gid <uid>             Set the gid (posix only)
 ```

--- a/bin/citgm
+++ b/bin/citgm
@@ -45,6 +45,8 @@ app
   )
   .option(
     '-t, --tap [path]', 'Output results in tap with optional file path'
+  ).option(
+    '-o, --timeout <length>', 'Set timeout for npm install', 1000 * 60 * 10
   );
 
 if (!citgm.windows) {
@@ -82,7 +84,8 @@ var options = {
   lookup: app.lookup,
   nodedir: app.nodedir,
   level: app.verbose,
-  npmLevel: app.npmLoglevel
+  npmLevel: app.npmLoglevel,
+  timeoutLength: app.timeout
 };
 
 if (!citgm.windows) {

--- a/bin/citgm-all
+++ b/bin/citgm-all
@@ -40,6 +40,8 @@ app
   )
   .option(
     '-t, --tap [path]', 'Output results in tap with optional file path'
+  ).option(
+    '-o, --timeout <length>', 'Output results in tap with optional file path', 1000 * 60 * 10
   );
 
 if (!citgm.windows) {
@@ -71,7 +73,8 @@ var options = {
   lookup: app.lookup,
   nodedir: app.nodedir,
   level: app.verbose,
-  npmLevel: app.npmLoglevel
+  npmLevel: app.npmLoglevel,
+  timeoutLength: app.timeout
 };
 
 var lookup = getLookup(options);

--- a/lib/npm/install.js
+++ b/lib/npm/install.js
@@ -7,7 +7,6 @@ var path = require('path');
 var spawn = require('../spawn');
 var createOptions = require('../create-options');
 
-
 function install(context, next) {
   var options =
     createOptions(
@@ -15,27 +14,40 @@ function install(context, next) {
   var args = ['install', '--loglevel', context.options.npmLevel];
   var bailed = false;
   context.emit('data', 'info', 'npm:', 'install started');
+
   if (context.options.nodedir) {
     var nodedir = path.resolve(process.cwd(), context.options.nodedir);
     options.env.npm_config_nodedir = nodedir;
     args.push('--nodedir="' + nodedir + '"');
     context.emit('data', 'verbose','nodedir', 'Using --nodedir="' + nodedir + '"');
   }
+
   var proc = spawn('npm', args, options);
-  proc.stderr.on('data', function (chunk) {
-    context.emit('data', 'warn', 'npm-install:', chunk.toString());
-  });
-  proc.stdout.on('data', function (chunk) {
-    context.emit('data', 'verbose', 'npm-install:', chunk.toString());
-  });
-  proc.on('error', function() {
+
+  // default timeout to 10 minutes if not provided
+  var timeout = setTimeout(cleanup, context.options.timeoutLength || 1000 * 60 * 10);
+
+  function cleanup() {
+    clearTimeout(timeout);
     bailed = true;
     context.emit('data', 'error', 'npm-install:', 'Install Failed');
     proc.kill();
     return next(Error('Install Failed'));
+  }
+
+  proc.stderr.on('data', function (chunk) {
+    context.emit('data', 'warn', 'npm-install:', chunk.toString());
   });
+
+  proc.stdout.on('data', function (chunk) {
+    context.emit('data', 'verbose', 'npm-install:', chunk.toString());
+  });
+
+  proc.on('error', cleanup);
+
   proc.on('close', function(code) {
     if (bailed) return;
+    clearTimeout(timeout);
     if (code > 0) {
       return next(Error('Install Failed'));
     }

--- a/man/citgm-all.1
+++ b/man/citgm-all.1
@@ -41,6 +41,8 @@ Output results in markdown
 .BR \-t ", " \-\-tap " " \fI[path]\fR
 Output results in tap
 .TP
+.BR \-o ", " \-\-timeout " " \fI<length>\fR
+Set timeout for npm install
 .BR \-u ", " \-\-uid " " \fIuid\fR
 Set the uid (posix only)
 .TP

--- a/man/citgm.1
+++ b/man/citgm.1
@@ -40,6 +40,8 @@ Output results in markdown
 .TP
 .BR \-t ", " \-\-tap " " \fI[path]\fR
 Output results in tap
+.BR \-o ", " \-\-timeout " " \fI<length>\fR
+Set timeout for npm install
 .TP
 .BR \-u ", " \-\-uid " " \fIuid\fR
 Set the uid (posix only)

--- a/test/test-citgm-sigint.js
+++ b/test/test-citgm-sigint.js
@@ -20,7 +20,7 @@ test('citgm: omg-i-pass', function (t) {
     t.equals(name, mod, 'it should be omg-i-pass');
     process.emit('SIGINT');
   }).on('fail', function (err) {
-    t.equals(err.message, 'Process Interrupted', 'it should fail with a process Interrupted message');
+    t.equals(err && err.message, 'Process Interrupted', 'it should fail with a process Interrupted message');
   }).on('end', function () {
     t.notOk(process.exitCode, 'it should exit with a code of 0');
     t.done();

--- a/test/test-citgm.js
+++ b/test/test-citgm.js
@@ -56,7 +56,7 @@ test('citgm: internal function find with error', function (t) {
     return next('Error');
   });
   find(undefined, undefined, function (err) {
-    t.equals(err.message, 'undefined not found in path!');
+    t.equals(err && err.message, 'undefined not found in path!');
     citgm.__set__('which', which);
     t.done();
   });

--- a/test/test-grab-project.js
+++ b/test/test-grab-project.js
@@ -95,7 +95,7 @@ test('grab-project: module does not exist', function (t) {
     options: {}
   };
   grabProject(context, function (err) {
-    t.equals(err.message, 'Failure getting project from npm');
+    t.equals(err && err.message, 'Failure getting project from npm');
     t.end();
   });
 });

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -141,7 +141,7 @@ test('lookup: no table', function (t) {
   };
 
   lookup(context, function (err) {
-    t.equals(err.message, 'Lookup table could not be loaded');
+    t.equals(err && err.message, 'Lookup table could not be loaded');
     t.done();
   });
 });
@@ -163,7 +163,7 @@ test('lookup: replace with no repo', function (t) {
   };
 
   lookup(context, function (err) {
-    t.equals(err.message, 'no-repository-field in package.json');
+    t.equals(err && err.message, 'no-repository-field in package.json');
     t.done();
   });
 });

--- a/test/test-npm-install.js
+++ b/test/test-npm-install.js
@@ -63,7 +63,7 @@ test('npm-install: no package.json', function (t) {
     }
   };
   npmInstall(context, function (err) {
-    t.equals(err.message, 'Install Failed');
+    t.equals(err && err.message, 'Install Failed');
     t.done();
   });
 });
@@ -82,7 +82,7 @@ test('npm-install: timout', function (t) {
     }
   };
   npmInstall(context, function (err) {
-    t.equals(err.message, 'Install Failed');
+    t.equals(err && err.message, 'Install Failed');
     t.done();
   });
 });
@@ -100,7 +100,7 @@ test('npm-install: failed install', function (t) {
     }
   };
   npmInstall(context, function (err) {
-    t.equals(err.message, 'Install Failed');
+    t.equals(err && err.message, 'Install Failed');
     t.done();
   });
 });

--- a/test/test-npm-install.js
+++ b/test/test-npm-install.js
@@ -68,6 +68,25 @@ test('npm-install: no package.json', function (t) {
   });
 });
 
+test('npm-install: timout', function (t) {
+  var context = {
+    emit: function() {},
+    path: sandbox,
+    module: {
+      name: 'omg-i-pass'
+    },
+    meta: {},
+    options: {
+      npmLevel: 'silly',
+      timeoutLength: 100
+    }
+  };
+  npmInstall(context, function (err) {
+    t.equals(err.message, 'Install Failed');
+    t.done();
+  });
+});
+
 test('npm-install: failed install', function (t) {
   var context = {
     emit: function() {},

--- a/test/test-npm-script-fetch.js
+++ b/test/test-npm-script-fetch.js
@@ -106,7 +106,7 @@ test('fetch: properly handle errors from request', function (t) {
   fs.createWriteStream = function () {};
   fetch.__set__('request', RequestMock);
   fetch(context, 'http://do-nothing.com', function (err) {
-    t.equals(err.message, 'I am broken');
+    t.equals(err && err.message, 'I am broken');
     fetch.__set__('request', request);
     fs.createWriteStream = createWriteStream;
     t.end();

--- a/test/test-npm-script-run.js
+++ b/test/test-npm-script-run.js
@@ -48,7 +48,7 @@ test('npm.script.run: should fail with failing script', function (t) {
   };
   var failingMsg = 'the canary is dead';
   run(context, failingScript, failingMsg, function (err) {
-    t.equals(err.message, failingMsg);
+    t.equals(err && err.message, failingMsg);
     t.done();
   });
 });

--- a/test/test-npm-test.js
+++ b/test/test-npm-test.js
@@ -72,7 +72,7 @@ test('npm-test: basic module failing', function (t) {
     options: {}
   };
   npmTest(context, function (err) {
-    t.equals(err.message, 'The canary is dead:');
+    t.equals(err && err.message, 'The canary is dead:');
     t.done();
   });
 });
@@ -88,7 +88,7 @@ test('npm-test: basic module no test script', function (t) {
     options: {}
   };
   npmTest(context, function (err) {
-    t.equals(err.message, 'Module does not support npm-test!');
+    t.equals(err && err.message, 'Module does not support npm-test!');
     t.done();
   });
 });
@@ -104,7 +104,7 @@ test('npm-test: no package.json', function (t) {
     options: {}
   };
   npmTest(context, function (err) {
-    t.equals(err.message, 'Package.json Could not be found');
+    t.equals(err && err.message, 'Package.json Could not be found');
     t.done();
   });
 });


### PR DESCRIPTION
We are currently noticing problems in CI with some npm install's
hanging for quite some time. This can make an entire CI run useless.

This PR introduces a new cli options `-o` or `--timeout` which takes
a single argument, a length (of type Number). The default is set to
10 minutes. If an npm install is taking more than 10 minutes it will
simply fail.