### PR TITLE
Ensure npm doesn't leave assets in $TMPDIR

### DIFF
--- a/lib/create-options.js
+++ b/lib/create-options.js
@@ -7,7 +7,9 @@ function createOptions(cwd, context) {
     if (context.options.gid) options.gid = context.options.gid;
   }
   options.env = Object.create(process.env);
-  options.env.npm_loglevel = 'error';
+  options.env['npm_loglevel'] = 'error';
+  options.env['npm_config_tmp'] = context.npmConfigTmp;
+
   return options;
 }
 

--- a/lib/temp-directory.js
+++ b/lib/temp-directory.js
@@ -1,22 +1,26 @@
 // node modules
-var fs = require('fs');
 var path = require('path');
 
 // npm modules
+var mkdirp = require('mkdirp');
 var rimraf = require('rimraf');
 var uuid = require('node-uuid');
 var osenv = require('osenv');
 
 function create(context, next) {
   var _path = path.join(osenv.tmpdir(),uuid.v4());
+  var npmConfigTmp = path.join(_path, 'npm_config_tmp');
+
   context.path = _path;
+  context.npmConfigTmp = npmConfigTmp;
+
   context.emit('data', 'silly', 'mk.tempdir', _path);
-  fs.mkdir(_path, function(err) {
+
+  mkdirp(npmConfigTmp, function (err) {
     if (err) {
-      next(err);
-      return;
+      return next(err);
     }
-    next(null,context);
+    return next(null, context);
   });
 }
 

--- a/test/test-create-options.js
+++ b/test/test-create-options.js
@@ -7,11 +7,13 @@ test('create-options:', function (t) {
   var cwd = __dirname;
 
   var context = {
-    options: {}
+    options: {},
+    npmConfigTmp: 'npm_config_tmp'
   };
 
   var env = Object.create(process.env);
-  env.npm_loglevel = 'error';
+  env['npm_loglevel'] = 'error';
+  env['npm_config_tmp'] = 'npm_config_tmp';
 
   var options = createOptions(cwd, context);
 

--- a/test/test-npm-script-run.js
+++ b/test/test-npm-script-run.js
@@ -12,7 +12,7 @@ var passingScript = path.join(__dirname, 'fixtures', 'example-test-script-passin
 var failingScript = path.join(__dirname, 'fixtures', 'example-test-script-failing.sh');
 var badPath = path.join(__dirname, 'fixtures', 'example-test-script-does-not-exist');
 
-var sandbox = path.join(os.tmpdir(), 'citgm-' + Date.now(), 'run-test');
+var sandbox = path.join(os.tmpdir(), 'citgm-' + Date.now() + 'run-test');
 
 test('npm.script.run: setup', function (t) {
   mkdirp(sandbox, function (err) {


### PR DESCRIPTION
Currently npm defaults are causing a leak in $TMPDIR

This change ensures that all the temporary cache for npm is cleaned
by citgm. This will help to fix a problem we noticed in CI of massive
amounts of memory being eaten up over time.

Closes #128