### PR TITLE
lookup: update body-parser flaky status

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -61,8 +61,7 @@
     "replace": true
   },
   "body-parser": {
-    "replace": true,
-    "flaky": ["v6", "v7"]
+    "replace": true
   },
   "uglify-js": {
     "replace": true,


### PR DESCRIPTION
As of version 1.5.1 of the `body-parser` module, it should no longer be flaky on v6/v7 with updated tests merged from @TheAlphaNerd.