### PR TITLE
[WIP] fix: inherit stdio/stderr so that we can test for node #6456

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
 "repo": "https://github.com/pugjs/jade" - Use a different github repo
 "skipAnsi": true             Strip ansi data from output stream of npm
 "script": /path/to/script | https://url/to/script - Use a custom test script
+"sha": "<git-commit-sha>"    Test against a specific commit
 ```
 ## Testing
 

--- a/bin/citgm
+++ b/bin/citgm
@@ -45,8 +45,12 @@ app
   )
   .option(
     '-t, --tap [path]', 'Output results in tap with optional file path'
-  ).option(
+  )
+  .option(
     '-o, --timeout <length>', 'Set timeout for npm install', 1000 * 60 * 10
+  )
+  .option(
+    '-c, --sha <commit-sha>', 'Install module from commit-sha'
   );
 
 if (!citgm.windows) {
@@ -85,7 +89,8 @@ var options = {
   nodedir: app.nodedir,
   level: app.verbose,
   npmLevel: app.npmLoglevel,
-  timeoutLength: app.timeout
+  timeoutLength: app.timeout,
+  sha: app.sha
 };
 
 if (!citgm.windows) {
@@ -103,7 +108,7 @@ if (!citgm.windows) {
 
 function launch(mod, options) {
   var runner = citgm.Tester(mod, options);
-  
+
   function cleanup() {
     runner.cleanup();
   }
@@ -111,7 +116,7 @@ function launch(mod, options) {
   process.on('SIGINT', cleanup);
   process.on('SIGHUP', cleanup);
   process.on('SIGBREAK', cleanup);
-  
+
   runner.on('start', function(name) {
     log.info('starting', name);
   }).on('fail', function(err) {

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -6,9 +6,15 @@ var path = require('path');
 var isFlaky = require('./is-flaky');
 
 // construct the tarball url using the repo, spec and prefix config
-function makeUrl(repo, spec, tags, prefix) {
-  prefix = prefix || '';
+function makeUrl(repo, spec, tags, prefix, sha) {
   var version = (!spec || spec === '') ? 'master' : tags[spec];
+  prefix = prefix || '';
+
+  if (sha) {
+    prefix = '';
+    version = sha;
+  }
+  
   return util.format('%s/archive/%s%s.tar.gz', repo, prefix, version);
 }
 
@@ -77,7 +83,8 @@ function resolve(context, next) {
           getRepo(rep.repo, meta),
           rep.master ? null : detail.spec,
           meta['dist-tags'],
-          rep.master ? null : rep.prefix);
+          rep.master ? null : rep.prefix,
+          rep.sha);
         context.emit('info','lookup-replace',url);
         context.module.raw = url;
       }

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -14,7 +14,7 @@ function makeUrl(repo, spec, tags, prefix, sha) {
     prefix = '';
     version = sha;
   }
-  
+
   return util.format('%s/archive/%s%s.tar.gz', repo, prefix, version);
 }
 
@@ -84,7 +84,7 @@ function resolve(context, next) {
           rep.master ? null : detail.spec,
           meta['dist-tags'],
           rep.master ? null : rep.prefix,
-          rep.sha);
+          context.options.sha || rep.sha);
         context.emit('info','lookup-replace',url);
         context.module.raw = url;
       }

--- a/lib/npm/test.js
+++ b/lib/npm/test.js
@@ -5,8 +5,8 @@ var path = require('path');
 var fs = require('fs');
 
 // npm modules
+var _ = require('lodash');
 var readPackage = require('read-package-json');
-var stripAnsi = require('strip-ansi');
 
 // local modules
 var spawn = require('../spawn');
@@ -57,20 +57,13 @@ function test(context, next) {
       return;
     }
 
-    var options = createOptions(wd, context);
+    var options = _.assign(
+      {
+        stdio: 'inherit'
+      },
+      createOptions(wd, context)
+    );
     var proc = spawn('npm', ['test', '--loglevel=' + context.options.npmLevel], options);
-    proc.stdout.on('data', function (data) {
-      if (context.module.stripAnsi) {
-        data = stripAnsi(data.toString());
-        data = data.replace(/\r/g, '\n');
-      }
-      context.testOutput += data;
-      context.emit('data', 'verbose', 'npm-test:', data.toString());
-    });
-    proc.stderr.on('data', function (data) {
-      context.testError += data;
-      context.emit('data', 'verbose', 'npm-test:', data.toString());
-    });
     proc.on('error', function() {
       next(new Error('Tests Failed'));
     });

--- a/test/test-bin.js
+++ b/test/test-bin.js
@@ -58,7 +58,7 @@ test('bin: no module /w root check', function (t) {
 
 test('bin: sigterm', function (t) {
   t.plan(1);
-  
+
   var proc = spawn(citgmPath, ['omg-i-pass', '-v', 'verbose']);
   proc.on('error', function(err) {
     t.error(err);
@@ -69,5 +69,17 @@ test('bin: sigterm', function (t) {
   });
   proc.on('exit', function (code) {
     t.equal(code, 1, 'omg-i-pass should fail from a sigint');
+  });
+});
+
+test('bin: install from sha', function (t) {
+  t.plan(1);
+  var proc = spawn(citgmPath, ['omg-i-pass', '-t', '-c', '37c34bad563599782c622baf3aaf55776fbc38a8']);
+  proc.on('error', function(err) {
+    t.error(err);
+    t.fail('we should not get an error testing omg-i-pass');
+  });
+  proc.on('close', function (code) {
+    t.ok(code === 0, 'omg-i-pass should pass and exit with a code of zero');
   });
 });

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -17,6 +17,8 @@ test('lookup: makeUrl', function (t) {
 
   var prefix = 'v';
 
+  var sha = 'abc123';
+
   var expected = repo + '/archive/master.tar.gz';
   var url = makeUrl(repo);
   t.equal(url, expected, 'by default makeUrl should give a link to master');
@@ -28,6 +30,10 @@ test('lookup: makeUrl', function (t) {
   expected = repo + '/archive/' + prefix + tags.latest + '.tar.gz';
   url = makeUrl(repo, 'latest', tags, prefix);
   t.equal(url, expected, 'if given a prefix it should be included in the filename');
+
+  expected = repo + '/archive/' + sha + '.tar.gz';
+  url = makeUrl(repo, 'latest', tags, prefix, sha);
+  t.equal(url, expected, 'if given sha, it should be used to create download URL');
 
   t.end();
 });


### PR DESCRIPTION
Please note that this pull is currently forked off of https://github.com/nodejs/citgm/pull/135, which made it easier to test.
## Problem

Because CITGM runs tests with spawn's default `pipe` behavior (`isTTY = false`), we are unable to detect the terminal output bug discussed here: https://github.com/nodejs/node/issues/6456

yargs has a regression test for terminal truncation that was not caught.
## Potential Solution

This pull request is a potential solution, rather than using `stdio = pipe`, we use `stdio = inherit`:

**the good:**

We're able to detect the terminal output bug:

_yargs at master:_

``` sh
./bin/citgm yargs
info:    passing module(s)   |                     
info:    module name:        | yargs               
info:    version:            | 4.7.1               
info:    done                | The smoke test has passed.
```

_yargs prior to the [set-blocking](https://www.npmjs.com/package/set-blocking) patch:_

``` sh
./bin/citgm yargs --sha=2df0dba39249549589eb96c95691bff756e84177
npm ERR! Test failed.  See above for more details.
error:   failure             | The canary is dead: 
error:   failing module(s)   |                     
error:   module name:        | yargs               
error:   version:            | 4.7.1               
error:   error:              | The canary is dead: 
error:   error:              |                     
error:   done                | The smoke test has failed.
```
## The Problem With This Solution

Since `stdout` is now equal to `inherit` our test output becomes _pretty_ noisy.
## Ben's Thought of the Day

I _hate_ noisy test output, having said that -- I think it might be worthwhile to have `citgm` run tests with `isTTY = true` like this, its a more realistic test of the behavior of CLI applications.
