### PR TITLE
Timeout fixes

### DIFF
--- a/lib/grab-project.js
+++ b/lib/grab-project.js
@@ -38,9 +38,13 @@ function grabProject(context, next) {
   proc.stdout.on('data', function(chunk) {
     filename += chunk;
   });
+
   proc.on('error', function(err) {
+    bailed = true;
+    clearTimeout(timeout);
     return next(err);
   });
+
   proc.on('close', function(code) {
     if (bailed) return;
     clearTimeout(timeout);

--- a/lib/grab-project.js
+++ b/lib/grab-project.js
@@ -12,6 +12,7 @@ function grabProject(context, next) {
   if (context.module.type === 'local') {
     package_name = path.resolve(process.cwd(),package_name);
   }
+  var bailed = false;
   context.emit('data', 'info','npm:','Downloading project: ' + package_name);
   var proc =
     spawn(
@@ -20,7 +21,20 @@ function grabProject(context, next) {
       createOptions(
         context.path,
         context));
+
   var filename = '';
+  
+  // default timeout to 10 minutes if not provided
+  var timeout = setTimeout(cleanup, context.options.timeoutLength || 1000 * 60 * 10);
+
+  function cleanup() {
+    clearTimeout(timeout);
+    bailed = true;
+    context.emit('data', 'error', 'npm:', 'Download Timed Out');
+    proc.kill();
+    return next(Error('Download Timed Out'));
+  }
+  
   proc.stdout.on('data', function(chunk) {
     filename += chunk;
   });
@@ -28,6 +42,8 @@ function grabProject(context, next) {
     return next(err);
   });
   proc.on('close', function(code) {
+    if (bailed) return;
+    clearTimeout(timeout);
     if (code > 0) {
       return next(Error('Failure getting project from npm'));
     }

--- a/lib/npm/install.js
+++ b/lib/npm/install.js
@@ -30,9 +30,9 @@ function install(context, next) {
   function cleanup() {
     clearTimeout(timeout);
     bailed = true;
-    context.emit('data', 'error', 'npm-install:', 'Install Failed');
+    context.emit('data', 'error', 'npm-install:', 'Install Timed Out');
     proc.kill();
-    return next(Error('Install Failed'));
+    return next(Error('Install Timed Out'));
   }
 
   proc.stderr.on('data', function (chunk) {
@@ -43,7 +43,11 @@ function install(context, next) {
     context.emit('data', 'verbose', 'npm-install:', chunk.toString());
   });
 
-  proc.on('error', cleanup);
+  proc.on('error', function() {
+    bailed = true;
+    clearTimeout(timeout);
+    return next(new Error('Install Failed'));
+  });
 
   proc.on('close', function(code) {
     if (bailed) return;

--- a/test/test-grab-project.js
+++ b/test/test-grab-project.js
@@ -100,6 +100,25 @@ test('grab-project: module does not exist', function (t) {
   });
 });
 
+test('grab-project: timeout', function (t) {
+  var context = {
+    emit: function() {},
+    path: sandbox,
+    module: {
+      name: 'omg-i-pass'
+    },
+    meta: {},
+    options: {
+      npmLevel: 'silly',
+      timeoutLength: 10
+    }
+  };
+  grabProject(context, function (err) {
+    t.equals(err && err.message, 'Download Timed Out');
+    t.done();
+  });
+});
+
 test('grab-project: teardown', function (t) {
   rimraf(sandbox, function (err) {
     t.error(err);

--- a/test/test-npm-install.js
+++ b/test/test-npm-install.js
@@ -68,7 +68,7 @@ test('npm-install: no package.json', function (t) {
   });
 });
 
-test('npm-install: timout', function (t) {
+test('npm-install: timeout', function (t) {
   var context = {
     emit: function() {},
     path: sandbox,
@@ -82,7 +82,7 @@ test('npm-install: timout', function (t) {
     }
   };
   npmInstall(context, function (err) {
-    t.equals(err && err.message, 'Install Failed');
+    t.equals(err && err.message, 'Install Timed Out');
     t.done();
   });
 });


### PR DESCRIPTION
Add timeout to grab-project and cleanup timeout from `npm.install`

This fixes some breakages and hanging processes we have noticed in CI