### PR TITLE
npm: use --cache-min 999999 when installing

### DIFF
--- a/lib/npm/install.js
+++ b/lib/npm/install.js
@@ -11,7 +11,7 @@ function install(context, next) {
   var options =
     createOptions(
       path.join(context.path, context.module.name), context);
-  var args = ['install', '--loglevel', context.options.npmLevel];
+  var args = ['install', '--cache-min', '999999', '--loglevel', context.options.npmLevel];
   var bailed = false;
   context.emit('data', 'info', 'npm:', 'install started');
 


### PR DESCRIPTION
This forces npm to use the internal cache if possible

I believe that this should result in significantly faster install times

Ref: https://github.com/npm/npm/issues/2568