### PR TITLE
bin: enable parallel task running for citgm-all

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Options:
   -u, --uid <uid>             Set the uid (posix only)
   -g, --gid <uid>             Set the gid (posix only)
   -a, --append                Turns on append results to file mode rather than replace
+  -j, --parallel <number>     Run tests in parallel
+  -J, --autoParallel          Run tests in parallel (automatically detect core count)
 ```
 
 When using a JSON config file, the properties need to be the same as the

--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -39,7 +39,7 @@ function find(app, context, next) {
       next(Error(app + ' not found in path!'));
       return;
     }
-    context.emit('data', 'verbose', 'using-' + app, resolved);
+    context.emit('data', 'verbose', context.module.name + ' using-' + app, resolved);
     next(null, context);
   });
 }
@@ -47,11 +47,11 @@ function find(app, context, next) {
 function init(context,next) {
   if (!windows) {
     if (context.options.uid)
-      context.emit('data', 'verbose','using-uid',context.options.uid);
+      context.emit('data', 'verbose', context.module.name + ' using-uid', context.options.uid);
     if (context.options.gid)
-      context.emit('data', 'verbose','using-gid',context.options.gid);
+      context.emit('data', 'verbose', context.module.name + ' using-gid', context.options.gid);
   }
-  context.emit('data', 'silly', 'init-detail', context.module);
+  context.emit('data', 'silly', context.module.name + ' init-detail', context.module);
   next(null,context); // inject the context
 }
 

--- a/lib/grab-module-data.js
+++ b/lib/grab-module-data.js
@@ -20,7 +20,7 @@ function grabModuleData(context, next) {
   });
   proc.on('close', function(code) {
     if (code > 0) {
-      context.emit('data', 'silly','npm-view','No npm package information available');
+      context.emit('data', 'silly', context.module.name + ' npm-view', 'No npm package information available');
       if (context.module.type === 'hosted' &&
           context.module.hosted.type === 'github') {
         context.meta = {
@@ -33,7 +33,7 @@ function grabModuleData(context, next) {
       next(null, context);
       return;
     }
-    context.emit('data', 'silly','npm-view','Data retrieved');
+    context.emit('data', 'silly', context.module.name + ' npm-view', 'Data retrieved');
     try {
       context.meta = JSON.parse(data);
     } catch (ex) {

--- a/lib/grab-project.js
+++ b/lib/grab-project.js
@@ -7,14 +7,14 @@ var createOptions = require('./create-options');
 
 function grabProject(context, next) {
   if (context.meta)
-    context.emit('data', 'silly', 'package-meta', context.meta);
+    context.emit('data', 'silly', context.module.name + ' package-meta', context.meta);
   var packageName = context.module.raw;
   if (context.module.type === 'local') {
     context.module.raw = context.module.name = path.basename(packageName);
     packageName = path.resolve(process.cwd(), packageName);
   }
   var bailed = false;
-  context.emit('data', 'info','npm:','Downloading project: ' + packageName);
+  context.emit('data', 'info', context.module.name + ' npm:', 'Downloading project: ' + packageName);
   var proc =
     spawn(
       'npm',
@@ -31,7 +31,7 @@ function grabProject(context, next) {
   function cleanup() {
     clearTimeout(timeout);
     bailed = true;
-    context.emit('data', 'error', 'npm:', 'Download Timed Out');
+    context.emit('data', 'error', context.module.name + ' npm:', 'Download Timed Out');
     proc.kill();
     return next(Error('Download Timed Out'));
   }
@@ -60,7 +60,7 @@ function grabProject(context, next) {
     if (filename === '') {
       return next(Error('No project downloaded'));
     }
-    context.emit('data', 'info','npm:','Project downloaded ' + filename);
+    context.emit('data', 'info', context.module.name + ' npm:', 'Project downloaded ' + filename);
     context.unpack = path.join(context.path, filename);
     return next(null, context);
   });

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -84,27 +84,27 @@ function resolve(context, next) {
           next(new Error('no-repository-field in package.json'));
           return;
         }
-        context.emit('data','info','lookup-found',detail.name);
+        context.emit('data', 'info', 'lookup-found', detail.name);
         var url = makeUrl(
           getRepo(rep.repo, meta),
           rep.master ? null : detail.spec,
           meta['dist-tags'],
           rep.master ? null : rep.prefix,
           context.options.sha || rep.sha);
-        context.emit('data','info','lookup-replace',url);
+        context.emit('data', 'info', context.module.name + ' lookup-replace', url);
         context.module.raw = url;
       }
       if (rep.install) {
-        context.emit('data','verbose', 'lookup-install', rep.install);
+        context.emit('data', 'verbose', context.module.name + ' lookup-install', rep.install);
         context.module.install = rep.install;
       }
       if (rep.script) {
-        context.emit('data','info','lookup-script',rep.script);
+        context.emit('data', 'info', context.module.name + ' lookup-script', rep.script);
         context.module.script = rep.script;
       }
       context.module.flaky = context.options.failFlaky ? false : isMatch(rep.flaky);
     } else {
-      context.emit('data','info','lookup-notfound',detail.name);
+      context.emit('data', 'info', 'lookup-notfound', detail.name);
     }
   }
 

--- a/lib/npm/install.js
+++ b/lib/npm/install.js
@@ -16,7 +16,7 @@ function install(context, next) {
       path.join(context.path, context.module.name), context);
   var args = ['install', '--loglevel', context.options.npmLevel];
   var bailed = false;
-  context.emit('data', 'info', 'npm:', 'install started');
+  context.emit('data', 'info', context.module.name + ' npm:', 'npm install started');
 
   if (context.module.install) {
     args = args.concat(context.module.install);
@@ -29,7 +29,7 @@ function install(context, next) {
       nodedir = nodedir.replace(/\\/g, '\\\\');
     }
     args.push('--nodedir="' + nodedir + '"');
-    context.emit('data', 'verbose','nodedir', 'Using --nodedir="' + nodedir + '"');
+    context.emit('data', 'verbose', context.module.name + 'nodedir', 'Using --nodedir="' + nodedir + '"');
   }
 
   var proc = spawn('npm', args, options);
@@ -40,7 +40,7 @@ function install(context, next) {
   function cleanup() {
     clearTimeout(timeout);
     bailed = true;
-    context.emit('data', 'error', 'npm-install:', 'Install Timed Out');
+    context.emit('data', 'error', context.module.name + ' npm:', 'npm-install Timed Out');
     proc.kill();
     return next(Error('Install Timed Out'));
   }
@@ -53,7 +53,7 @@ function install(context, next) {
       chunk = stripAnsi(chunk.toString());
       chunk = chunk.replace(/\r/g, '\n');
     }
-    context.emit('data', 'warn', 'npm-install:', chunk.toString());
+    context.emit('data', 'warn', context.module.name + ' npm-install:', chunk.toString());
     installError += chunk;
   });
 
@@ -62,7 +62,7 @@ function install(context, next) {
       chunk = stripAnsi(chunk.toString());
       chunk = chunk.replace(/\r/g, '\n');
     }
-    context.emit('data', 'verbose', 'npm-install:', chunk.toString());
+    context.emit('data', 'verbose', context.module.name + ' npm-install:', chunk.toString());
     installOutput += chunk;
   });
 
@@ -82,7 +82,7 @@ function install(context, next) {
       context.testError = installError || '';
       return next(Error('Install Failed'));
     }
-    context.emit('data', 'info', 'npm:', 'install successfully completed');
+    context.emit('data', 'info', context.module.name + ' npm:', 'npm install successfully completed');
     return next(null, context);
   });
 }

--- a/lib/npm/script/fetch.js
+++ b/lib/npm/script/fetch.js
@@ -23,7 +23,7 @@ function fetchScript(context, script, next) {
     readStream = fs.createReadStream(_path);
   }
   else {
-    context.emit('data', 'silly', 'fetch-script-start', script);
+    context.emit('data', 'silly', context.module.name + ' fetch-script-start', script);
     readStream = request(res.href);
   }
 
@@ -32,7 +32,7 @@ function fetchScript(context, script, next) {
   });
 
   readStream.on('end', function() {
-    context.emit('data', 'silly', 'fetch-script-end', dest);
+    context.emit('data', 'silly', context.module.name + ' fetch-script-end', dest);
     next(null, dest);
   });
 

--- a/lib/npm/script/run.js
+++ b/lib/npm/script/run.js
@@ -16,7 +16,7 @@ function runScript(context, script, msg, next) {
     next = msg;
     msg = util.format('Script %s failed', _path);
   }
-  context.emit('data', 'verbose','script-start', _path);
+  context.emit('data', 'verbose', context.module.name + ' script-start', _path);
   fs.stat(_path, function(err, stat) {
     if (err || !stat.isFile()) {
       return next(err);
@@ -29,11 +29,11 @@ function runScript(context, script, msg, next) {
         data = data.replace(/\r/g, '\n');
       }
       context.testOutput += data;
-      context.emit('data', 'verbose', 'npm-test:', data.toString());
+      context.emit('data', 'verbose', context.module.name + ' npm-test:', data.toString());
     });
     proc.stderr.on('data', function (data) {
       context.testError += data;
-      context.emit('data', 'verbose', 'npm-error:', data.toString());
+      context.emit('data', 'verbose', context.module.name + ' npm-error:', data.toString());
     });
     proc.on('error', function(err) {
       next(err);
@@ -42,7 +42,7 @@ function runScript(context, script, msg, next) {
       if (code > 0) {
         return next(Error(msg));
       }
-      context.emit('data', 'verbose','script-end', _path);
+      context.emit('data', 'verbose', context.module.name + ' script-end', _path);
       return next(null, context);
     });
   });

--- a/lib/npm/test.js
+++ b/lib/npm/test.js
@@ -42,7 +42,7 @@ function test(context, next) {
     return;
   }
   var wd = path.join(context.path, context.module.name);
-  context.emit('data', 'info', 'npm:', 'test suite started');
+  context.emit('data', 'info', context.module.name + ' npm:', 'test suite started');
   readPackage(path.join(wd,'package.json'),false,function(err,data) {
     if (err) {
       next(new Error('Package.json Could not be found'));
@@ -51,7 +51,7 @@ function test(context, next) {
     if (data.scripts === undefined ||
         data.scripts.test === undefined) {
       if (data.author) {
-        context.emit('data', 'warn', 'notice',
+        context.emit('data', 'warn', context.module.name + ' notice',
           'Please contact the module developer to request adding npm' +
           ' test support: ' + authorName(data.author));
       }
@@ -76,11 +76,11 @@ function test(context, next) {
         data = data.replace(/\r/g, '\n');
       }
       context.testOutput += data;
-      context.emit('data', 'verbose', 'npm-test:', data.toString());
+      context.emit('data', 'verbose', context.module.name + ' npm-test:', data.toString());
     });
     proc.stderr.on('data', function (data) {
       context.testError += data;
-      context.emit('data', 'verbose', 'npm-test:', data.toString());
+      context.emit('data', 'verbose', context.module.name + ' npm-test:', data.toString());
     });
     proc.on('error', function() {
       next(new Error('Tests Failed'));

--- a/lib/temp-directory.js
+++ b/lib/temp-directory.js
@@ -14,7 +14,7 @@ function create(context, next) {
   context.path = _path;
   context.npmConfigTmp = npmConfigTmp;
 
-  context.emit('data', 'silly', 'mk.tempdir', _path);
+  context.emit('data', 'silly', context.module.name + ' mk.tempdir', _path);
 
   mkdirp(npmConfigTmp, function (err) {
     if (err) {
@@ -28,7 +28,7 @@ function remove(context, next) {
   if (!context.path) {
     return next(null, context);
   }
-  context.emit('data', 'silly', 'rm.tempdir', context.path);
+  context.emit('data', 'silly', context.module.name + ' rm.tempdir', context.path);
   rimraf(context.path, function(err) {
     return next(err, context);
   });

--- a/lib/unpack.js
+++ b/lib/unpack.js
@@ -10,7 +10,7 @@ function unpack(context, next) {
   if (typeof context.unpack === 'string') {
     fs.exists(context.unpack, function(exists) {
       if (exists) {
-        context.emit('data', 'silly','gzip-unpack-start',context.unpack);
+        context.emit('data', 'silly', context.module.name + ' gzip-unpack-start', context.unpack);
         var gzip = zlib.createGunzip();
         var inp = fs.createReadStream(context.unpack);
         var out = tar.Extract({
@@ -19,7 +19,7 @@ function unpack(context, next) {
         });
         var res = inp.pipe(gzip).pipe(out);
         res.on('end', function() {
-          context.emit('data', 'silly','gzip-unpack-end', context.unpack);
+          context.emit('data', 'silly', context.module.name + ' gzip-unpack-end', context.unpack);
           return next(null, context);
         });
         res.on('error', function(err) {

--- a/test/bin/test-citgm-all.js
+++ b/test/bin/test-citgm-all.js
@@ -5,9 +5,9 @@ var spawn = require('../../lib/spawn');
 
 var citgmAllPath = require.resolve('../../bin/citgm-all.js');
 
-test('citgm-all: /w markdown', function (t) {
+test('citgm-all: /w markdown /w -j', function (t) {
   t.plan(1);
-  var proc = spawn(citgmAllPath, ['-l', 'test/fixtures/custom-lookup.json', '-m']);
+  var proc = spawn(citgmAllPath, ['-l', 'test/fixtures/custom-lookup.json', '-m', '-j', '1']);
   proc.on('error', function(err) {
     t.error(err);
     t.fail('we should not get an error testing omg-i-pass');
@@ -17,9 +17,9 @@ test('citgm-all: /w markdown', function (t) {
   });
 });
 
-test('citgm-all: envVar', function (t) {
+test('citgm-all: envVar /w -J', function (t) {
   t.plan(1);
-  var proc = spawn(citgmAllPath, ['-l', 'test/fixtures/custom-lookup-envVar.json']);
+  var proc = spawn(citgmAllPath, ['-l', 'test/fixtures/custom-lookup-envVar.json', '-J']);
   proc.on('error', function(err) {
     t.error(err);
   });

--- a/test/npm/test-npm-script-fetch.js
+++ b/test/npm/test-npm-script-fetch.js
@@ -29,7 +29,10 @@ test('fetch: setup', function (t) {
 test('fetch: given a file path', function (t) {
   var context = {
     path: sandbox,
-    emit: function () {}
+    emit: function () {},
+    module: {
+      name: 'test-module'
+    }
   };
   fetch(context, passing, function (err, _path)  {
     t.error(err);
@@ -47,6 +50,9 @@ test('fetch: given a custom lookup table and relative path', function (t) {
   var context = {
     path: sandbox,
     emit: function () {},
+    module: {
+      name: 'test-module'
+    },
     options: {
       lookup: path.join(fixtures, 'custom-lookup-script.json')
     }
@@ -66,7 +72,10 @@ test('fetch: given a custom lookup table and relative path', function (t) {
 test('fetch: given a uri with http', function (t) {
   var context = {
     path: sandbox,
-    emit: function () {}
+    emit: function () {},
+    module: {
+      name: 'test-module'
+    }
   };
   fetch(context, uriHttp, function (err, _path) {
     t.error(err);
@@ -82,7 +91,10 @@ test('fetch: given a uri with http', function (t) {
 test('fetch: given a uri with https', function (t) {
   var context = {
     path: sandbox,
-    emit: function () {}
+    emit: function () {},
+    module: {
+      name: 'test-module'
+    }
   };
   fetch(context, uriHttps, function (err, _path) {
     t.error(err);
@@ -98,7 +110,10 @@ test('fetch: given a uri with https', function (t) {
 test('fetch: properly handle errors from request', function (t) {
   var context = {
     path: sandbox,
-    emit: function () {}
+    emit: function () {},
+    module: {
+      name: 'test-module'
+    }
   };
 
   var request = fetch.__get__('request');

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -263,13 +263,13 @@ test('lookup: logging', function (t) {
     { type: 'info', key: 'lookup', msg: 'omg-i-pass' },
     { type: 'info', key: 'lookup-found', msg: 'omg-i-pass' },
     { type: 'info',
-      key: 'lookup-replace',
+      key: 'omg-i-pass lookup-replace',
       msg: 'https://github.com/nodejs/citgm/archive/master.tar.gz' },
     { type: 'verbose',
-      key: 'lookup-install',
+      key: 'omg-i-pass lookup-install',
       msg: [ '--extra-param' ] },
     { type: 'info',
-      key: 'lookup-script',
+      key: 'omg-i-pass lookup-script',
       msg: './example-test-script-passing.sh' }
   ];
   var EventEmitter = require('events').EventEmitter;

--- a/test/test-temp-directory.js
+++ b/test/test-temp-directory.js
@@ -9,12 +9,18 @@ var tempDirectory = rewire('../lib/temp-directory');
 
 var context = {
   path: null,
-  emit: function () {}
+  emit: function () {},
+  module: {
+    name: 'test-module'
+  }
 };
 
 var badContext = {
   path: null,
-  emit: function () {}
+  emit: function () {},
+  module: {
+    name: 'test-module-bad'
+  }
 };
 
 test('tempDirectory.create:', function (t) {


### PR DESCRIPTION
Currently all tests are run one at a time for `citgm-all` are run
sequentially. This is done using async.queue.

It queues to the number of available processors on the system, with a default of 1.
