### PR TITLE
Revert "npm: use --cache-min 999999 when installing"

### DIFF
--- a/lib/npm/install.js
+++ b/lib/npm/install.js
@@ -11,7 +11,7 @@ function install(context, next) {
   var options =
     createOptions(
       path.join(context.path, context.module.name), context);
-  var args = ['install', '--cache-min', '999999', '--loglevel', context.options.npmLevel];
+  var args = ['install', '--loglevel', context.options.npmLevel];
   var bailed = false;
   context.emit('data', 'info', 'npm:', 'install started');
 


### PR DESCRIPTION
This reverts commit 0d4ae1c2eb22fe6fe0739bf423e278f10900cafc.

Too many failures, not enough upside

/cc @rvagg 