### PR TITLE
lib: fix local modules

### DIFF
--- a/lib/grab-project.js
+++ b/lib/grab-project.js
@@ -8,16 +8,17 @@ var createOptions = require('./create-options');
 function grabProject(context, next) {
   if (context.meta)
     context.emit('data', 'silly', 'package-meta', context.meta);
-  var package_name = context.module.raw;
+  var packageName = context.module.raw;
   if (context.module.type === 'local') {
-    package_name = path.resolve(process.cwd(),package_name);
+    context.module.raw = context.module.name = path.basename(packageName);
+    packageName = path.resolve(process.cwd(), packageName);
   }
   var bailed = false;
-  context.emit('data', 'info','npm:','Downloading project: ' + package_name);
+  context.emit('data', 'info','npm:','Downloading project: ' + packageName);
   var proc =
     spawn(
       'npm',
-      ['pack', package_name],
+      ['pack', packageName],
       createOptions(
         context.path,
         context));
@@ -52,6 +53,10 @@ function grabProject(context, next) {
       return next(Error('Failure getting project from npm'));
     }
     filename = filename.trim();
+    if (context.module.type === 'local') {
+      filename = filename.trim().split('\n');
+      filename = filename.pop();
+    }
     if (filename === '') {
       return next(Error('No project downloaded'));
     }

--- a/test/test-grab-project.js
+++ b/test/test-grab-project.js
@@ -43,6 +43,27 @@ test('grab-project: npm module', function (t) {
   });
 });
 
+test('grab-project: local', function (t) {
+  var context = {
+    emit: function() {},
+    path: sandbox,
+    module: {
+      raw: './test/fixtures/omg-i-pass',
+      type: 'local'
+    },
+    meta: {},
+    options: {}
+  };
+  grabProject(context, function (err) {
+    t.error(err);
+    fs.stat(context.unpack, function (err, stats) {
+      t.error(err);
+      t.ok(stats.isFile(), 'The tar ball should exist on the system');
+      t.done();
+    });
+  });
+});
+
 test('grab-project: lookup table', function (t) {
   var context = {
     emit: function() {},


### PR DESCRIPTION
Seems like testing local folders wasn't working, especially for cases
where `npm pack` had a variety of output. This patch sanitizes the output
and ensures the proper module name is propogated