### PR TITLE
bin: add --node-bin flag for choosing test-node

### DIFF
--- a/bin/citgm-all.js
+++ b/bin/citgm-all.js
@@ -30,6 +30,9 @@ app
     'Path to the node source to use when compiling native addons'
   )
   .option(
+    '-p, --test-path <path>', 'Path to prepend to $PATH when running tests'
+  )
+  .option(
     '-n, --no-color', 'Turns off colorized output'
   )
   .option(
@@ -72,6 +75,7 @@ if (!app.su) {
 var options = {
   lookup: app.lookup,
   nodedir: app.nodedir,
+  testPath: app.testPath,
   level: app.verbose,
   npmLevel: app.npmLoglevel,
   timeoutLength: app.timeout

--- a/bin/citgm.js
+++ b/bin/citgm.js
@@ -35,6 +35,9 @@ app
     'Path to the node source to use when compiling native addons'
   )
   .option(
+    '-p, --test-path <path>', 'Path to prepend to $PATH when running tests'
+  )
+  .option(
     '-n, --no-color', 'Turns off colorized output'
   )
   .option(
@@ -87,6 +90,7 @@ var options = {
   script: script,
   lookup: app.lookup,
   nodedir: app.nodedir,
+  testPath: app.testPath,
   level: app.verbose,
   npmLevel: app.npmLoglevel,
   timeoutLength: app.timeout,

--- a/lib/npm/test.js
+++ b/lib/npm/test.js
@@ -7,6 +7,7 @@ var fs = require('fs');
 // npm modules
 var readPackage = require('read-package-json');
 var stripAnsi = require('strip-ansi');
+var which = require('which').sync;
 
 // local modules
 var spawn = require('../spawn');
@@ -58,7 +59,13 @@ function test(context, next) {
     }
 
     var options = createOptions(wd, context);
-    var proc = spawn('npm', ['test', '--loglevel=' + context.options.npmLevel], options);
+    var nodeBin = 'node';
+    if (context.options.testPath) {
+      options.env.PATH = context.options.testPath + ':' + process.env.PATH;
+      nodeBin = which('node', {path: options.env.PATH || process.env.PATH});
+    }
+    var npmBin = which('npm',  {path: options.env.PATH || process.env.PATH});
+    var proc = spawn(nodeBin, [npmBin, 'test', '--loglevel=' + context.options.npmLevel], options);
     proc.stdout.on('data', function (data) {
       if (context.module.stripAnsi) {
         data = stripAnsi(data.toString());

--- a/test/fixtures/fakenodebin/node
+++ b/test/fixtures/fakenodebin/node
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo "Not a real node"
+exit 1

--- a/test/npm/test-npm-test.js
+++ b/test/npm/test-npm-test.js
@@ -147,6 +147,26 @@ test('npm-test: custom script does not exist', function (t) {
   });
 });
 
+test('npm-test: alternative test-path', function (t) {
+  // Same test as 'basic module passing', except with alt node bin which fails.
+  var context = {
+    emit: function() {},
+    path: sandbox,
+    module: {
+      name: 'omg-i-pass'
+    },
+    meta: {},
+    options: {
+      npmLevel: 'silly',
+      testPath: path.resolve(__dirname, '..', 'fixtures', 'fakenodebin')
+    }
+  };
+  npmTest(context, function (err) {
+    t.equals(err && err.message, 'The canary is dead:');
+    t.end();
+  });
+});
+
 test('npm-test: teardown', function (t) {
   rimraf(sandbox, function (err) {
     t.error(err);


### PR DESCRIPTION
This options selects which node binary to run for `npm test` only.

---

I'm testing a "simluated"/"non-real"/"kinda weird" implementation of node. In it, `npm install` runs particularly slowly. This change ensures that the first `node` on the `$PATH` is used to run `citgm` and its `npm install`, as before, but now `npm test` is run using the node binary passed in as `--node-bin`.