### PR TITLE
bin: add --fail-flaky, to always fail on failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Options:
   -m, --markdown              Output results in markdown
   -t, --tap [path]            Output results in tap with optional file path
   -o, --timeout <length>      Set timeout for npm install
+  -f, --fail-flaky            Ignore flaky flags. Don't ignore any failures.
   -u, --uid <uid>             Set the uid (posix only)
   -g, --gid <uid>             Set the gid (posix only)
 ```

--- a/bin/citgm-all.js
+++ b/bin/citgm-all.js
@@ -45,6 +45,9 @@ app
     '-t, --tap [path]', 'Output results in tap with optional file path'
   ).option(
     '-o, --timeout <length>', 'Output results in tap with optional file path', 1000 * 60 * 10
+  )
+  .option(
+    '-f, --fail-flaky', 'Ignore flaky flags. Don\'t ignore any failures.'
   );
 
 if (!citgm.windows) {
@@ -76,6 +79,7 @@ var options = {
   lookup: app.lookup,
   nodedir: app.nodedir,
   testPath: app.testPath,
+  failFlaky: app.failFlaky,
   level: app.verbose,
   npmLevel: app.npmLoglevel,
   timeoutLength: app.timeout

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -92,7 +92,7 @@ function resolve(context, next) {
         context.emit('info','lookup-script',rep.script);
         context.options.script = rep.script;
       }
-      context.module.flaky = isFlaky(rep.flaky);
+      context.module.flaky = context.options.failFlaky ? false : isFlaky(rep.flaky);
     } else {
       context.emit('info','lookup-notfound',detail.name);
     }

--- a/man/citgm-all.1
+++ b/man/citgm-all.1
@@ -43,6 +43,10 @@ Output results in tap
 .TP
 .BR \-o ", " \-\-timeout " " \fI<length>\fR
 Set timeout for npm install
+.TP
+.BR \-f ", " \-\-fail-flaky
+Ignore flaky flags. Don't ignore any failures.
+.TP
 .BR \-u ", " \-\-uid " " \fIuid\fR
 Set the uid (posix only)
 .TP

--- a/test/bin/test-citgm-all.js
+++ b/test/bin/test-citgm-all.js
@@ -39,6 +39,17 @@ test('citgm-all: flaky-fail', function (t) {
   });
 });
 
+test('citgm-all: flaky-fail ignoring flakyness', function (t) {
+  t.plan(1);
+  var proc = spawn(citgmAllPath, ['-f', '-l', 'test/fixtures/custom-lookup-flaky.json']);
+  proc.on('error', function(err) {
+    t.error(err);
+  });
+  proc.on('close', function (code) {
+    t.equals(code, 1, 'citgm-all should exit with signal 1');
+  });
+});
+
 test('citgm-all: skip /w rootcheck /w tap to fs', function (t) {
   t.plan(1);
   var proc = spawn(citgmAllPath, ['-l', 'test/fixtures/custom-lookup-skip.json', '-s', '-t', '/dev/null']);

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -196,3 +196,28 @@ test('lookup: lookup with script', function (t) {
     t.end();
   });
 });
+
+test('lookup: --fail-flaky', function (t) {
+  var context = {
+    lookup: null,
+    module: {
+      name: 'lodash',
+      raw: null
+    },
+    meta: {
+      repository: {
+        url: 'https://github.com/lodash/lodash'
+      }
+    },
+    options: {
+      failFlaky: true
+    },
+    emit: function () {}
+  };
+
+  lookup(context, function (err) {
+    t.error(err);
+    t.false(context.module.flaky, 'flaky should be disabled');
+    t.end();
+  });
+});


### PR DESCRIPTION
With the flag enabled, all "flaky" data in `lookup.json` is ignored,
so that failures always count as failures.

---

I'm comparing a node-like environment with "real" node, so I want to have a correct count of failing modules in the TAP output, without having to modify the `lookup.json`.