### PR TITLE
lookup: add ember-cli

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -291,5 +291,9 @@
   "bson": {
     "replace": true,
     "prefix": "V"
+  },
+  "ember-cli": {
+    "replace": true,
+    "prefix": "v"
   }
 }


### PR DESCRIPTION
Currently this PR adds only `ember-cli` to the citgm lookup table. I think it would also be good to consider other highly depended on + tested repo's that make up the ember ecosystem.

/cc @tomdale @wycats for suggestions

Adding ember.js proper is currently a non starter due to the submodules 😢 
https://github.com/emberjs/ember.js/blob/master/.gitmodules