### PR TITLE
Mark level/leveldown and eslint as flaky on AIX/s390

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -81,7 +81,7 @@
   "eslint": {
     "replace": true,
     "prefix": "v",
-    "flaky": ["ppc", "v7"]
+    "flaky": ["ppc", "v7", "s390"]
   },
   "tape": {
     "replace": true,
@@ -102,7 +102,8 @@
   },
   "level": {
     "replace": true,
-    "prefix": "v"
+    "prefix": "v",
+    "flaky": ["aix", "s390"]
   },
   "torrent-stream": {
     "replace": true,
@@ -275,7 +276,8 @@
   },
   "leveldown": {
     "replace": true,
-    "prefix": "v"
+    "prefix": "v",
+    "flaky": ["aix", "s390"]
   },
   "bcrypt": {
     "replace": true,


### PR DESCRIPTION
eslint attempts to pull in the phantomjs prebuilt binary, but doesn't have an s390 version (or AIX, but it's already marked as flaky for ppc)  I've added a comment to an existing issue on phantomjs https://github.com/ariya/phantomjs/issues/13973 to see what would be required to produce a binary, but marking it flaky until this might be resolved.

leveldown is a pre-req of level which is the reason these modules are both affected.  It should attempt to build from source if a prebuild doesn't exist, but this falls over as it doesn't know what to do with an OS of "AIX", and the s390 platform fails the compilation with a "Please implement AtomicPointer for this platform." comment, so marking flaky on these two platforms, having opened an issue on level down https://github.com/Level/leveldown/issues/306

I've tested my changes on our test 390/aix machines, and all is working ok.