### PR TITLE
bin: use yargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Options:
 
   -h, --help                  output usage information
   -V, --version               output the version number
+  --config                    Path to a JSON config file
   -v, --verbose [level]       Verbose output (silly, verbose, info, warn, error)
   -q, --npm-loglevel [level]  Verbose output (silent, error, warn, http, info, verbose, silly)
   -l, --lookup <path>         Use the lookup table provided at <path>
@@ -42,6 +43,10 @@ Options:
   -u, --uid <uid>             Set the uid (posix only)
   -g, --gid <uid>             Set the gid (posix only)
 ```
+
+When using a JSON config file, the properties need to be the same as the
+longer-form CLI options. You can also use environment variables. For example,
+`CITGM_TEST_PATH=$HOME/bin` is the same as `--test-path $HOME/bin`.
 
 The tool requires online access to the npm registry to run. If you want to
 point to a private npm registry, then you'll need to set that up in your
@@ -71,6 +76,7 @@ Options:
 
   -h, --help                  output usage information
   -V, --version               output the version number
+  --config                    Path to a JSON config file
   -v, --verbose [level]       Verbose output (silly, verbose, info, warn, error)
   -q, --npm-loglevel [level]  Verbose output (silent, error, warn, http, info, verbose, silly)
   -l, --lookup <path>         Use the lookup table provided at <path>
@@ -86,6 +92,10 @@ Options:
   -u, --uid <uid>             Set the uid (posix only)
   -g, --gid <uid>             Set the gid (posix only)
 ```
+
+When using a JSON config file, the properties need to be the same as the
+longer-form CLI options. You can also use environment variables. For example,
+`CITGM_TEST_PATH=$HOME/bin` is the same as `--test-path $HOME/bin`.
 
 You can also test your own list of modules:
 

--- a/bin/citgm-all.js
+++ b/bin/citgm-all.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 'use strict';
-var app = require('commander');
+var yargs = require('yargs');
 var async = require('async');
 
 var update = require('../lib/update');
@@ -8,66 +8,21 @@ var citgm = require('../lib/citgm');
 var logger = require('../lib/out');
 var reporter = require('../lib/reporter');
 var getLookup = require('../lib/lookup').get;
+var commonArgs = require('../lib/common-args');
 
-var pkg = require('../package.json');
+yargs = commonArgs(yargs)
+  .usage('citgm-all [options]')
+  .option('fail-flaky', {
+    alias: 'f',
+    type: 'boolean',
+    description: 'Ignore flaky flags. Don\'t ignore any failures.'
+  });
 
-app
-  .version(pkg.version)
-  .option(
-    '-v, --verbose [level]',
-    'Verbose output (silly, verbose, info, warn, error)',
-    /^(silly|verbose|info|warn|error)$/i, 'info')
-  .option(
-    '-q, --npm-loglevel [level]',
-    'Verbose output (silent, error, warn, http, info, verbose, silly)',
-    /^(silent|error|warn|http|info|verbose|silly)$/i, 'error')
-  .option(
-    '-l, --lookup <path>',
-    'Use the lookup table provided at <path>'
-  )
-  .option(
-    '-d, --nodedir <path>',
-    'Path to the node source to use when compiling native addons'
-  )
-  .option(
-    '-p, --test-path <path>', 'Path to prepend to $PATH when running tests'
-  )
-  .option(
-    '-n, --no-color', 'Turns off colorized output'
-  )
-  .option(
-    '-s, --su', 'Allow running the tool as root.'
-  )
-  .option(
-    '-m, --markdown', 'Output results in markdown'
-  )
-  .option(
-    '-t, --tap [path]', 'Output results in tap with optional file path'
-  )
-  .option(
-    '-x, --junit [path]', 'Output results in junit xml with optional file path'
-  )
-  .option(
-    '-o, --timeout <length>', 'Output results in tap with optional file path', 1000 * 60 * 10
-  )
-  .option(
-    '-f, --fail-flaky', 'Ignore flaky flags. Don\'t ignore any failures.'
-  );
-
-if (!citgm.windows) {
-  app.option(
-    '-u, --uid <uid>', 'Set the uid (posix only)'
-  )
-  .option(
-    '-g, --gid <uid>', 'Set the gid (posix only)'
-  );
-}
-
-app.parse(process.argv);
+var app = yargs.argv;
 
 var log = logger({
   level: app.verbose,
-  nocolor: !app.color
+  nocolor: app.color
 });
 
 update(log);

--- a/bin/citgm.js
+++ b/bin/citgm.js
@@ -4,75 +4,28 @@ var update = require('../lib/update');
 var citgm = require('../lib/citgm');
 var logger = require('../lib/out');
 var reporter = require('../lib/reporter');
-var app = require('commander');
-
-var pkg = require('../package.json');
+var commonArgs = require('../lib/common-args');
+var yargs = require('yargs');
 
 var mod;
 var script;
 
-app
-  .version(pkg.version)
-  .arguments('<module> [script]')
-  .action(function(m, s) {
-    mod = m;
-    script = s;
-  })
-  .option(
-    '-v, --verbose [level]',
-    'Verbose output (silly, verbose, info, warn, error)',
-    /^(silly|verbose|info|warn|error)$/i, 'info')
-  .option(
-    '-q, --npm-loglevel [level]',
-    'Verbose output (silent, error, warn, http, info, verbose, silly)',
-    /^(silent|error|warn|http|info|verbose|silly)$/i, 'error')
-  .option(
-    '-l, --lookup <path>',
-    'Use the lookup table provided at <path>'
-  )
-  .option(
-    '-d, --nodedir <path>',
-    'Path to the node source to use when compiling native addons'
-  )
-  .option(
-    '-p, --test-path <path>', 'Path to prepend to $PATH when running tests'
-  )
-  .option(
-    '-n, --no-color', 'Turns off colorized output'
-  )
-  .option(
-    '-s, --su', 'Allow running the tool as root.'
-  )
-  .option(
-    '-m, --markdown', 'Output results in markdown'
-  )
-  .option(
-    '-t, --tap [path]', 'Output results in tap with optional file path'
-  )
-  .option(
-    '-x, --junit [path]', 'Output results in junit xml with optional file path'
-  )
-  .option(
-    '-o, --timeout <length>', 'Set timeout for npm install', 1000 * 60 * 10
-  )
-  .option(
-    '-c, --sha <commit-sha>', 'Install module from commit-sha'
-  );
+yargs = commonArgs(yargs)
+  .usage('citgm [options] <module> [script]')
+  .option('sha', {
+    alias: 'c',
+    type: 'string',
+    description: 'Install module from commit-sha'
+  });
 
-if (!citgm.windows) {
-  app.option(
-    '-u, --uid <uid>', 'Set the uid (posix only)'
-  )
-  .option(
-    '-g, --gid <uid>', 'Set the gid (posix only)'
-  );
-}
+var app = yargs.argv;
 
-app.parse(process.argv);
+mod = app._[0];
+script = app._[1];
 
 var log = logger({
   level:app.verbose,
-  nocolor: !app.color
+  nocolor: app.noColor
 });
 
 update(log);
@@ -85,7 +38,7 @@ if (!app.su) {
 }
 
 if (!mod) {
-  app.outputHelp();
+  yargs.showHelp();
   process.exit(0);
 }
 

--- a/lib/common-args.js
+++ b/lib/common-args.js
@@ -1,0 +1,85 @@
+'use strict';
+var citgm = require('./citgm');
+var pkg = require('../package.json');
+
+module.exports = function commonArgs (app) {
+  app = app
+  .version(pkg.version)
+  .help()
+  .alias('help', 'h')
+  .config()
+  .env('CITGM')
+  .option('verbose', {
+    alias: 'v',
+    choices: ['silly', 'verbose', 'info', 'warn', 'error'],
+    default: 'info',
+    description: 'Verbose output'
+  })
+  .option('npm-loglevel', {
+    alias: 'q',
+    choices: ['silly', 'verbose', 'info', 'warn', 'error', 'http', 'silent'],
+    default: 'error',
+    description: 'Verbose output for npm'
+  })
+  .option('lookup', {
+    alias: 'l',
+    type: 'string',
+    description: 'Use the lookup table provided at <path>'
+  })
+  .option('nodedir', {
+    alias: 'd',
+    type: 'string',
+    description: 'Path to the node source to use when compiling native addons'
+  })
+  .option('test-path', {
+    alias: 'p',
+    type: 'string',
+    description: 'Path to prepend to $PATH when running tests'
+  })
+  .option('no-color', {
+    alias: 'n',
+    type: 'boolean',
+    description: 'Turns off colorized output'
+  })
+  .option('su', {
+    alias: 's',
+    type: 'boolean',
+    description: 'Allow running the tool as root.'
+  })
+  .option('markdown', {
+    alias: 'm',
+    type: 'boolean',
+    description: 'Output results in markdown'
+  })
+  .option('tap', {
+    alias: 't',
+    type: 'string',
+    description: 'Output results in tap with optional file path'
+  })
+  .option('junit', {
+    alias: 'x',
+    type: 'string',
+    description: 'Output results in junit xml with optional file path'
+  })
+  .option('timeout', {
+    alias: 'o',
+    type: 'number',
+    description: 'Set timeout for npm install',
+    default: 1000 * 60 * 10
+  });
+
+  if (!citgm.windows) {
+    app = app.option('uid', {
+      alias: 'u',
+      type: 'number',
+      description: 'Set the uid (posix only)'
+    })
+    .option('gid', {
+      alias: 'g',
+      type: 'number',
+      description: 'Set the gid (posix only)'
+    });
+  }
+
+  return app;
+};

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "async": "^1.4.0",
     "chalk": "^1.1.3",
     "columnify": "^1.5.1",
-    "commander": "^2.8.1",
     "dotenv": "^2.0.0",
     "lodash": "^4.12.0",
     "mkdirp": "^0.5.1",
@@ -55,7 +54,8 @@
     "which": "^1.2.8",
     "winston": "^2.2.0",
     "xml-sanitizer": "^1.1.2",
-    "xmlbuilder": "^8.2.2"
+    "xmlbuilder": "^8.2.2",
+    "yargs": "^5.0.0"
   },
   "devDependencies": {
     "eslint": "^2.10.2",


### PR DESCRIPTION
Also cordon off common CLI options into lib/common-args.js to keep
it DRY. This also enables config files and environment variables
as config.

Fixes: #181

Currently this results in two tests failing regarding signal handling, so I'll have to figure that out before removing the `[WIP]`.