### PR TITLE
[wip] npm: log process.versions

### DIFF
--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -15,6 +15,7 @@ var grabProject = require('./grab-project');
 var unpack = require('./unpack');
 var tempDirectory = require('./temp-directory');
 var grabModuleData = require('./grab-module-data');
+var grabNodeVersionData = require('./grab-node-version-data');
 var npm = require('./npm');
 
 var windows = (process.platform === 'win32');
@@ -102,6 +103,7 @@ Tester.prototype.run = function() {
     init.bind(null, self),
     find.bind(null, 'node'),
     find.bind(null, 'npm'),
+    grabNodeVersionData,
     tempDirectory.create,
     grabModuleData,
     lookup,

--- a/lib/grab-node-version-data.js
+++ b/lib/grab-node-version-data.js
@@ -1,0 +1,83 @@
+'use strict';
+// npm modules
+var which = require('which').sync;
+
+// node modules
+var path = require('path');
+
+// local modules
+var spawn = require('./spawn');
+
+var cache = {};
+function grabOneNodeVersionData (context, nodeBin, cb) {
+  if (cache[nodeBin]) {
+    return cb(null, cache[nodeBin]);
+  }
+  var proc = spawn(nodeBin, [
+    '-p',
+    'process.versions.execPath = process.execPath; JSON.stringify(process.versions)'
+  ]);
+  var chunks = [];
+  proc.stdout.on('data', function (chunk) {
+    chunks.push(chunk.toString());
+  });
+  proc.stdout.on('error', cb);
+  proc.stdout.on('close', function () {
+    cache[nodeBin] = JSON.parse(chunks.join(''));
+    cb(null, cache[nodeBin]);
+  });
+}
+
+function log(context, step, data) {
+  context.emit(
+    'data',
+    'verbose',
+    'npm-' + step + '-versions',
+    JSON.stringify(data, null, 4)
+  );
+}
+
+function grabNodeVersionData (context, cb) {
+  // get the test node
+  var testNodeBin = 'node';
+  if (context.options.testpath) {
+    var testPath = context.options.testpath + ':' + process.env.PATH;
+    testNodeBin = which('node', {path: testPath});
+  }
+  context.testNodeBin = testNodeBin;
+
+  // Short circuit if we're not at the right loglevel. We could cache the
+  // installNodeBin onto the context like we do with testNodeBin, but it's
+  // passed into npm install as nodedir, so we don't really gain anything by
+  // joining it with 'node' here ahead of time.
+  if (context.options.level !== 'verbose' && context.options.level !== 'silly') {
+    return cb(null, context);
+  }
+
+  // get the install node
+  var installNodeBin = 'node';
+  if (context.options.nodedir) {
+    installNodeBin = path.join(
+      path.resolve(process.cwd(), context.options.nodedir), 'node'
+    );
+  }
+
+  grabOneNodeVersionData(context, installNodeBin, function (err, data) {
+    if (err) {
+      return cb(err);
+    }
+    context.npmInstallVersions = data;
+    log(context, 'install', data);
+    grabOneNodeVersionData(context, testNodeBin, function (err, data) {
+      if (err) {
+        return cb(err);
+      }
+      context.npmTestVersions = data;
+      log(context, 'test', data);
+      cb(null, context);
+    });
+  });
+}
+
+module.exports = grabNodeVersionData;
+

--- a/lib/npm/test.js
+++ b/lib/npm/test.js
@@ -59,16 +59,14 @@ function test(context, next) {
     }
 
     var options = createOptions(wd, context);
-    var nodeBin = 'node';
     if (context.options.testPath) {
       options.env.PATH = context.options.testPath + ':' + process.env.PATH;
-      nodeBin = which('node', {path: options.env.PATH || process.env.PATH});
     }
     var npmBin = which('npm',  {path: options.env.PATH || process.env.PATH});
     if (windows) {
       npmBin = path.join(path.dirname(npmBin), 'node_modules', 'npm', 'bin', 'npm-cli.js');
     }
-    var proc = spawn(nodeBin, [npmBin, 'test', '--loglevel=' + context.options.npmLevel], options);
+    var proc = spawn(context.testNodeBin, [npmBin, 'test', '--loglevel=' + context.options.npmLevel], options);
     proc.stdout.on('data', function (data) {
       if (context.module.stripAnsi) {
         data = stripAnsi(data.toString());

--- a/test/npm/test-npm-test.js
+++ b/test/npm/test-npm-test.js
@@ -46,6 +46,7 @@ test('npm-test: setup', function (t) {
 test('npm-test: basic module passing', function (t) {
   var context = {
     emit: function() {},
+    testNodeBin: 'node',
     path: sandbox,
     module: {
       name: 'omg-i-pass'
@@ -64,6 +65,7 @@ test('npm-test: basic module passing', function (t) {
 test('npm-test: basic module failing', function (t) {
   var context = {
     emit: function() {},
+    testNodeBin: 'node',
     path: sandbox,
     module: {
       name: 'omg-i-fail'
@@ -80,6 +82,7 @@ test('npm-test: basic module failing', function (t) {
 test('npm-test: basic module no test script', function (t) {
   var context = {
     emit: function() {},
+    testNodeBin: 'node',
     path: sandbox,
     module: {
       name: 'omg-i-do-not-support-testing'
@@ -96,6 +99,7 @@ test('npm-test: basic module no test script', function (t) {
 test('npm-test: no package.json', function (t) {
   var context = {
     emit: function() {},
+    testNodeBin: 'node',
     path: sandbox,
     module: {
       name: 'omg-i-dont-exist'
@@ -112,6 +116,7 @@ test('npm-test: no package.json', function (t) {
 test('npm-test: custom script', function (t) {
   var context = {
     emit: function() {},
+    testNodeBin: 'node',
     path: sandbox,
     module: {
       name: 'omg-i-pass'
@@ -131,6 +136,7 @@ test('npm-test: custom script', function (t) {
 test('npm-test: custom script does not exist', function (t) {
   var context = {
     emit: function() {},
+    testNodeBin: 'node',
     path: sandbox,
     module: {
       name: 'omg-i-pass'
@@ -151,6 +157,7 @@ test('npm-test: alternative test-path', function (t) {
   // Same test as 'basic module passing', except with alt node bin which fails.
   var context = {
     emit: function() {},
+    testNodeBin: 'node',
     path: sandbox,
     module: {
       name: 'omg-i-pass'

--- a/test/test-grab-node-version-data.js
+++ b/test/test-grab-node-version-data.js
@@ -1,0 +1,93 @@
+'use strict';
+
+var rewire = require('rewire');
+var EE = require('events');
+var test = require('tap').test;
+
+var grabNode = rewire('../lib/grab-node-version-data');
+
+test('grab-node-version-data: setup', function (t) {
+  grabNode.__set__('spawn', function (bin, args) {
+    var stdout = new EE;
+    process.nextTick(function () {
+      stdout.emit('data', JSON.stringify({
+        argsWere: [bin, args]
+      }));
+      stdout.emit('close');
+    });
+    return {stdout: stdout};
+  });
+  t.end();
+});
+
+test('grab-node-version-data: lower loglevel', function (t) {
+  var emitted = [];
+  var context = {
+    emit: function () {
+      emitted.push(Array.prototype.slice.call(arguments));
+    },
+    options: {
+      level: 'info'
+    }
+  };
+  var expectedEmitted = [];
+  grabNode(context, function (err) {
+    t.error(err);
+    t.equals(emitted.length, 0, 'There should be zero log messages');
+    t.same(emitted, expectedEmitted, 'The correct output was generated');
+    t.end();
+  });
+
+});
+
+test('grab-node-version-data: verbose', function (t) {
+  var emitted = [];
+  var context = {
+    emit: function () {
+      emitted.push(Array.prototype.slice.call(arguments));
+    },
+    options: {
+      level: 'verbose'
+    }
+  };
+  var expectedEmitted = [
+    ['data', 'verbose', 'npm-install-versions', JSON.stringify({
+      argsWere: ['node', ['-p', 'process.versions.execPath = process.execPath; JSON.stringify(process.versions)']]
+    }, null, 4)],
+    ['data', 'verbose', 'npm-test-versions', JSON.stringify({
+      argsWere: ['node', ['-p', 'process.versions.execPath = process.execPath; JSON.stringify(process.versions)']]
+    }, null, 4)]
+  ];
+  grabNode(context, function (err) {
+    t.error(err);
+    t.equals(emitted.length, 2, 'There should be two log messages');
+    t.same(emitted, expectedEmitted, 'The correct output was generated');
+    t.end();
+  });
+});
+
+test('grab-node-version-data: silly', function (t) {
+  var emitted = [];
+  var context = {
+    emit: function () {
+      emitted.push(Array.prototype.slice.call(arguments));
+    },
+    options: {
+      level: 'silly'
+    }
+  };
+  var expectedEmitted = [
+    ['data', 'verbose', 'npm-install-versions', JSON.stringify({
+      argsWere: ['node', ['-p', 'process.versions.execPath = process.execPath; JSON.stringify(process.versions)']]
+    }, null, 4)],
+    ['data', 'verbose', 'npm-test-versions',JSON.stringify({
+      argsWere: ['node', ['-p', 'process.versions.execPath = process.execPath; JSON.stringify(process.versions)']]
+    }, null, 4)]
+  ];
+  grabNode(context, function (err) {
+    t.error(err);
+    t.equals(emitted.length, 2, 'There should be two log messages');
+    t.same(emitted, expectedEmitted, 'The correct output was generated');
+    t.end();
+  });
+});


### PR DESCRIPTION
Adds verbose-mode logging of process.versions prior to npm install
and npm test. Versions are cached so that they're only checked
once per citgm run.

Also outputs process.execPath

Ref: https://github.com/nodejs/citgm/issues/164
