### PR TITLE
logging: remove ellipsis wrapping

### DIFF
--- a/lib/out.js
+++ b/lib/out.js
@@ -22,7 +22,7 @@ function output(tag, message, dest) {
       showHeaders: false,
       maxLineWidth: 'auto',
       minWidth: 20,
-      maxWidth: 50,
+      maxWidth: Infinity,
       columnSplitter: '| ',
       preserveNewLines: true
     }


### PR DESCRIPTION
The ellipsis-wrapping at 50 chars makes it hard to read, hard to copy & paste URLs, etc., so removing that so the lines don't wrap.