### PR TITLE
Use latest dist-tag for node-sass

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -300,7 +300,6 @@
   },
   "node-sass": {
     "replace": true,
-    "master": true,
     "flaky": "ppc"
   }
 }


### PR DESCRIPTION
As of node-sass@3.10.1 `npm test` can now be run from the published
tarball.

The node-sass failure seen in #187 are due to using master. In order to
compile node-sass from git the `src/libsass` submodule needs to be fetched.
The missing submodule is causing node-gyp to fail because it can't find the
LibSass sources files.

```sh
make: *** No rule to make target 'Release/obj.target/libsass/src/libsass/src/ast.o', needed by 'Release/obj.target/src/sass.a'.  Stop.
```

The LibSass source is published to npm so node-gyp will _just work_.