### PR TITLE
reporter: sanitize carriage returns

### DIFF
--- a/lib/reporter/util.js
+++ b/lib/reporter/util.js
@@ -28,7 +28,7 @@ function hasFailures(modules) {
 
 function sanitizeOutput(output, delimiter, xml) {
   if (!output || output === '') return '';
-  return _(output.split('\n')).filter(function (item) {
+  return _(output.split(/[\r\n]+/)).filter(function (item) {
     return item.length && item !== '\n' && item !== 'undefined';
   }).map(function (item) {
     if (xml) item = xmlSanitizer(item);

--- a/test/fixtures/CR-raw.txt
+++ b/test/fixtures/CR-raw.txt
@@ -1,0 +1,6 @@
+  Route
+    ✓ should work without handlers
+    .all
+      ✓ should add handler
+      ✓ should handle VERBS
+      ✓ should stack

--- a/test/fixtures/CR-sanitized.txt
+++ b/test/fixtures/CR-sanitized.txt
@@ -1,0 +1,6 @@
+#   Route
+#     ✓ should work without handlers
+#     .all
+#       ✓ should add handler
+#       ✓ should handle VERBS
+#       ✓ should stack

--- a/test/reporter/test-reporter-util.js
+++ b/test/reporter/test-reporter-util.js
@@ -1,8 +1,15 @@
 'use strict';
+var fs = require('fs');
+var path = require('path');
+
 var test = require('tap').test;
 
 var util = require('../../lib/reporter/util');
 var fixtures = require('../fixtures/reporter-fixtures');
+
+var fixturesPath = path.join(__dirname, '..', 'fixtures');
+var carriageReturnPath = path.join(fixturesPath, 'CR-raw.txt');
+var carriageReturnExpectedPath = path.join(fixturesPath, 'CR-sanitized.txt');
 
 var noPassing = [
   fixtures.iFail,
@@ -64,5 +71,14 @@ test('hasFailures:', function (t) {
   t.ok(util.hasFailures(somePassing), 'there should be failures in the somePassing list');
   t.notok(util.hasFailures(allPassing), 'there should be no failures in the allPassing list');
   t.notok(util.hasFailures(flakeCityUsa), 'there should be no failures in the flakeCityUsa list');
+  t.end();
+});
+
+test('util.sanitizeOutput', function (t) {
+  // var result = util.sanitizeOutput();
+  var raw = fs.readFileSync(carriageReturnPath, 'utf-8');
+  var expected = fs.readFileSync(carriageReturnExpectedPath, 'utf-8');
+  var result = util.sanitizeOutput(raw, '#');
+  t.equals(result, expected, 'there should be a # on every line');
   t.end();
 });


### PR DESCRIPTION
Currently we are not sanitizing carriage returns which can break
tap output. This change adds a regular expression to the reporters
sanitizer to replace all carriage returns with new lines.

Fixes: https://github.com/nodejs/citgm/issues/189