### PR TITLE
npm: fix starting tests on Windows

### DIFF
--- a/lib/npm/test.js
+++ b/lib/npm/test.js
@@ -66,7 +66,7 @@ function test(context, next) {
     }
     var npmBin = which('npm',  {path: options.env.PATH || process.env.PATH});
     if (windows) {
-      npmBin = path.join(path.dirname(npmBin), 'node_modules\\npm\\bin\\npm-cli.js');
+      npmBin = path.join(path.dirname(npmBin), 'node_modules', 'npm', 'bin', 'npm-cli.js');
     }
     var proc = spawn(nodeBin, [npmBin, 'test', '--loglevel=' + context.options.npmLevel], options);
     proc.stdout.on('data', function (data) {

--- a/lib/npm/test.js
+++ b/lib/npm/test.js
@@ -65,6 +65,9 @@ function test(context, next) {
       nodeBin = which('node', {path: options.env.PATH || process.env.PATH});
     }
     var npmBin = which('npm',  {path: options.env.PATH || process.env.PATH});
+    if (windows) {
+      npmBin = path.join(path.dirname(npmBin), 'node_modules\\npm\\bin\\npm-cli.js');
+    }
     var proc = spawn(nodeBin, [npmBin, 'test', '--loglevel=' + context.options.npmLevel], options);
     proc.stdout.on('data', function (data) {
       if (context.module.stripAnsi) {


### PR DESCRIPTION
https://github.com/nodejs/citgm/commit/67ae086fd744426d376c45f83d6835d8a2243c34 changed how `npm` was started, to allow `--test-path` parameter. After that change CITGM explicit starts node with location of the `npm-cli.js`. Location of that file is obtained by calling `which npm`. Under Linux this will return location of `npm-cli.js`.  Under Windows it will return location of `npm.cmd` - shell script that starts node with `npm-cli.js`

This adds logic that finds `npm-cli.js` location based on `npm.cmd` directory.

Fixes: https://github.com/nodejs/citgm/issues/170