### PR TITLE
npm: escape backslashes in nodedir on Windows

### DIFF
--- a/lib/npm/install.js
+++ b/lib/npm/install.js
@@ -18,6 +18,9 @@ function install(context, next) {
   if (context.options.nodedir) {
     var nodedir = path.resolve(process.cwd(), context.options.nodedir);
     options.env.npm_config_nodedir = nodedir;
+    if (process.platform === 'win32') {
+      nodedir = nodedir.replace(/\\/g, '\\\\');
+    }
     args.push('--nodedir="' + nodedir + '"');
     context.emit('data', 'verbose','nodedir', 'Using --nodedir="' + nodedir + '"');
   }


### PR DESCRIPTION
Currently `--nodedir` does not work under Windows. `npm` requires that provided `nodedir` is a valid JSON value, otherwise it fails at [`JSON.parse`](https://github.com/npm/npm/blob/master/lib/config/core.js#L377).

This escapes backslashes in provided `nodedir` path.