### PR TITLE
mark underscore as flaky on aix

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -5,7 +5,8 @@
   },
   "underscore": {
     "replace": true,
-    "master": true
+    "master": true,
+    "flaky": "aix"
   },
   "request": {
     "replace": true,


### PR DESCRIPTION
This test is failing on AIX61 but not AIX7, I will work on getting isflaky to differentiate between these two distributions but for now lets just mark it flaky on AIX 