### PR TITLE
FLAKY: add compatibility for aix version, mac os version, and z-linux versions

### DIFF
--- a/lib/is-flaky.js
+++ b/lib/is-flaky.js
@@ -1,16 +1,31 @@
 'use strict';
 
+var fs = require('fs');
+var execSync = require('child_process').execSync;
 var _ = require('lodash');
-var lsb = require('dotenv').config({path: '/etc/lsb-release', silent: true});
 
-var distro = lsb['DISTRIB_ID'] || '';
-var release = lsb['DISTRIB_RELEASE'] || '';
 var version = process.version;
-var platform = [process.platform, process.arch].join('-');
+var platform = process.platform;
+var arch = process.arch;
+var distro = '';
+var release = '';
+
+if (fs.existsSync('/etc/os-release')) {
+  var osRelease = require('dotenv').config({path: '/etc/os-release', silent: true});
+  distro = osRelease['ID'] || '';
+  release = osRelease['VERSION_ID'] || '';
+} else if (platform === 'darwin') {
+  distro = 'macos';
+  release = execSync('sw_vers -productVersion').toString() || '';
+} else if (platform === 'aix' ) {
+  release = execSync('oslevel').toString() || '';
+  release = release.replace(/(\r\n|\n|\r)/gm,'') || '';
+}
+
 var endian = process.config.variables.node_byteorder || '';
 
 function isStringFlaky(flaky) {
-  var checks = [distro, release, version, platform, endian];
+  var checks = [distro, release, version, [platform, arch].join('-'), endian];
   return _.some(checks, function (check) {
     return check.search(flaky) !== -1;
   });

--- a/test/test-is-flaky.js
+++ b/test/test-is-flaky.js
@@ -24,7 +24,8 @@ var invalid = {
 
 function shim() {
   isFlaky.__set__('version', 'v5.3.1');
-  isFlaky.__set__('platform', 'darwin-x64');
+  isFlaky.__set__('platform', 'darwin');
+  isFlaky.__set__('arch', 'x64');
 }
 
 function revertShim() {
@@ -67,26 +68,26 @@ function testArrays(t, testFunction) {
     notFlake,
     invalid
   ]), 'not flaky array of objects');
-  
+
   t.ok(testFunction([
     'hurd',
     'x86',
     'v4',
     'darwin'
   ]), 'flakey array of string');
-  
+
   t.notok(testFunction([
     'hurd',
     'x86',
     'v4'
   ]), 'not flakey array of string');
-  
+
   t.notok(testFunction([
     true,
     false,
     123
   ]), 'not flaky invalid input');
-  
+
   revertShim();
 }
 


### PR DESCRIPTION
Now included in is-flaky.js:

**AIX VERSIONS**

- eg. aix 6.1.0.0

**MAC OS Versions**

- eg. darwin 10.12

- can also pass in macos now

**Z Linux Versions**

- eg. sles 12

- eg. ubuntu 14.04

**Pass in os-arch or os and arch separately**

- eg. win-x64:true

- eg win:true

