### PR TITLE
There is no fedora21 node anymore

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -218,7 +218,7 @@
     "flaky": {
       "s390": true,
       "darwin": true,
-      "v0.12": ["fedroa21", "fedora22", "ubuntu1204"]
+      "v0.12": ["fedora22", "ubuntu1204"]
     }
   },
   "bluebird": {


### PR DESCRIPTION
Also it was misspelled as `fedroa21`.