### PR TITLE
chore: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,11 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "async": "^1.4.0",
+    "async": "^2.1.2",
     "chalk": "^1.1.3",
     "columnify": "^1.5.1",
     "dotenv": "^2.0.0",
+    "eslint": "^2.13.1",
     "lodash": "^4.12.0",
     "mkdirp": "^0.5.1",
     "node-uuid": "^1.4.3",
@@ -50,19 +51,19 @@
     "supports-color": "^3.1.0",
     "tar": "^2.1.1",
     "uid-number": "0.0.6",
-    "update-notifier": "^0.7.0",
+    "update-notifier": "^1.0.2",
     "which": "^1.2.8",
     "winston": "^2.2.0",
     "xml-sanitizer": "^1.1.2",
     "xmlbuilder": "^8.2.2",
-    "yargs": "^5.0.0"
+    "yargs": "^6.3.0"
   },
   "devDependencies": {
-    "eslint": "^2.10.2",
+    "eslint": "^3.9.1",
     "ncp": "^2.0.0",
-    "nyc": "^6.4.4",
+    "nyc": "^8.4.0",
     "opener": "^1.4.1",
     "rewire": "^2.4.0",
-    "tap": "^5.7.0"
+    "tap": "^8.0.0"
   }
 }


### PR DESCRIPTION
updates include:

* async
* update-notifier
* yargs
* eslint (updated to latest v2 as v3 does not support 0.12)
* nyc
* tap