### PR TITLE
[WIP] citgm-stress: add a citgm stress test

### DIFF
--- a/bin/citgm-stress.js
+++ b/bin/citgm-stress.js
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+'use strict';
+var update = require('../lib/update');
+var citgm = require('../lib/citgm');
+var logger = require('../lib/out');
+var reporter = require('../lib/reporter');
+var commonArgs = require('../lib/common-args');
+var yargs = require('yargs');
+
+var mod;
+var script;
+
+yargs = commonArgs(yargs)
+  .usage('citgm [options] <module> [script]')
+  .option('sha', {
+    alias: 'c',
+    type: 'string',
+    description: 'Install module from commit-sha'
+  })
+  .option('repeat', {
+    alias: 'r',
+    type: 'string',
+    description: 'set how many times to run the testsuite'
+  });
+
+var app = yargs.argv;
+
+mod = app._[0];
+script = app._[1];
+
+var log = logger({
+  level:app.verbose,
+  nocolor: app.noColor
+});
+
+update(log);
+
+if (!app.su) {
+  require('root-check')(); // silently downgrade if running as root...
+                           // unless --su is passed
+} else {
+  log.warn('root', 'Running as root! Use caution!');
+}
+
+if (!mod) {
+  yargs.showHelp();
+  process.exit(0);
+}
+
+var options = {
+  script: script,
+  lookup: app.lookup,
+  nodedir: app.nodedir,
+  testPath: app.testPath,
+  level: app.verbose,
+  npmLevel: app.npmLoglevel,
+  timeoutLength: app.timeout,
+  sha: app.sha,
+  repeat: app.repeat
+};
+
+if (!citgm.windows) {
+  var uidnumber = require('uid-number');
+  var uid = app.uid || process.getuid();
+  var gid = app.gid || process.getgid();
+  uidnumber(uid, gid, function(err, uid, gid) {
+    options.uid = uid;
+    options.gid = gid;
+    launch(mod, options);
+  });
+} else {
+  launch(mod, options);
+}
+
+function launch(mod, options) {
+  var runner = citgm.Tester(mod, options);
+
+  function cleanup() {
+    runner.cleanup();
+  }
+
+  process.on('SIGINT', cleanup);
+  process.on('SIGHUP', cleanup);
+  process.on('SIGBREAK', cleanup);
+
+  runner.on('start', function(name) {
+    log.info('starting', name);
+  }).on('fail', function(err) {
+    log.error('failure', err.message);
+  }).on('data', function(type, key, message) {
+    log[type](key, message);
+  }).on('end', function(module) {
+    reporter.logger(log, module);
+
+    if (app.markdown) {
+      reporter.markdown(log.bypass, module);
+    }
+
+    if (typeof app.tap === 'string') {
+      var tap = (app.tap) ? app.tap : log.bypass;
+      reporter.tap(tap, module, true);
+    }
+
+    if (typeof app.junit === 'string') {
+      var junit = (app.junit) ? app.junit : log.bypass;
+      reporter.junit(junit, module, true);
+    }
+
+    process.removeListener('SIGINT', cleanup);
+    process.removeListener('SIGHUP', cleanup);
+    process.removeListener('SIGBREAK', cleanup);
+    process.exit(module.error ? 1 : 0);
+  }).run();
+}

--- a/lib/npm/test.js
+++ b/lib/npm/test.js
@@ -3,6 +3,7 @@
 // node modules
 var path = require('path');
 var fs = require('fs');
+var async = require('async');
 
 // npm modules
 var readPackage = require('read-package-json');
@@ -68,21 +69,34 @@ function test(context, next) {
     if (windows) {
       npmBin = path.join(path.dirname(npmBin), 'node_modules', 'npm', 'bin', 'npm-cli.js');
     }
+    var start = 0;
+    if (!context.options.repeat) {
+      context.options.repeat = 1;
+    }
     var proc = spawn(nodeBin, [npmBin, 'test', '--loglevel=' + context.options.npmLevel], options);
-    proc.stdout.on('data', function (data) {
-      if (context.module.stripAnsi) {
-        data = stripAnsi(data.toString());
-        data = data.replace(/\r/g, '\n');
-      }
-      context.testOutput += data;
-      context.emit('data', 'verbose', 'npm-test:', data.toString());
-    });
-    proc.stderr.on('data', function (data) {
-      context.testError += data;
-      context.emit('data', 'verbose', 'npm-test:', data.toString());
-    });
-    proc.on('error', function() {
-      next(new Error('Tests Failed'));
+    async.whilst(function () {
+      return start <= context.options.repeat;
+    },
+    function (runTest) {
+      proc.stdout.on('data', function (data) {
+        if (context.module.stripAnsi) {
+          data = stripAnsi(data.toString());
+          data = data.replace(/\r/g, '\n');
+        }
+        context.testOutput += data;
+        context.emit('data', 'verbose', 'npm-test:', data.toString());
+      });
+      proc.stderr.on('data', function (data) {
+        context.testError += data;
+        context.emit('data', 'verbose', 'npm-test:', data.toString());
+      });
+      proc.on('error', function() {
+        next(new Error('Tests Failed'));
+      });
+      start++;
+      runTest();
+    },
+    function (err) {
     });
     proc.on('close', function(code) {
       if (code > 0) {
@@ -92,6 +106,6 @@ function test(context, next) {
     });
 
   });
-}
 
+}
 module.exports = test;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "preferGlobal": true,
   "bin": {
     "citgm": "./bin/citgm.js",
-    "citgm-all": "./bin/citgm-all.js"
+    "citgm-all": "./bin/citgm-all.js",
+    "citgm-stress": "./bin/citgm-stress.js"
   },
   "scripts": {
     "test": "npm run lint && npm run tap",


### PR DESCRIPTION
ISSUE: https://github.com/nodejs/citgm/issues/122
The idea behind citgm stress is that we can repeat a single module test multiple times without having to repeat the entire npm install process.
You can run citgm-stress using `./bin/citgm-stress.js module -r n` where n is the number of repeats