### PR TITLE
citgm-all: get modules from github by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ citgm-all -l ./path/to/my_lookup.json
 For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
 
 ```
-"replace": true              Download module from github repo in package.json
+"npm": true                  Download the module from npm instead of github
 "master": true               Use the master branch
 "prefix": "v"                Specify the prefix used in the module version.
 "flaky": true                Ignore failures

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -76,7 +76,10 @@ function resolve(context, next) {
       if (rep.stripAnsi) {
         context.module.stripAnsi = rep.stripAnsi;
       }
-      if (rep.replace) {
+      if (typeof rep.replace === 'boolean' && !rep.replace) {
+        rep.npm = true;
+      }
+      if (!rep.npm){
         if (!rep.repo && !meta.repository) {
           next(new Error('no-repository-field in package.json'));
           return;

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -1,356 +1,276 @@
 {
   "lodash": {
-    "replace": true
   },
   "underscore": {
-    "replace": true,
     "master": true,
     "flaky": "aix"
   },
   "request": {
-    "replace": true,
     "prefix": "v",
     "flaky": true
   },
   "commander": {
-    "replace": true,
     "prefix": "v",
     "repo": "https://github.com/tj/commander.js"
   },
   "express": {
-    "replace": true,
     "flaky": {
       "ppc": ["v5"]
     }
   },
   "q": {
-    "replace": true,
     "prefix": "v"
   },
   "coffee-script": {
-    "replace": true
   },
   "through2": {
-    "replace": true,
     "prefix": "v",
     "stripAnsi": true
   },
   "glob": {
-    "replace": true,
     "prefix": "v",
     "flaky": ["v6", "v7"]
   },
   "gulp-util": {
-    "replace": true,
     "prefix": "v"
   },
   "pug": {
-    "replace": true,
     "flaky": {
       "ppc": ["v6", "v7"]
     }
   },
   "socket.io": {
-    "replace": true,
     "flaky": true
   },
   "fs-extra": {
-    "replace": true,
     "flaky": ["linux-ia32", "aix", "s390"]
   },
   "body-parser": {
-    "replace": true
   },
   "uglify-js": {
-    "replace": true,
     "prefix": "v",
     "flaky": ["darwin", "aix"]
   },
   "jquery": {
-    "replace": true
   },
   "rimraf": {
-    "replace": true,
     "prefix": "v"
   },
   "david": {
-    "replace": true,
     "prefix": "v",
     "flaky": true
   },
   "eslint": {
-    "replace": true,
     "prefix": "v",
     "flaky": ["ppc", "v7", "s390"],
     "skip": "v8"
   },
   "tape": {
-    "replace": true,
     "prefix": "v",
     "flaky": "linux"
   },
   "browserify": {
-    "replace": true,
     "flaky": ["v7"]
   },
   "watchify": {
-    "replace": true,
     "prefix": "v",
     "flaky": ["ppc", "v7", "s390"]
   },
   "stylus": {
-    "replace": true
   },
   "level": {
-    "replace": true,
     "prefix": "v",
     "flaky": ["aix", "s390"]
   },
   "torrent-stream": {
-    "replace": true,
     "prefix": "v",
     "flaky": true
   },
   "react": {
-    "replace": true,
     "prefix": "v",
     "flaky": ["v0.10", "v0.12", "v6", "v7"],
     "skip": true
   },
   "gulp": {
-    "replace": true,
     "prefix": "v",
     "flaky": {
       "ppc": ["v5", "v6"]
     }
   },
   "moment": {
-    "replace": true,
     "flaky": true
   },
   "ws": {
-    "replace": true,
     "flaky": "s390"
   },
   "vinyl": {
-    "replace": true,
     "prefix": "v"
   },
   "vinyl-fs": {
-    "replace": true,
     "prefix": "v",
     "flaky": true,
     "master": true
   },
   "readable-stream": {
-    "replace": true,
     "prefix": "v",
     "flaky": ["ppc", "darwin"]
   },
   "ftp": {
-    "replace": true,
     "prefix": "v"
   },
   "split2": {
-    "replace": true,
     "prefix": "v"
   },
   "throughv": {
-    "replace": true,
     "prefix": "v",
     "stripAnsi": true
   },
   "duplexer2": {
-    "replace": true,
     "prefix": "v"
   },
   "bl": {
-    "replace": true,
     "prefix": "v",
     "stripAnsi": true
   },
   "binary-split": {
-    "replace": true,
     "prefix": "v"
   },
   "spdy": {
-    "replace": true,
     "prefix": "v",
     "flaky": "aix"
   },
   "dicer": {
-    "replace": true,
     "prefix": "v"
   },
   "spdy-transport": {
-    "replace": true,
     "prefix": "v"
   },
   "sax": {
-    "replace": true,
     "prefix": "v"
   },
   "duplexify": {
-    "replace": true,
     "prefix": "v"
   },
   "pumpify": {
-    "replace": true,
     "prefix": "v"
   },
   "from2": {
-    "replace": true,
     "prefix": "v"
   },
   "flush-write-stream": {
-    "replace": true,
     "prefix": "v"
   },
   "jsonstream": {
-    "replace": true,
     "prefix": "v"
   },
   "csv-parser": {
-    "replace": true,
     "prefix": "v"
   },
   "async": {
-    "replace": true,
     "prefix": "v",
     "flaky": true
   },
   "bluebird": {
-    "replace": true,
     "prefix": "v"
   },
   "mkdirp": {
-    "replace": true,
     "master": true,
     "flaky": ["v6", "v7"],
     "skip": ["v8"]
   },
   "yeoman-generator": {
-    "replace": true,
     "prefix": "v",
     "flaky": "ppc"
   },
   "minimist": {
-    "replace": true
   },
   "cheerio": {
-    "replace": true
   },
   "uuid": {
-    "replace": true,
     "prefix": "v"
   },
   "winston": {
-    "replace": true
   },
   "yargs": {
-    "replace": true,
     "prefix": "v",
     "flaky": "aix"
   },
   "semver": {
-    "replace": true,
     "prefix": "v"
   },
   "mime": {
-    "replace": true,
     "prefix": "v",
     "flaky": true
   },
   "serialport": {
-    "replace": true,
     "flaky": "ppc"
   },
   "isarray": {
-    "replace": true,
     "prefix": "v"
   },
   "inherits": {
-    "replace": true,
     "prefix": "v"
   },
   "graceful-fs": {
-    "replace": true,
     "prefix": "v"
   },
   "leveldown": {
-    "replace": true,
     "prefix": "v",
     "flaky": ["aix", "s390"]
   },
   "bcrypt": {
-    "replace": true,
     "prefix": "v"
   },
   "ref": {
-    "replace": true,
     "flaky": "aix"
   },
   "time": {
-    "replace": true,
     "flaky": ["linux-ia32", "aix", "s390"]
   },
   "bson": {
-    "replace": true,
     "prefix": "V"
   },
   "ember-cli": {
-    "replace": true,
     "prefix": "v"
   },
   "node-sass": {
-    "replace": true,
     "prefix": "v",
     "flaky": ["ppc", "v7", "s390"],
     "skip": true
   },
   "full-icu-test": {
-    "replace": true,
     "prefix": "v"
   },
   "sqlite3": {
-    "replace": true,
     "prefix": "v",
     "flaky": "aix"
   },
   "iconv": {
-    "replace": true,
     "prefix": "v",
     "flaky": "aix"
   },
   "electron-prebuilt": {
-    "replace": true,
     "prefix": "v",
     "flaky": ["ppc", "aix", "s390"]
   },
   "libxmljs": {
-    "replace": true,
     "prefix": "v",
     "flaky": "aix"
   },
   "radium": {
-    "replace": true,
     "prefix": "v",
     "flaky": ["ppc", "aix", "s390", "fedora"]
   },
   "ffi": {
-    "replace": true,
     "flaky": ["ppc", "aix", "s390"]
   },
   "microtime": {
-    "replace": true,
     "prefix": "v"
   },
   "koa": {
-    "replace": true,
     "skip": "<4"
   },
   "spawn-wrap": {
-    "replace": true,
     "prefix": "v"
   }
 }

--- a/test/bin/test-citgm-all.js
+++ b/test/bin/test-citgm-all.js
@@ -72,6 +72,17 @@ test('citgm-all: flaky-fail', function (t) {
   });
 });
 
+test('citgm-all: test with replace', function (t) {
+  t.plan(1);
+  var proc = spawn(citgmAllPath, ['-l', 'test/fixtures/custom-lookup-backwards-compatibilty.json']);
+  proc.on('error', function(err) {
+    t.error(err);
+  });
+  proc.on('close', function (code) {
+    t.equals(code, 0, 'citgm-all should exit with signal 0');
+  });
+});
+
 test('citgm-all: flaky-fail ignoring flakyness', function (t) {
   t.plan(1);
   var proc = spawn(citgmAllPath, ['-f', '-l', 'test/fixtures/custom-lookup-flaky.json']);

--- a/test/fixtures/custom-lookup-backwards-compatibilty.json
+++ b/test/fixtures/custom-lookup-backwards-compatibilty.json
@@ -1,10 +1,10 @@
 {
   "omg-i-pass": {
-    "npm": true
+    "replace": false
   },
   "omg-i-pass-too": {
+    "replace": true,
     "prefix": "v",
     "stripAnsi": true
-  },
-}
+  }
 }

--- a/test/fixtures/custom-lookup-envVar.json
+++ b/test/fixtures/custom-lookup-envVar.json
@@ -1,6 +1,6 @@
 {
   "omg-i-pass": {
-    "replace": false,
+    "npm": true,
     "envVar": {
       "testenvVar": "thisisatest"
     },

--- a/test/fixtures/custom-lookup-fail.json
+++ b/test/fixtures/custom-lookup-fail.json
@@ -1,9 +1,8 @@
 {
   "omg-i-fail": {
-    "replace": true,
     "flaky": true
   },
   "omg-i-fail": {
-    "replace": false
+    "npm": true
   }
 }

--- a/test/fixtures/custom-lookup-flaky.json
+++ b/test/fixtures/custom-lookup-flaky.json
@@ -1,6 +1,5 @@
 {
   "omg-i-fail": {
-    "replace": true,
     "prefix": "v",
     "flaky": true
   }

--- a/test/fixtures/custom-lookup-install.json
+++ b/test/fixtures/custom-lookup-install.json
@@ -1,5 +1,6 @@
 {
   "omg-i-pass-with-install-param": {
-    "install": ["--extra-param"]
+    "install": ["--extra-param"],
+    "npm": true
   }
 }

--- a/test/fixtures/custom-lookup-no-repo.json
+++ b/test/fixtures/custom-lookup-no-repo.json
@@ -1,5 +1,4 @@
 {
   "omg-i-pass": {
-    "replace": true
   }
 }

--- a/test/fixtures/custom-lookup-script.json
+++ b/test/fixtures/custom-lookup-script.json
@@ -1,14 +1,16 @@
 {
   "omg-i-pass": {
-    "replace": false,
+    "npm": true,
     "script": "./example-test-script-failing.sh"
   },
   "omg-i-have-script": {
+    "npm": true,
     "prefix": "v",
     "script": "./example-test-script-passing.sh",
     "stripAnsi": true
   },
   "omg-i-fail": {
+    "npm": true,
     "script": "./example-test-script-passing.sh"
   }
 }

--- a/test/fixtures/custom-lookup-skip.json
+++ b/test/fixtures/custom-lookup-skip.json
@@ -1,9 +1,9 @@
 {
   "omg-i-pass": {
-    "replace": false
+    "npm": true
   },
   "omg-i-fail": {
-    "replace": false,
+    "npm": true,
     "skip": true
   }
 }

--- a/test/fixtures/custom-lookup.json
+++ b/test/fixtures/custom-lookup.json
@@ -1,9 +1,8 @@
 {
   "omg-i-pass": {
-    "replace": false
+    "npm": true
   },
   "omg-i-pass-too": {
-    "replace": true,
     "prefix": "v",
     "stripAnsi": true
   }

--- a/test/fixtures/pretty-print.json
+++ b/test/fixtures/pretty-print.json
@@ -1,14 +1,11 @@
 {
   "chalk": {
-    "replace": true,
     "prefix": "v"
   },
   "colors": {
-    "replace": true,
     "prefix": "v"
   },
   "yosay": {
-    "replace": true,
     "prefix": "v"
   }
 }

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -49,7 +49,7 @@ test('lookup[getLookupTable]:', function (t) {
   }
   t.ok(table, 'table should exist');
   t.ok(table.lodash, 'lodash should be in the table');
-  t.ok(table.lodash.replace, 'lodash should need to be replaced');
+  t.ok(table.underscore.master, 'underscore should contain a master paramter');
 
   t.end();
 });
@@ -66,10 +66,9 @@ test('lookup[getLookupTable]: custom table', function (t) {
 
   t.deepEquals(table, {
     'omg-i-pass': {
-      replace: false
+      npm: true
     },
     'omg-i-pass-too': {
-      replace: true,
       prefix: 'v',
       stripAnsi: true
     }


### PR DESCRIPTION
Currently we pass `"replace": true` into our lookup.json file to get the tests from github instead of npm. At the moment all of our modules is lookup.json contain this tag so it makes no sense to make it an option. 

This PR changes makes replace redundant and adds `"npm": true` to NOT get the tests from github and instead get them from npm. This means that existing users with custom json files will still be able to get from npm or github