### PR TITLE
lookup: do not skip lodash

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -1,7 +1,6 @@
 {
   "lodash": {
-    "replace": true,
-    "skip": true
+    "replace": true
   },
   "underscore": {
     "replace": true,


### PR DESCRIPTION
lodash started being skipped a while ago, it was an oversight that it
has not been re added.

ci master: https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/444/
ci v7: https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/445/
ci v6: https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/446/
ci v4: https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/447/