### PR TITLE
add nodereport to lookup.json

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -308,5 +308,8 @@
   "spawn-wrap": {
     "prefix": "v",
     "flaky": ["win32", "sles"]
+  },
+  "node-report": {
+    "prefix": "v"
   }
 }


### PR DESCRIPTION
[nodereport](https://github.com/nodejs/nodereport) is a foundation module that we should be testing. It seems to be passing on our IBM machines so looks like it should be okay