### PR TITLE
citgm: add a timer to time each module test

### DIFF
--- a/bin/citgm-all.js
+++ b/bin/citgm-all.js
@@ -71,6 +71,7 @@ function runCitgm (mod, name, next) {
     return next();
   }
 
+  var start = new Date();
   var runner = citgm.Tester(name, options);
   var bailed = false;
 
@@ -90,6 +91,8 @@ function runCitgm (mod, name, next) {
   }).on('data', function(type,key,message) {
     log[type](key, message);
   }).on('end', function(result) {
+    result.duration = new Date() - start;
+    log.info('duration', 'test duration: ' + result.duration + 'ms');
     if (result.error) {
       log.error('done', 'The test suite for ' + result.name + ' version ' + result.version + ' failed');
     }

--- a/bin/citgm.js
+++ b/bin/citgm.js
@@ -66,6 +66,7 @@ if (!citgm.windows) {
   launch(mod, options);
 }
 
+var start = new Date();
 function launch(mod, options) {
   var runner = citgm.Tester(mod, options);
 
@@ -84,8 +85,10 @@ function launch(mod, options) {
   }).on('data', function(type, key, message) {
     log[type](key, message);
   }).on('end', function(module) {
+    module.duration = new Date() - start;
     reporter.logger(log, module);
 
+    log.info('duration', 'test duration: ' + module.duration + 'ms');
     if (app.markdown) {
       reporter.markdown(log.bypass, module);
     }

--- a/lib/reporter/junit.js
+++ b/lib/reporter/junit.js
@@ -11,6 +11,7 @@ function generateTest(xml, mod) {
   var output =util.sanitizeOutput(mod.testOutput, '', true);
   var item = xml.ele('testcase');
   item.att('name', [mod.name, 'v' + mod.version].join('-'));
+  item.att('time', mod.duration / 1000);
   item.ele('system-out').dat(output);
   if (mod.skip || (mod.flaky && mod.error)) {
     item.ele('skipped');

--- a/lib/reporter/markdown.js
+++ b/lib/reporter/markdown.js
@@ -8,7 +8,7 @@ function printModulesMarkdown(logger, title, modules) {
   if (modules.length > 0) {
     logger('### ' + title + ' Modules');
     _.each(modules, function (mod) {
-      logger('  * ' + mod.name + ' v' + mod.version);
+      logger('  * ' + mod.name + ' v' + mod.version + ' duration:' + mod.duration + 'ms');
       if (mod.error) {
         logger('    - ' + mod.error.message);
       }

--- a/lib/reporter/tap.js
+++ b/lib/reporter/tap.js
@@ -11,12 +11,10 @@ function generateTest(mod, count) {
   if (mod.error && mod.error.message) {
     mod.error = mod.error.message;
   }
-  var output = '';
   var error = mod.error ? [directive, mod.error].join(' ') : '';
-  if (mod.testOutput && mod.testOutput.length > 0) {
-    output = '\n  ---\n' + util.sanitizeOutput(mod.testOutput, '  #') + '\n  ...';
-  }
-  return [result, count + 1, '-', mod.name, 'v' + mod.version + error + output].join(' ');
+  var duration = '\n  duration_ms: ' + mod.duration;
+  var output = mod.testOutput ? '\n' + util.sanitizeOutput(mod.testOutput, '  #') : '';
+  return [result, count + 1, '-', mod.name, 'v' + mod.version + error + '\n  ---' + output + duration + '\n  ...'].join(' ');
 }
 
 function generateTap(modules) {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "rewire": "^2.4.0",
     "tap": "^8.0.0",
     "tap-parser": "^3.0.3",
-    "string-to-stream": "^1.1.0"
+    "string-to-stream": "^1.1.0",
+    "xml2js": "^0.4.17"
   }
 }

--- a/test/fixtures/parsed-junit.json
+++ b/test/fixtures/parsed-junit.json
@@ -1,0 +1,55 @@
+{
+  "testsuite": {
+    "$": {
+      "name": "citgm"
+    },
+    "testcase": [
+      {
+        "$": {
+          "name": "iPass-v4.2.2",
+          "time": "0.05"
+        },
+        "system-out": [
+          "\n      \n    "
+        ]
+      },
+      {
+        "$": {
+          "name": "iFlakyFail-v3.3.3",
+          "time": "0.05"
+        },
+        "system-out": [
+          "\n       Thanks for testing!\n    "
+        ],
+        "skipped": [
+          ""
+        ],
+        "failure": [
+          {
+            "_": "[object Object] ",
+            "$": {
+              "message": "module test suite failed"
+            }
+          }
+        ]
+      },
+      {
+        "$": {
+          "name": "iFail-v3.0.1",
+          "time": "0.05"                                          
+        },
+        "system-out": [
+          "\n       Thanks for testing!\n    "
+        ],
+        "failure": [
+          {
+            "_": "[object Object] ",
+            "$": {
+              "message": "module test suite failed"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/fixtures/parsed-tap.json
+++ b/test/fixtures/parsed-tap.json
@@ -4,7 +4,9 @@
   "fail": 1,
   "failures": [
     {
-      "diag": null,
+      "diag": {
+        "duration_ms": 50
+      },
       "id": 3,
       "name": "iFail v3.0.1 I dun wurk",
       "ok": false

--- a/test/fixtures/reporter-fixtures.json
+++ b/test/fixtures/reporter-fixtures.json
@@ -1,7 +1,8 @@
 {
   "iPass": {
     "name": "iPass",
-    "version": "4.2.2"
+    "version": "4.2.2",
+    "duration": 50
   },
   "iFail": {
     "name": "iFail",
@@ -9,13 +10,15 @@
     "error": {
       "message": "I dun wurk"
     },
-    "testOutput": "Thanks for testing!"
+    "testOutput": "Thanks for testing!",
+    "duration": 50
   },
   "iFlakyPass": {
     "name": "iFlakyPass",
     "version": "3.0.1",
     "flaky": true,
-    "testOutput": "Thanks for testing!"
+    "testOutput": "Thanks for testing!",
+    "duration": 50
   },
   "iFlakyFail": {
     "name": "iFlakyFail",
@@ -24,6 +27,7 @@
     "error": {
       "message": "I dun wurk"
     },
-    "testOutput": "Thanks for testing!"
+    "testOutput": "Thanks for testing!",
+    "duration": 50
   }
 }

--- a/test/fixtures/test-out-tap-failing.txt
+++ b/test/fixtures/test-out-tap-failing.txt
@@ -1,11 +1,16 @@
 TAP version 13
 ok 1 - iPass v4.2.2
+  ---
+  duration_ms: 50
+  ...
 ok 2 - iFlakyFail v3.3.3 # SKIP I dun wurk
   ---
   # Thanks for testing!
+  duration_ms: 50
   ...
 not ok 3 - iFail v3.0.1 I dun wurk
   ---
   # Thanks for testing!
+  duration_ms: 50
   ...
 1..3

--- a/test/fixtures/test-out-tap-passing-append.txt
+++ b/test/fixtures/test-out-tap-passing-append.txt
@@ -1,8 +1,12 @@
 This is a test!
 TAP version 13
 ok 1 - iPass v4.2.2
+  ---
+  duration_ms: 50
+  ...
 ok 2 - iFlakyPass v3.0.1
   ---
   # Thanks for testing!
+  duration_ms: 50
   ...
 1..2

--- a/test/fixtures/test-out-tap-passing.txt
+++ b/test/fixtures/test-out-tap-passing.txt
@@ -1,7 +1,11 @@
 TAP version 13
 ok 1 - iPass v4.2.2
+  ---
+  duration_ms: 50
+  ...
 ok 2 - iFlakyPass v3.0.1
   ---
   # Thanks for testing!
+  duration_ms: 50
   ...
 1..2

--- a/test/fixtures/test-out-xml-failing.txt
+++ b/test/fixtures/test-out-xml-failing.txt
@@ -1,17 +1,17 @@
 <testsuite name="citgm">
-  <testcase name="iPass-v4.2.2">
+  <testcase name="iPass-v4.2.2" time="0.05">
     <system-out>
       <![CDATA[]]>
     </system-out>
   </testcase>
-  <testcase name="iFlakyFail-v3.3.3">
+  <testcase name="iFlakyFail-v3.3.3" time="0.05">
     <system-out>
       <![CDATA[ Thanks for testing!]]>
     </system-out>
     <skipped/>
     <failure message="module test suite failed">[object Object] </failure>
   </testcase>
-  <testcase name="iFail-v3.0.1">
+  <testcase name="iFail-v3.0.1" time="0.05">
     <system-out>
       <![CDATA[ Thanks for testing!]]>
     </system-out>

--- a/test/fixtures/test-out-xml-passing-append.txt
+++ b/test/fixtures/test-out-xml-passing-append.txt
@@ -1,11 +1,11 @@
 This is a test!
 <testsuite name="citgm">
-  <testcase name="iPass-v4.2.2">
+  <testcase name="iPass-v4.2.2" time="0.05">
     <system-out>
       <![CDATA[]]>
     </system-out>
   </testcase>
-  <testcase name="iFlakyPass-v3.0.1">
+  <testcase name="iFlakyPass-v3.0.1" time="0.05">
     <system-out>
       <![CDATA[ Thanks for testing!]]>
     </system-out>

--- a/test/fixtures/test-out-xml-passing.txt
+++ b/test/fixtures/test-out-xml-passing.txt
@@ -1,10 +1,10 @@
 <testsuite name="citgm">
-  <testcase name="iPass-v4.2.2">
+  <testcase name="iPass-v4.2.2" time="0.05">
     <system-out>
       <![CDATA[]]>
     </system-out>
   </testcase>
-  <testcase name="iFlakyPass-v3.0.1">
+  <testcase name="iFlakyPass-v3.0.1" time="0.05">
     <system-out>
       <![CDATA[ Thanks for testing!]]>
     </system-out>

--- a/test/reporter/test-reporter-junit.js
+++ b/test/reporter/test-reporter-junit.js
@@ -7,6 +7,7 @@ var test = require('tap').test;
 var mkdirp = require('mkdirp');
 var rimraf = require('rimraf');
 var _ = require('lodash');
+var parseString = require('xml2js').parseString;
 
 var junit = require('../../lib/reporter/junit');
 var fixtures = require('../fixtures/reporter-fixtures');
@@ -35,6 +36,7 @@ var failingInput = [
   fixtures.iFail
 ];
 
+var junitParserExpected = require('../fixtures/parsed-junit.json');
 var failingExpectedPath = path.join(fixturesPath, 'test-out-xml-failing.txt');
 var failingExpected = fs.readFileSync(failingExpectedPath, 'utf-8');
 
@@ -96,6 +98,20 @@ test('reporter.junit(): failing', function (t) {
   junit(logger, failingInput);
   t.equals(output, failingExpected), 'we should get the expected output when a module fails';
   t.end();
+});
+
+test('reporter.junit(): parser', function (t) {
+  var output = '';
+  function logger(message) {
+    output += message;
+    output += '\n';
+  }
+
+  junit(logger, failingInput);
+  parseString(output, function (err, result) {
+    t.deepEquals(result, junitParserExpected), 'we should get the expected output when a module fails';
+    t.end();
+  });
 });
 
 test('reporter.junit(): write to disk', function (t) {

--- a/test/reporter/test-reporter-markdown.js
+++ b/test/reporter/test-reporter-markdown.js
@@ -11,7 +11,7 @@ test('single passing module:', function (t) {
   }, fixtures.iPass);
   var expected = '## 🎉🎉 CITGM Passed 🎉🎉';
   expected += '### Passing Modules';
-  expected += '  * iPass v4.2.2';
+  expected += '  * iPass v4.2.2 duration:50ms';
   t.equals(output, expected, 'we should have the expected markdown output');
   t.end();
 });
@@ -23,7 +23,7 @@ test('single failing module:', function (t) {
   }, fixtures.iFail);
   var expected = '## 🔥⚠️🔥 CITGM FAILED 🔥⚠️🔥';
   expected += '### Failing Modules';
-  expected += '  * iFail v3.0.1';
+  expected += '  * iFail v3.0.1 duration:50ms';
   expected += '    - I dun wurk';
   expected += '    -  Thanks for testing!';
   t.equals(output, expected, 'we should have the expected markdown output');
@@ -38,10 +38,10 @@ test('multiple modules passing, with a flaky module that fails:', function (t) {
   var expected = '## 🎉🎉 CITGM Passed 🎉🎉';
   expected += '## 📛 But with Flaky Failures 📛';
   expected += '### Passing Modules';
-  expected += '  * iPass v4.2.2';
-  expected += '  * iFlakyPass v3.0.1';
+  expected += '  * iPass v4.2.2 duration:50ms';
+  expected += '  * iFlakyPass v3.0.1 duration:50ms';
   expected += '### Flaky Modules';
-  expected += '  * iFlakyFail v3.3.3';
+  expected += '  * iFlakyFail v3.3.3 duration:50ms';
   expected += '    - I dun wurk';
   expected += '    -  Thanks for testing!';
   t.equals(output, expected, 'we should have the expected markdown output');


### PR DESCRIPTION
This will be useful for diagnosing machine issues and will also allow us to see which modules are slowing down the citgm-all job.
