### PR TITLE
Add support for testing native modules and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
   `build` or `rebuild`
   * `"vertify-node-gyp-not-called": true` - Asserts that `npm` did not call `node-gyp`
   * `"envVar": { "var": "value" }` - Pass an environment variable before running
+  * `"test-command"` - Use custom test command:
+```javascript
+"test-command": {
+  "default": "./node_modules/.bin/nodeunit test",
+  "win32": "node_modules\\\\.bin\\\\nodeunit test"
+}
+```
 
 If you want to pass options to npm, eg `--registry`, you can usually define an
 environment variable, eg `"npm_config_registry": "https://www.xyz.com"`.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
   * `"script": /path/to/script | https://url/to/script` - Use a custom test script
   * `"sha": "<git-commit-sha>"` - Test against a specific commit
   * `"test-name": "name"` - Custom name for test case
+  * `"verify-node-gyp-called": true` - Asserts that `npm` called `node-gyp` with either
+  `build` or `rebuild`
+  * `"vertify-node-gyp-not-called": true` - Asserts that `npm` did not call `node-gyp`
   * `"envVar": { "var": "value" }` - Pass an environment variable before running
 
 If you want to pass options to npm, eg `--registry`, you can usually define an

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
   `build` or `rebuild`
   * `"vertify-node-gyp-not-called": true` - Asserts that `npm` did not call `node-gyp`
   * `"envVar": { "var": "value" }` - Pass an environment variable before running
+  * `"install": ["--build-from-source"]` - Array of extra parameters passed to `npm install`
   * `"test-command"` - Use custom test command:
 ```javascript
 "test-command": {

--- a/README.md
+++ b/README.md
@@ -106,18 +106,17 @@ citgm-all -l ./path/to/my_lookup.json
 ```
 For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
 
-```
-"replace": true              Download module from github repo in package.json
-"master": true               Use the master branch
-"prefix": "v"                Specify the prefix used in the module version.
-"flaky": true                Ignore failures
-"skip": true                 Completely skip the module
-"repo": "https://github.com/pugjs/jade" - Use a different github repo
-"skipAnsi": true             Strip ansi data from output stream of npm
-"script": /path/to/script | https://url/to/script - Use a custom test script
-"sha": "<git-commit-sha>"    Test against a specific commit
-"envVar"                     Pass an environment variable before running
-```
+  * `"replace": true` - Download module from github repo in package.json
+  * `"master": true` - Use the master branch
+  * `"prefix": "v"` - Specify the prefix used in the module version.
+  * `"flaky": true` - Ignore failures
+  * `"skip": true` - Completely skip the module
+  * `"repo": "https://github.com/pugjs/jade"` - Use a different github repo
+  * `"skipAnsi": true` - Strip ansi data from output stream of npm
+  * `"script": /path/to/script | https://url/to/script` - Use a custom test script
+  * `"sha": "<git-commit-sha>"` - Test against a specific commit
+  * `"test-name": "name"` - Custom name for test case
+  * `"envVar": { "var": "value" }` - Pass an environment variable before running
 
 If you want to pass options to npm, eg `--registry`, you can usually define an
 environment variable, eg `"npm_config_registry": "https://www.xyz.com"`.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
   * `"vertify-node-gyp-not-called": true` - Asserts that `npm` did not call `node-gyp`
   * `"envVar": { "var": "value" }` - Pass an environment variable before running
   * `"install": ["--build-from-source"]` - Array of extra parameters passed to `npm install`
+  * `"node-version": ">=6.0.0"` - Required minimal node.js version. Uses `node-semver` syntax.  
   * `"test-command"` - Use custom test command:
 ```javascript
 "test-command": {

--- a/bin/citgm-all.js
+++ b/bin/citgm-all.js
@@ -82,20 +82,23 @@ function runCitgm (mod, name, next) {
   process.on('SIGHUP', cleanup);
   process.on('SIGBREAK', cleanup);
 
-  runner.on('start', function(name) {
+  runner.on('start', function(name, test) {
     log.info('starting', name);
+    if (test) {
+      log.info('test', test);
+    }
   }).on('fail', function(err) {
     log.error('failure', err.message);
   }).on('data', function(type,key,message) {
     log[type](key, message);
-  }).on('end', function(result) {
+  }).on('done', function(result) {
     if (result.error) {
-      log.error('done', 'The test suite for ' + result.name + ' version ' + result.version + ' failed');
-    }
-    else {
-      log.info('done', 'The test suite for ' + result.name + ' version ' + result.version + ' passed.');
+      log.error('done', 'The test suite for ' + result.useName + ' failed');
+    } else {
+      log.info('done', 'The test suite for ' + result.useName + ' passed.');
     }
     modules.push(result);
+  }).on('end', function() {
     process.removeListener('SIGINT', cleanup);
     process.removeListener('SIGHUP', cleanup);
     process.removeListener('SIGBREAK', cleanup);

--- a/bin/citgm-all.js
+++ b/bin/citgm-all.js
@@ -2,6 +2,7 @@
 'use strict';
 var yargs = require('yargs');
 var async = require('async');
+var semver = require('semver');
 
 var update = require('../lib/update');
 var citgm = require('../lib/citgm');
@@ -68,6 +69,16 @@ var modules = [];
 function runCitgm (mod, name, next) {
   if (mod.skip) {
     return next();
+  }
+
+  if (mod['node-version']) {
+    // Get node version, stripping prerealase
+    var nodeVersion = semver.major(process.version) + '.' +
+                      semver.minor(process.version) + '.' +
+                      semver.patch(process.version);
+    if (!semver.satisfies(nodeVersion, mod['node-version'])) {
+      return next();
+    }
   }
 
   var runner = citgm.Tester(name, options);

--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -81,20 +81,72 @@ function extractDetail(mod) {
  *  - start = emitted when run is started
  **/
 
-function Tester(mod, options) {
-  if (!(this instanceof Tester))
-    return new Tester(mod, options);
+function TestRunner(moduleDetail, test, options) {
+  if (!(this instanceof TestRunner))
+    return new TestRunner(moduleDetail, test, options);
   EventEmitter.call(this);
-  this.module = extractDetail(mod);
+  this.module = moduleDetail;
+  this.test = test;
   this.options = options;
   this.testOutput = '';
   this.testError = '';
   this.cleanexit = false;
 }
 
+util.inherits(TestRunner, EventEmitter);
+
+function Tester(mod, options) {
+  if (!(this instanceof Tester))
+    return new Tester(mod, options);
+  EventEmitter.call(this);
+  this.module = extractDetail(mod);
+  this.options = options;
+}
+
 util.inherits(Tester, EventEmitter);
 
 Tester.prototype.run = function() {
+  var self = this;
+  var lookupTable = lookup.get(self.options);
+  if (!lookupTable) {
+    self.emit('fail',new Error('Lookup table could not be loaded'));
+    self.emit('end');
+    return;
+  }
+  var moduleTests = lookupTable[this.module.name];
+  var tests = moduleTests instanceof Array ? moduleTests : [moduleTests];
+
+  async.forEachOfSeries(tests, function(test, index, next) {
+    var runner = new TestRunner(Object.assign({}, self.module), test, Object.assign({}, self.options));
+    self.runner = runner;
+    var testName = test ? test['test-name'] : undefined;
+    runner.on('start', function(name) {
+      self.emit('start', name, testName);
+    }).on('fail', function(err) {
+      self.emit('fail', err);
+    }).on('data', function(type,key,message) {
+      self.emit('data', type, key, message);
+    }).on('done', function(result) {
+      result.test = testName;
+      var useName = result.name + ' version ' + result.version;
+      if (result.test)
+        useName += ' test ' + result.test;
+      result.useName = useName;
+      self.emit('done', result);
+      next();
+    }).run();
+
+  }, function done () {
+    self.emit('end');
+  });
+};
+
+Tester.prototype.cleanup = function() {
+  if (this.runner)
+    this.runner.cleanup();
+};
+
+TestRunner.prototype.run = function() {
   var self = this;
   this.emit('start', this.module.raw, this.options);
 
@@ -127,14 +179,14 @@ Tester.prototype.run = function() {
         payload.testOutput += self.testError + '\n';
       }
       tempDirectory.remove(self, function() {
-        self.emit('end', payload);
+        self.emit('done', payload);
         self.cleanexit = true;
       });
     }
   });
 };
 
-Tester.prototype.cleanup = function () {
+TestRunner.prototype.cleanup = function () {
   var self = this;
   self.cleanexit = true;
   var payload = {
@@ -143,7 +195,7 @@ Tester.prototype.cleanup = function () {
   };
   self.emit('fail', payload.error);
   tempDirectory.remove(self, function() {
-    self.emit('end', payload);
+    self.emit('done', payload);
   });
 };
 

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -58,16 +58,11 @@ function getLookupTable(options) {
  * the path to a different lookup json file can be specified
  **/
 function resolve(context, next) {
-  var lookup = getLookupTable(context.options);
-  if (!lookup) {
-    next(Error('Lookup table could not be loaded'));
-    return;
-  }
   var detail = context.module;
   context.emit('info','lookup',detail.name);
   var meta = context.meta;
   if (meta) {
-    var rep = lookup[detail.name];
+    var rep = context.test;
     context.module.version = meta.version;
     if (rep) {
       if (rep.envVar){

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -102,6 +102,10 @@ function resolve(context, next) {
         context.emit('info','lookup-replace',url);
         context.module.raw = url;
       }
+      if (rep.install) {
+        context.emit('info','lookup-install',rep.install);
+        context.module.install = rep.install;
+      }
       if (rep.script) {
         context.emit('info','lookup-script',rep.script);
         context.module.script = rep.script;

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -91,6 +91,9 @@ function resolve(context, next) {
         context.options.script = rep.script;
       }
       context.module.flaky = context.options.failFlaky ? false : isFlaky(rep.flaky);
+      context.module.verifyNodeGypCalled = rep['verify-node-gyp-called'] === true;
+      context.module.verifyNodeGypNotCalled = rep['verify-node-gyp-not-called'] === true;
+      context.module.verifyNodeGyp = context.module.verifyNodeGypCalled || context.module.verifyNodeGypNotCalled;
     } else {
       context.emit('info','lookup-notfound',detail.name);
     }

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -42,6 +42,22 @@ function getLookupTable(options) {
   }
 }
 
+function parseTestCommand(testCommand) {
+  if (!testCommand) {
+    return undefined;
+  }
+  if (typeof testCommand === 'string') {
+    return testCommand;
+  }
+  if (typeof testCommand[process.platform] === 'string') {
+    return testCommand[process.platform];
+  }
+  if (typeof testCommand['default'] === 'string') {
+    return testCommand['default'];
+  }
+  return undefined;
+}
+
 /**
  * Certain known modules in npm do not publish their tests,
  * causing npm test to fail. In such cases, we need to grab
@@ -89,6 +105,11 @@ function resolve(context, next) {
       if (rep.script) {
         context.emit('info','lookup-script',rep.script);
         context.module.script = rep.script;
+      }
+      if (rep['test-command']) {
+        var testCommand = parseTestCommand(rep['test-command']);
+        context.module.testCommand = testCommand;
+        context.emit('info','test-command', testCommand);
       }
       context.module.flaky = context.options.failFlaky ? false : isFlaky(rep.flaky);
       context.module.verifyNodeGypCalled = rep['verify-node-gyp-called'] === true;

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -88,7 +88,7 @@ function resolve(context, next) {
       }
       if (rep.script) {
         context.emit('info','lookup-script',rep.script);
-        context.options.script = rep.script;
+        context.module.script = rep.script;
       }
       context.module.flaky = context.options.failFlaky ? false : isFlaky(rep.flaky);
       context.module.verifyNodeGypCalled = rep['verify-node-gyp-called'] === true;

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -8,17 +8,26 @@
   "underscore": {
     "replace": true,
     "master": true,
-    "flaky": "aix"
+    "flaky": "aix",
+    "test-command": {
+      "win32": "for %i in (test\\\\*.js) do node_modules\\\\.bin\\\\qunit-cli %i"
+    }
   },
   "request": {
     "replace": true,
     "prefix": "v",
-    "flaky": true
+    "flaky": true,
+    "test-command": {
+      "win32": "for %i in (test\\\\test-*.js) do node_modules\\\\.bin\\\\traper %i"
+    }
   },
   "commander": {
     "replace": true,
     "prefix": "v",
-    "repo": "https://github.com/tj/commander.js"
+    "repo": "https://github.com/tj/commander.js",
+    "test-command": {
+      "win32": "for %i in (test\\\\test.*js) do node %i"
+    }
   },
   "express": {
     "replace": true,
@@ -41,11 +50,14 @@
   "glob": {
     "replace": true,
     "prefix": "v",
-    "flaky": ["v6", "v7"]
+    "flaky": ["v6", "v7", "win32"]
   },
   "gulp-util": {
     "replace": true,
-    "prefix": "v"
+    "prefix": "v",
+    "test-command": {
+      "win32": "node_modules\\\\.bin\\\\mocha"
+    }
   },
   "pug": {
     "replace": true,
@@ -59,7 +71,7 @@
   },
   "fs-extra": {
     "replace": true,
-    "flaky": ["linux-ia32", "aix", "s390"]
+    "flaky": ["linux-ia32", "aix", "s390", "win32"]
   },
   "body-parser": {
     "replace": true
@@ -70,21 +82,26 @@
     "flaky": ["darwin", "aix"]
   },
   "jquery": {
-    "replace": true
+    "replace": true,
+    "flaky": "win32"
   },
   "rimraf": {
     "replace": true,
-    "prefix": "v"
+    "prefix": "v",
+    "flaky": "win32"
   },
   "david": {
     "replace": true,
     "prefix": "v",
-    "flaky": true
+    "flaky": true,
+    "test-command": {
+      "win32": "node test\\\\david.js && node test\\\\cli.js"
+    }
   },
   "eslint": {
     "replace": true,
     "prefix": "v",
-    "flaky": ["ppc", "v7", "s390"]
+    "flaky": ["ppc", "v7", "s390", "win32"]
   },
   "tape": {
     "replace": true,
@@ -93,15 +110,16 @@
   },
   "browserify": {
     "replace": true,
-    "flaky": ["v7"]
+    "flaky": ["v7", "win32"]
   },
   "watchify": {
     "replace": true,
     "prefix": "v",
-    "flaky": ["ppc", "v7"]
+    "flaky": ["ppc", "v7", "win32"]
   },
   "stylus": {
-    "replace": true
+    "replace": true,
+    "flaky": "win32"
   },
   "level": {
     "replace": true,
@@ -116,13 +134,16 @@
   "react": {
     "replace": true,
     "prefix": "v",
-    "flaky": ["v0.10", "v0.12", "v6", "v7"]
+    "flaky": ["v0.10", "v0.12", "v6", "v7", "win32"]
   },
   "gulp": {
     "replace": true,
     "prefix": "v",
     "flaky": {
       "ppc": ["v5", "v6"]
+    },
+    "test-command": {
+      "win32": "node_modules\\\\.bin\\\\mocha --reporter spec"
     }
   },
   "moment": {
@@ -130,7 +151,12 @@
     "flaky": true
   },
   "ws": {
-    "replace": true
+    "replace": true,
+    "flaky": "win32",
+    "test-command": {
+      "win32": "node_modules\\\\.bin\\\\mocha -t 5000 -s 2400 test\\\\*.test.js"
+    },
+    "verify-node-gyp-called": true
   },
   "vinyl": {
     "replace": true,
@@ -171,12 +197,16 @@
   },
   "binary-split": {
     "replace": true,
-    "prefix": "v"
+    "prefix": "v",
+    "flaky": "win32"
   },
   "spdy": {
     "replace": true,
     "prefix": "v",
-    "flaky": "aix"
+    "flaky": "aix",
+    "test-command": {
+      "win32": "node_modules\\\\.bin\\\\mocha --reporter=spec test\\\\*-test.js"
+    }
   },
   "dicer": {
     "replace": true,
@@ -184,7 +214,10 @@
   },
   "spdy-transport": {
     "replace": true,
-    "prefix": "v"
+    "prefix": "v",
+    "test-command": {
+      "win32": "node_modules\\\\.bin\\\\mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+    }
   },
   "sax": {
     "replace": true,
@@ -208,11 +241,15 @@
   },
   "jsonstream": {
     "replace": true,
-    "prefix": "v"
+    "prefix": "v",
+    "test-command": {
+      "win32": "for %i in (test\\\\*.js) do node %i"
+    }    
   },
   "csv-parser": {
     "replace": true,
-    "prefix": "v"
+    "prefix": "v",
+    "flaky": "win32"
   },
   "async": {
     "replace": true,
@@ -220,7 +257,8 @@
     "flaky": {
       "s390": true,
       "darwin": true,
-      "v0.12": ["fedora22", "ubuntu1204"]
+      "v0.12": ["fedora22", "ubuntu1204"],
+      "win32": true
     }
   },
   "bluebird": {
@@ -230,7 +268,7 @@
   "mkdirp": {
     "replace": true,
     "master": true,
-    "flaky": ["v6", "v7"]
+    "flaky": ["v6", "v7", "win32"]
   },
   "yeoman-generator": {
     "replace": true,
@@ -241,14 +279,19 @@
     "replace": true
   },
   "cheerio": {
-    "replace": true
+    "replace": true,
+    "test-command": {
+      "win32": "node_modules\\\\.bin\\\\mocha --recursive"
+    }
   },
   "node-uuid": {
     "replace": true,
-    "prefix": "v"
+    "prefix": "v",
+    "flaky": "win32"
   },
   "winston": {
-    "replace": true
+    "replace": true,
+    "flaky": "win32"
   },
   "yargs": {
     "replace": true,
@@ -287,23 +330,31 @@
   },
   "bcrypt": {
     "replace": true,
-    "prefix": "v"
+    "prefix": "v",
+    "test-command": {
+      "default": "./node_modules/.bin/nodeunit test",
+      "win32": "node_modules\\\\.bin\\\\nodeunit test"
+    },
+    "verify-node-gyp-called": true
   },
   "ref": {
     "replace": true,
-    "flaky": "aix"
+    "flaky": "aix",
+    "verify-node-gyp-called": true
   },
   "time": {
     "replace": true,
-    "flaky": ["linux-ia32", "aix", "s390"]
+    "flaky": ["linux-ia32", "aix", "s390", "win32"]
   },
   "bson": {
     "replace": true,
-    "prefix": "V"
+    "prefix": "V",
+    "flaky": "win32"
   },
   "ember-cli": {
     "replace": true,
-    "prefix": "v"
+    "prefix": "v",
+    "flaky": "win32"
   },
   "node-sass": [ {
       "replace": true,

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -305,11 +305,19 @@
     "replace": true,
     "prefix": "v"
   },
-  "node-sass": {
-    "replace": true,
-    "prefix": "v",
-    "flaky": ["ppc", "v7", "s390"]
-  },
+  "node-sass": [ {
+      "replace": true,
+      "prefix": "v",
+      "test-name": "using node-gyp",
+      "flaky": ["ppc", "v7", "s390", "win32"],
+      "envVar": { "SKIP_SASS_BINARY_DOWNLOAD_FOR_CI": 1 }
+    }, {
+      "replace": true,
+      "prefix": "v",
+      "test-name": "not using node-gyp",
+      "flaky": ["ppc", "v7", "s390", "win32"]
+    }
+  ],
   "full-icu-test": {
     "replace": true,
     "prefix": "v",

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -1,4 +1,7 @@
 {
+  "citgm": {
+    "flaky": ["win32"]
+  },
   "lodash": {
     "replace": true
   },
@@ -309,6 +312,71 @@
   },
   "full-icu-test": {
     "replace": true,
-    "prefix": "v"
+    "prefix": "v",
+    "flaky": "win32"
+  },
+  "bufferutil": {
+    "replace": true,
+    "verify-node-gyp-called": true
+  },
+  "utf-8-validate": {
+    "replace": true,
+    "verify-node-gyp-called": true
+  },
+  "kerberos": {
+    "test-command": " ",
+    "verify-node-gyp-called": true
+  },
+  "weak": {
+    "replace": true,
+    "verify-node-gyp-called": true
+  },
+  "hiredis": {
+    "verify-node-gyp-called": true
+  },
+  "iconv": {
+    "prefix": "v",
+    "replace": true,
+    "verify-node-gyp-called": true
+  },
+  "contextify": {
+    "prefix": "v",
+    "install": ["--build-from-source"],
+    "replace": true,
+    "flaky": true,
+    "verify-node-gyp-called": true
+  },
+  "thread-sleep": {
+    "replace": true,
+    "install": ["--build-from-source"],
+    "verify-node-gyp-called": true      
+  },
+  "sqlite3": [ {
+      "test-name": "using node-gyp",
+      "master": true,
+      "prefix": "v",
+      "replace": true,
+      "install": ["--build-from-source"],
+      "verify-node-gyp-called": true
+    }, {
+      "test-name": "not using node-gyp",
+      "prefix": "v",
+      "replace": true,
+      "verify-node-gyp-not-called": true
+    }
+  ],
+   "v8-profiler":  {
+      "node-version": ">=6.0.0",
+      "prefix": "v",
+      "replace": true,
+      "flaky": true,
+      "verify-node-gyp-called": true
+  },
+  "v8-debug": {
+      "node-version": ">=6.0.0",
+      "prefix": "v",
+      "replace": true,
+      "flaky": true,
+      "verify-node-gyp-called": true
   }
 }

--- a/lib/npm/install.js
+++ b/lib/npm/install.js
@@ -19,6 +19,10 @@ function install(context, next) {
   var bailed = false;
   context.emit('data', 'info', 'npm:', 'install started');
 
+  if (context.module.install) {
+    args = args.concat(context.module.install);
+  }
+
   if (context.options.nodedir) {
     var nodedir = path.resolve(process.cwd(), context.options.nodedir);
     options.env.npm_config_nodedir = nodedir;

--- a/lib/npm/install.js
+++ b/lib/npm/install.js
@@ -3,6 +3,9 @@
 // node modules
 var path = require('path');
 
+// npm modules
+var stripAnsi = require('strip-ansi');
+
 // local modules
 var spawn = require('../spawn');
 var createOptions = require('../create-options');
@@ -38,17 +41,32 @@ function install(context, next) {
     return next(Error('Install Timed Out'));
   }
 
+  var installOutput = '';
+  var installError = '';
+
   proc.stderr.on('data', function (chunk) {
     context.emit('data', 'warn', 'npm-install:', chunk.toString());
+    if (context.module.stripAnsi) {
+      chunk = stripAnsi(chunk.toString());
+      chunk = chunk.replace(/\r/g, '\n');
+    }
+    installError += chunk;
   });
 
   proc.stdout.on('data', function (chunk) {
     context.emit('data', 'verbose', 'npm-install:', chunk.toString());
+    if (context.module.stripAnsi) {
+      chunk = stripAnsi(chunk.toString());
+      chunk = chunk.replace(/\r/g, '\n');
+    }
+    installOutput += chunk;
   });
 
   proc.on('error', function() {
     bailed = true;
     clearTimeout(timeout);
+    context.testOutput += installOutput;
+    context.testError += installError;
     return next(new Error('Install Failed'));
   });
 
@@ -56,6 +74,8 @@ function install(context, next) {
     if (bailed) return;
     clearTimeout(timeout);
     if (code > 0) {
+      context.testOutput += installOutput;
+      context.testError += installError;
       return next(Error('Install Failed'));
     }
     context.emit('data', 'info', 'npm:', 'install successfully completed');

--- a/lib/npm/install.js
+++ b/lib/npm/install.js
@@ -9,6 +9,7 @@ var stripAnsi = require('strip-ansi');
 // local modules
 var spawn = require('../spawn');
 var createOptions = require('../create-options');
+var VerifyNodeGyp = require('./verify-node-gyp');
 
 function install(context, next) {
   var options =
@@ -28,6 +29,12 @@ function install(context, next) {
     context.emit('data', 'verbose','nodedir', 'Using --nodedir="' + nodedir + '"');
   }
 
+  var verifyNodeGyp;
+  if (context.module.verifyNodeGyp) {
+    verifyNodeGyp = new VerifyNodeGyp(context);
+    verifyNodeGyp.setOptions(options);
+  }
+  context.emit('data', 'verbose', 'npm install args', JSON.stringify(args));
   var proc = spawn('npm', args, options);
 
   // default timeout to 10 minutes if not provided
@@ -77,6 +84,13 @@ function install(context, next) {
       context.testOutput += installOutput;
       context.testError += installError;
       return next(Error('Install Failed'));
+    }
+    if (verifyNodeGyp) {
+      var nodeGypCalled = verifyNodeGyp.wasCalled();
+      if (context.module.verifyNodeGypCalled && !nodeGypCalled)
+        return next(new Error('node-gyp was not called'));
+      if (context.module.verifyNodeGypNotCalled && nodeGypCalled)
+        return next(new Error('node-gyp was called'));
     }
     context.emit('data', 'info', 'npm:', 'install successfully completed');
     return next(null, context);

--- a/lib/npm/script/index.js
+++ b/lib/npm/script/index.js
@@ -1,7 +1,9 @@
 var fetch = require('./fetch');
 var run = require('./run');
+var runTestCommand = require('./run-test-command');
 
 module.exports = {
   fetch: fetch,
-  run: run
+  run: run,
+  runTestCommand: runTestCommand
 };

--- a/lib/npm/script/run-test-command.js
+++ b/lib/npm/script/run-test-command.js
@@ -1,0 +1,46 @@
+// node modules
+var path = require('path');
+var spawn = require('child_process').spawn;
+
+// npm modules
+var stripAnsi = require('strip-ansi');
+
+// local modules
+var createOptions = require('../../create-options');
+
+function runTestCommand(nodeBin, npmBin, context, command, next) {
+  var workDir = path.join(context.path, context.module.name);
+  var options = createOptions(workDir, context);
+  if (context.options.testPath) {
+    options.env.PATH = context.options.testPath + ':' + process.env.PATH;
+  }
+
+  options.shell = true;
+  context.emit('data', 'verbose', 'npm-test-command', command);
+  var proc = spawn(command, [], options);
+
+  proc.stdout.on('data', function (data) {
+    if (context.module.stripAnsi) {
+      data = stripAnsi(data.toString());
+      data = data.replace(/\r/g, '\n');
+    }
+    context.testOutput += data;
+    context.emit('data', 'verbose', 'npm-test:', data.toString());
+  });
+  proc.stderr.on('data', function (data) {
+    context.testError += data;
+    context.emit('data', 'verbose', 'npm-error:', data.toString());
+  });
+  proc.on('error', function(err) {
+    next(err);
+  });
+  proc.on('close', function(code) {
+    if (code > 0) {
+      return next(Error('The canary is dead.'));
+    }
+    context.emit('data', 'verbose','npm-test-command-end', command);
+    return next(null, context);
+  });
+}
+
+module.exports = runTestCommand;

--- a/lib/npm/test.js
+++ b/lib/npm/test.js
@@ -26,9 +26,9 @@ function authorName(author) {
 }
 
 function test(context, next) {
-  if (context.options.script) {
 
-    script.fetch(context, context.options.script, function(err, file) {
+  if (context.module.script) {
+    script.fetch(context, context.module.script, function(err, file) {
       if (err) {
         return next(err);
       }

--- a/lib/npm/test.js
+++ b/lib/npm/test.js
@@ -26,6 +26,17 @@ function authorName(author) {
 }
 
 function test(context, next) {
+  var wd = path.join(context.path, context.module.name);
+  var options = createOptions(wd, context);
+  var nodeBin = 'node';
+  if (context.options.testPath) {
+    options.env.PATH = context.options.testPath + ':' + process.env.PATH;
+    nodeBin = which('node', {path: options.env.PATH || process.env.PATH});
+  }
+  var npmBin = which('npm',  {path: options.env.PATH || process.env.PATH});
+  if (windows) {
+    npmBin = path.join(path.dirname(npmBin), 'node_modules', 'npm', 'bin', 'npm-cli.js');
+  }
 
   if (context.module.script) {
     script.fetch(context, context.module.script, function(err, file) {
@@ -40,7 +51,12 @@ function test(context, next) {
 
     return;
   }
-  var wd = path.join(context.path, context.module.name);
+
+  if (context.module.testCommand) {
+    script.runTestCommand(nodeBin, npmBin, context, context.module.testCommand, next);
+    return;
+  }
+
   context.emit('data', 'info', 'npm:', 'test suite started');
   readPackage(path.join(wd,'package.json'),false,function(err,data) {
     if (err) {
@@ -58,16 +74,6 @@ function test(context, next) {
       return;
     }
 
-    var options = createOptions(wd, context);
-    var nodeBin = 'node';
-    if (context.options.testPath) {
-      options.env.PATH = context.options.testPath + ':' + process.env.PATH;
-      nodeBin = which('node', {path: options.env.PATH || process.env.PATH});
-    }
-    var npmBin = which('npm',  {path: options.env.PATH || process.env.PATH});
-    if (windows) {
-      npmBin = path.join(path.dirname(npmBin), 'node_modules', 'npm', 'bin', 'npm-cli.js');
-    }
     var proc = spawn(nodeBin, [npmBin, 'test', '--loglevel=' + context.options.npmLevel], options);
     proc.stdout.on('data', function (data) {
       if (context.module.stripAnsi) {

--- a/lib/npm/verify-node-gyp.js
+++ b/lib/npm/verify-node-gyp.js
@@ -1,0 +1,40 @@
+'use strict';
+var uuid = require('node-uuid');
+var path = require('path');
+var fs = require('fs');
+var which = require('which').sync;
+
+function VerifyNodeGyp(context) {
+  if (!(this instanceof VerifyNodeGyp))
+    return new VerifyNodeGyp(context);
+  this.verifyNodeGyp = context.module.verifyNodeGyp;
+  var id = uuid.v4();
+  var scriptFilename = id + '.js';
+  this.script = path.resolve(context.path, scriptFilename);
+  this.marker = path.resolve(context.path, id + '.tmp');
+
+  var npmLocation = which('npm');
+  var nodeGypBinary = process.platform === 'win32' ?
+    path.resolve(path.dirname(npmLocation), 'node_modules', 'npm', 'node_modules',
+                 'node-gyp', 'bin', 'node-gyp.js') :
+    path.resolve(path.dirname(npmLocation), '..', 'lib', 'node_modules', 'npm',
+                 'node_modules', 'node-gyp', 'bin', 'node-gyp.js');
+  var script = '#!/usr/bin/env node\n' +
+               'var args = process.argv.slice(1);\n' +
+               'if (args.indexOf(\'build\') != -1 || args.indexOf(\'rebuild\') != -1) {\n' +
+               '  require(\'fs\').writeFileSync(\'' + this.marker.replace(/\\/g, '\\\\') + '\', \'.\');\n' +
+               '}\n' +
+               'require(\'child_process\').fork(\'' + nodeGypBinary.replace(/\\/g, '\\\\') + '\', args)\n' +
+               '  .on(\'close\', function(code) { process.exit(code); });\n';
+  fs.writeFileSync(this.script, script, {mode: parseInt('777', 8)});
+}
+
+VerifyNodeGyp.prototype.setOptions = function(options) {
+  options.env['npm_config_node_gyp'] = this.script;
+};
+
+VerifyNodeGyp.prototype.wasCalled = function() {
+  return fs.existsSync(this.marker);
+};
+
+module.exports = VerifyNodeGyp;

--- a/lib/reporter/junit.js
+++ b/lib/reporter/junit.js
@@ -11,6 +11,9 @@ function generateTest(xml, mod) {
   var output =util.sanitizeOutput(mod.testOutput, '', true);
   var item = xml.ele('testcase');
   item.att('name', [mod.name, 'v' + mod.version].join('-'));
+  if (mod.test) {
+    item.att('test', mod.test);
+  }
   item.ele('system-out').dat(output);
   if (mod.skip || (mod.flaky && mod.error)) {
     item.ele('skipped');

--- a/lib/reporter/logger.js
+++ b/lib/reporter/logger.js
@@ -7,6 +7,9 @@ var util = require('./util');
 
 function logModule(log, logType, module) {
   log[logType](chalk.yellow('module name:'), module.name);
+  if (module.test) {
+    log[logType](chalk.yellow('test:'), module.test);
+  }
   log[logType](chalk.yellow('version:'), module.version);
   if (module.error) {
     log[logType]('error:', module.error.message);

--- a/lib/reporter/markdown.js
+++ b/lib/reporter/markdown.js
@@ -8,7 +8,11 @@ function printModulesMarkdown(logger, title, modules) {
   if (modules.length > 0) {
     logger('### ' + title + ' Modules');
     _.each(modules, function (mod) {
-      logger('  * ' + mod.name + ' v' + mod.version);
+      if (mod.test) {
+        logger('  * ' + mod.name + ' test ' + mod.test + ' v' + mod.version);
+      } else {
+        logger('  * ' + mod.name + ' v' + mod.version);
+      }
       if (mod.error) {
         logger('    - ' + mod.error.message);
       }

--- a/lib/reporter/tap.js
+++ b/lib/reporter/tap.js
@@ -13,7 +13,11 @@ function generateTest(mod, count) {
   }
   var error = mod.error ? [directive, mod.error].join(' ') : '';
   var output = mod.testOutput ? '\n' + util.sanitizeOutput(mod.testOutput, '# ') : '';
-  return [result, count + 1, '-', mod.name, 'v' + mod.version + error + output].join(' ');
+  if (mod.test) {
+    return [result, count + 1, '-', mod.name, 'test', mod.test, 'v' + mod.version + error + output].join(' ');
+  } else {
+    return [result, count + 1, '-', mod.name, 'v' + mod.version + error + output].join(' ');
+  }
 }
 
 function generateTap(modules) {

--- a/test/bin/test-citgm.js
+++ b/test/bin/test-citgm.js
@@ -2,13 +2,17 @@
 
 var test = require('tap').test;
 
-var spawn = require('../../lib/spawn');
+var spawn = require('child_process').spawn;
 
 var citgmPath = require.resolve('../../bin/citgm.js');
 
+function callCitgm(params) {
+  return spawn(process.argv[0], [citgmPath].concat(params));
+}
+
 test('bin: omg-i-pass /w tap output /w junit', function (t) {
   t.plan(1);
-  var proc = spawn(citgmPath, ['omg-i-pass', '-t', '-x']);
+  var proc = callCitgm(['omg-i-pass', '-t', '-x']);
   proc.on('error', function(err) {
     t.error(err);
     t.fail('we should not get an error testing omg-i-pass');
@@ -20,7 +24,7 @@ test('bin: omg-i-pass /w tap output /w junit', function (t) {
 
 test('bin: omg-i-fail /w markdown output /w nodedir', function (t) {
   t.plan(1);
-  var proc = spawn(citgmPath, ['omg-i-fail', '-m', '-d', '/dev/null']);
+  var proc = callCitgm(['omg-i-fail', '-m', '-d', '/dev/null']);
   proc.on('error', function(err) {
     t.error(err);
     t.fail('we should not get an error testing omg-i-pass');
@@ -30,12 +34,12 @@ test('bin: omg-i-fail /w markdown output /w nodedir', function (t) {
   });
 });
 
-test('bin: omg-i-have-script /w custom script /w tap to file /w junit to file  /w append', function (t) {
+test('bin: omg-i-fail /w custom script /w tap to file /w junit to file /w append', function (t) {
   t.plan(1);
-  var proc = spawn(citgmPath, ['omg-i-pass', '-l', './fixtures/custom-lookup-script.json', '--tap', '/dev/null', '--junit', '/dev/null', '--append']);
+  var proc = callCitgm(['omg-i-fail', '-l', './test/fixtures/custom-lookup-script.json', '--tap', '/dev/null', '--junit', '/dev/null', '--append']);
   proc.on('error', function(err) {
     t.error(err);
-    t.fail('we should not get an error testing omg-i-pass');
+    t.fail('we should not get an error testing omg-i-fail');
   });
   proc.on('close', function (code) {
     t.equal(code, 1, 'omg-i-fail should fail and exit with a code of one');
@@ -44,7 +48,7 @@ test('bin: omg-i-have-script /w custom script /w tap to file /w junit to file  /
 
 test('bin: no module /w root check', function (t) {
   t.plan(1);
-  var proc = spawn(citgmPath, ['-s']);
+  var proc = callCitgm(['-s']);
   proc.on('error', function(err) {
     t.error(err);
     t.fail('we should not get an error');
@@ -57,7 +61,7 @@ test('bin: no module /w root check', function (t) {
 test('bin: sigterm', function (t) {
   t.plan(1);
 
-  var proc = spawn(citgmPath, ['omg-i-pass', '-v', 'verbose']);
+  var proc = callCitgm(['omg-i-pass', '-v', 'verbose']);
   proc.on('error', function(err) {
     t.error(err);
     t.fail('we should not get an error testing omg-i-pass');
@@ -72,7 +76,7 @@ test('bin: sigterm', function (t) {
 
 test('bin: install from sha', function (t) {
   t.plan(1);
-  var proc = spawn(citgmPath, ['omg-i-pass', '-t', '-c', '37c34bad563599782c622baf3aaf55776fbc38a8']);
+  var proc = callCitgm(['omg-i-pass', '-t', '-c', '37c34bad563599782c622baf3aaf55776fbc38a8']);
   proc.on('error', function(err) {
     t.error(err);
     t.fail('we should not get an error testing omg-i-pass');

--- a/test/fixtures/custom-lookup-script.json
+++ b/test/fixtures/custom-lookup-script.json
@@ -7,5 +7,8 @@
     "prefix": "v",
     "script": "./example-test-script-passing.sh",
     "stripAnsi": true
+  },
+  "omg-i-fail": {
+    "script": "./example-test-script-failing.sh"
   }
 }

--- a/test/fixtures/example-test-script-passing.sh
+++ b/test/fixtures/example-test-script-passing.sh
@@ -1,2 +1,2 @@
-ECHO I PASS
+echo I PASS
 exit 0

--- a/test/npm/test-npm-test.js
+++ b/test/npm/test-npm-test.js
@@ -114,12 +114,12 @@ test('npm-test: custom script', function (t) {
     emit: function() {},
     path: sandbox,
     module: {
-      name: 'omg-i-pass'
+      name: 'omg-i-pass',
+      script: customScript
     },
     meta: {},
     options: {
-      npmLevel: 'silly',
-      script: customScript
+      npmLevel: 'silly'
     }
   };
   npmTest(context, function (err) {
@@ -133,12 +133,12 @@ test('npm-test: custom script does not exist', function (t) {
     emit: function() {},
     path: sandbox,
     module: {
-      name: 'omg-i-pass'
+      name: 'omg-i-pass',
+      script: './i/do/not/exist.lol'
     },
     meta: {},
     options: {
-      npmLevel: 'silly',
-      script: './i/do/not/exist.lol'
+      npmLevel: 'silly'
     }
   };
   npmTest(context, function (err) {

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -8,6 +8,13 @@ var lookup = rewire('../lib/lookup');
 var makeUrl = lookup.__get__('makeUrl');
 var getLookupTable = lookup.get;
 
+function testLookup(context, next) {
+  var table = getLookupTable(context.options);
+  var moduleTests = table[context.module.name];
+  context.test = moduleTests instanceof Array ? moduleTests[0] : moduleTests;
+  lookup(context, next);
+}
+
 test('lookup: makeUrl', function (t) {
   var repo = 'https://github.com/nodejs/citgm';
 
@@ -107,7 +114,7 @@ test('lookup: module not in table', function (t) {
     emit: function () {}
   };
 
-  lookup(context, function (err) {
+  testLookup(context, function (err) {
     t.error(err);
     t.notOk(context.module.raw, 'raw should remain falsey if module is not in lookup');
     t.end();
@@ -132,22 +139,9 @@ test('lookup: module in table', function (t) {
     emit: function () {}
   };
 
-  lookup(context, function (err) {
+  testLookup(context, function (err) {
     t.error(err);
     t.equals(context.module.raw, 'https://github.com/lodash/lodash/archive/master.tar.gz', 'raw should be truthy if the module was in the list');
-    t.end();
-  });
-});
-
-test('lookup: no table', function (t) {
-  var context = {
-    options: {
-      lookup: 'test/fixtures/custom-lookup-does-not-exist.json'
-    }
-  };
-
-  lookup(context, function (err) {
-    t.equals(err && err.message, 'Lookup table could not be loaded');
     t.end();
   });
 });
@@ -168,7 +162,7 @@ test('lookup: replace with no repo', function (t) {
     emit: function () {}
   };
 
-  lookup(context, function (err) {
+  testLookup(context, function (err) {
     t.equals(err && err.message, 'no-repository-field in package.json');
     t.end();
   });
@@ -190,9 +184,9 @@ test('lookup: lookup with script', function (t) {
     emit: function () {}
   };
 
-  lookup(context, function (err) {
+  testLookup(context, function (err) {
     t.error(err);
-    t.equals(context.options.script, './example-test-script-passing.sh');
+    t.equals(context.module.script, './example-test-script-passing.sh');
     t.end();
   });
 });
@@ -215,7 +209,7 @@ test('lookup: --fail-flaky', function (t) {
     emit: function () {}
   };
 
-  lookup(context, function (err) {
+  testLookup(context, function (err) {
     t.error(err);
     t.false(context.module.flaky, 'flaky should be disabled');
     t.end();


### PR DESCRIPTION
This PR adds testing of native modules built locally to the smoke tests. It includes all necessary changes to the CITGM and adds modules to `package.json`:
  * bufferutil
  * utf-8-validate
  * kerberos
  * weak
  * hiredis
  * iconv
  * contextify
  * thread-sleep
  * sqlite3
  * v8-profiler
  * v8-debuger
  * node-sass
 
It also fixes problem with `script` key in `package.json` (details in 4th commit description), adds CITGM itself to smoke tests and makes CITGM ready for use under Windows.
 
The PR is splitted in 10 commits for easier review.

  * [First commit](https://github.com/nodejs/citgm/commit/32631b8813df6cccf25f0e6260feacd65284cf22) adds support for multiple test cases per single module. This is used for example by node-sass and sqlite3 - we test version with prebuild binaries and with ones built locally. With this we can make sure that node works correctly for both the users and module developers. This is the biggest change in this PR.
  * [Second commit](https://github.com/nodejs/citgm/commit/1434c95238887e266af5b18256498cf3aedc7c0e) adds displaying of errors form install stage in the default logging level. Without this changes, if `npm install` failed its console output was lost unless running in verbose.
  * [Third commit](https://github.com/nodejs/citgm/commit/9e32982520242328bc0d3be1b95fa3c637ba5680) adds support for verifying if `npm` called `node-gyp` with either `build` or `rebuild`. It is done by setting `npm_config_node_gyp` (see [this npm commit](https://github.com/npm/npm/commit/145af6587f45de135cc876be2027ed818ed4ca6a)).
  * [Fourth commit](https://github.com/nodejs/citgm/commit/9c014adb9be6162bf16ae7ca5c4fa1ae34ea4844) fixes issues with `script` key in lookup. Right now it is wrongly added to `options` and not `module`. Also, script with `example-test-script-passing.sh` filename is expected to fail by the test. Besides fixing those two errors, this commit makes also `test-npm-test.js` run under Windows.
  * [Fifth commit](https://github.com/nodejs/citgm/commit/081e0398b9d9e0112ecb6c8f7846bd8dd5978e91) adds support for `test-command` key in lookup. It works similar to `script` - a user provided command is used instead of `npm test` when testing.
  * [Sixth commit](https://github.com/nodejs/citgm/commit/d33f68056c018c332b99bdb80a7a358d2292dcbf) adds `install` parameter to lookup. This allows for extra parameters to be passed to `npm install` - e.g. `--build-from-source`.
  * [Seventh commit](https://github.com/nodejs/citgm/commit/8c577978bb39004972d346c839ed2c3db4e4474b) adds `node-version` to lookup. It can be used to specify minimal node version needed to run given test in `citgm-all`.
  * [Eighth commit](https://github.com/nodejs/citgm/commit/ebf06c17cf9a2297aab1facaeb66c1bfbc0f08c5) adds citgm and native modules to `lookup.json`
  * [Ninth commit](https://github.com/nodejs/citgm/commit/c96fe17e25ca8b929d2e23b945f36324dcc6146f) extends node-sass entry in `lookup.json`, so that both downloaded and build binaries will be tested
  * [Tenth commit](https://github.com/nodejs/citgm/commit/f1296d52a7591a542ae7395da2790f11c9e3a259) adds support for Windows. It either marks module as flaky or adds workaround for testing with `test-command`
