### PR TITLE
lookup: skip node-sass

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -307,7 +307,8 @@
   "node-sass": {
     "replace": true,
     "prefix": "v",
-    "flaky": ["ppc", "v7", "s390"]
+    "flaky": ["ppc", "v7", "s390"],
+    "skip": true
   },
   "full-icu-test": {
     "replace": true,


### PR DESCRIPTION
It looks like the tarballs have regressed and are no longer
including the source from the submodules