### PR TITLE
npm: forward install error message on failure

### DIFF
--- a/lib/npm/install.js
+++ b/lib/npm/install.js
@@ -3,6 +3,9 @@
 // node modules
 var path = require('path');
 
+// npm modules
+var stripAnsi = require('strip-ansi');
+
 // local modules
 var spawn = require('../spawn');
 var createOptions = require('../create-options');
@@ -38,17 +41,32 @@ function install(context, next) {
     return next(Error('Install Timed Out'));
   }
 
+  var installOutput = '';
+  var installError = '';
+
   proc.stderr.on('data', function (chunk) {
+    if (context.module.stripAnsi) {
+      chunk = stripAnsi(chunk.toString());
+      chunk = chunk.replace(/\r/g, '\n');
+    }
     context.emit('data', 'warn', 'npm-install:', chunk.toString());
+    installError += chunk;
   });
 
   proc.stdout.on('data', function (chunk) {
+    if (context.module.stripAnsi) {
+      chunk = stripAnsi(chunk.toString());
+      chunk = chunk.replace(/\r/g, '\n');
+    }
     context.emit('data', 'verbose', 'npm-install:', chunk.toString());
+    installOutput += chunk;
   });
 
   proc.on('error', function() {
     bailed = true;
     clearTimeout(timeout);
+    context.testOutput = installOutput || '';
+    context.testError = installError || '';
     return next(new Error('Install Failed'));
   });
 
@@ -56,6 +74,8 @@ function install(context, next) {
     if (bailed) return;
     clearTimeout(timeout);
     if (code > 0) {
+      context.testOutput = installOutput || '';
+      context.testError = installError || '';
       return next(Error('Install Failed'));
     }
     context.emit('data', 'info', 'npm:', 'install successfully completed');

--- a/test/npm/test-npm-install.js
+++ b/test/npm/test-npm-install.js
@@ -99,8 +99,13 @@ test('npm-install: failed install', function (t) {
       npmLevel: 'http'
     }
   };
+  var expected = {
+    testOutput: /^$/,
+    testError: /npm ERR! 404 Registry returned 404 for GET on https:\/\/registry.npmjs.org\/THIS-WILL-FAIL/
+  };
   npmInstall(context, function (err) {
     t.equals(err && err.message, 'Install Failed');
+    t.match(context, expected, 'Install error reported');
     t.end();
   });
 });


### PR DESCRIPTION
When install step fails all output is lost unless logging was set to verbose. This changes this behavior, so that when install step fails output will be logged just like test errors.