### PR TITLE
lookup: fix script option and tests

### DIFF
--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -93,7 +93,7 @@ function resolve(context, next) {
       }
       if (rep.script) {
         context.emit('info','lookup-script',rep.script);
-        context.options.script = rep.script;
+        context.module.script = rep.script;
       }
       context.module.flaky = context.options.failFlaky ? false : isMatch(rep.flaky);
     } else {

--- a/lib/npm/test.js
+++ b/lib/npm/test.js
@@ -26,9 +26,8 @@ function authorName(author) {
 }
 
 function test(context, next) {
-  if (context.options.script) {
-
-    script.fetch(context, context.options.script, function(err, file) {
+  if (context.module.script) {
+    script.fetch(context, context.module.script, function(err, file) {
       if (err) {
         return next(err);
       }

--- a/test/bin/test-citgm.js
+++ b/test/bin/test-citgm.js
@@ -30,15 +30,27 @@ test('bin: omg-i-fail /w markdown output /w nodedir', function (t) {
   });
 });
 
-test('bin: omg-i-have-script /w custom script /w tap to file /w junit to file  /w append', function (t) {
+test('bin: omg-i-fail /w custom script /w tap to file /w junit to file /w append', function (t) {
   t.plan(1);
-  var proc = spawn(citgmPath, ['omg-i-pass', '-l', './fixtures/custom-lookup-script.json', '--tap', '/dev/null', '--junit', '/dev/null', '--append']);
+  var proc = spawn(citgmPath, ['omg-i-fail', '-l', './test/fixtures/custom-lookup-script.json', '--tap', '/dev/null', '--junit', '/dev/null', '--append']);
+  proc.on('error', function(err) {
+    t.error(err);
+    t.fail('we should not get an error testing omg-i-fail');
+  });
+  proc.on('close', function (code) {
+    t.equal(code, 0, 'omg-i-fail should succeed and exit with a code of zero');
+  });
+});
+
+test('bin: omg-i-pass /w custom script /w tap to file /w junit to file /w append', function (t) {
+  t.plan(1);
+  var proc = spawn(citgmPath, ['omg-i-pass', '-l', './test/fixtures/custom-lookup-script.json', '--tap', '/dev/null', '--junit', '/dev/null', '--append']);
   proc.on('error', function(err) {
     t.error(err);
     t.fail('we should not get an error testing omg-i-pass');
   });
   proc.on('close', function (code) {
-    t.equal(code, 1, 'omg-i-fail should fail and exit with a code of one');
+    t.equal(code, 1, 'omg-i-pass should fail and exit with a code of one');
   });
 });
 

--- a/test/fixtures/custom-lookup-script.json
+++ b/test/fixtures/custom-lookup-script.json
@@ -1,11 +1,14 @@
 {
   "omg-i-pass": {
     "replace": false,
-    "script": "./example-test-script-passing.sh"
+    "script": "./example-test-script-failing.sh"
   },
   "omg-i-have-script": {
     "prefix": "v",
     "script": "./example-test-script-passing.sh",
     "stripAnsi": true
+  },
+  "omg-i-fail": {
+    "script": "./example-test-script-passing.sh"
   }
 }

--- a/test/fixtures/example-test-script-passing.sh
+++ b/test/fixtures/example-test-script-passing.sh
@@ -1,2 +1,2 @@
-ECHO I PASS
+echo I PASS
 exit 0

--- a/test/npm/test-npm-test.js
+++ b/test/npm/test-npm-test.js
@@ -114,12 +114,12 @@ test('npm-test: custom script', function (t) {
     emit: function() {},
     path: sandbox,
     module: {
-      name: 'omg-i-pass'
+      name: 'omg-i-pass',
+      script: customScript
     },
     meta: {},
     options: {
-      npmLevel: 'silly',
-      script: customScript
+      npmLevel: 'silly'
     }
   };
   npmTest(context, function (err) {
@@ -133,12 +133,12 @@ test('npm-test: custom script does not exist', function (t) {
     emit: function() {},
     path: sandbox,
     module: {
-      name: 'omg-i-pass'
+      name: 'omg-i-pass',
+      script: './i/do/not/exist.lol'
     },
     meta: {},
     options: {
-      npmLevel: 'silly',
-      script: './i/do/not/exist.lol'
+      npmLevel: 'silly'
     }
   };
   npmTest(context, function (err) {

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -192,7 +192,7 @@ test('lookup: lookup with script', function (t) {
 
   lookup(context, function (err) {
     t.error(err);
-    t.equals(context.options.script, './example-test-script-passing.sh');
+    t.equals(context.module.script, './example-test-script-passing.sh');
     t.end();
   });
 });


### PR DESCRIPTION
This moves script option from `context.options` to `context.module` where it should be. It also fixes script test, which expected a `example-test-script-passing.sh` script to fail.

Additionally `test/bin/test-citgm.js` is altered, so it can be executed under Windows.