### PR TITLE
flaky, skip: add support for minimal node version

### DIFF
--- a/lib/match-conditions.js
+++ b/lib/match-conditions.js
@@ -3,8 +3,12 @@
 var fs = require('fs');
 var execSync = require('child_process').execSync;
 var _ = require('lodash');
+var semver = require('semver');
 
 var version = process.version;
+var semVersion = semver.major(process.version) + '.' +
+                 semver.minor(process.version) + '.' +
+                 semver.patch(process.version);
 var platform = process.platform;
 var arch = process.arch;
 var distro = '';
@@ -25,6 +29,8 @@ if (fs.existsSync('/etc/os-release')) {
 var endian = process.config.variables.node_byteorder || '';
 
 function isStringMatch(conditions) {
+  if (semver.validRange(conditions) && semver.satisfies(semVersion, conditions))
+    return true;
   var checks = [distro, release, version, [platform, arch].join('-'), endian];
   return _.some(checks, function (check) {
     return check.search(conditions) !== -1;

--- a/test/test-match-conditions.js
+++ b/test/test-match-conditions.js
@@ -7,6 +7,7 @@ var isMatch = rewire('../lib/match-conditions');
 
 var platformCache = isMatch.__get__('platform');
 var versionCache = isMatch.__get__('version');
+var semVersionCache = isMatch.__get__('semVersion');
 
 var match = {
   v5: ['darwin', 'hurd', 'x86']
@@ -26,18 +27,22 @@ function shim() {
   isMatch.__set__('version', 'v5.3.1');
   isMatch.__set__('platform', 'darwin');
   isMatch.__set__('arch', 'x64');
+  isMatch.__set__('semVersion', 'v5.3.1');
 }
 
 function revertShim() {
   isMatch.__set__('version', versionCache);
   isMatch.__set__('platform', platformCache);
+  isMatch.__set__('semVersion', semVersionCache);
 }
 
 function testVersions(t, testFunction) {
   t.ok(testFunction(process.version), 'the current version is what it is matched against');
   shim();
   t.ok(testFunction('v5'), 'the module is matched on the current platform');
+  t.ok(testFunction('> 5.0.0'), 'the module is matched on the current platform');
   t.notok(testFunction('v2'), 'the module is not matched on the current platform');
+  t.notok(testFunction('<=v2.0.0'), 'the module is not matched on the current platform');
   revertShim();
 }
 


### PR DESCRIPTION
Add support for node version ranges (using `node-semver`) to `"skip"` and `"flaky"` lookup attributes.

This depends on  https://github.com/nodejs/citgm/pull/247 landing first.