### PR TITLE
lookup: add support for extra install parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
 "script": /path/to/script | https://url/to/script - Use a custom test script
 "sha": "<git-commit-sha>"    Test against a specific commit
 "envVar"                     Pass an environment variable before running
+"install": ["--build-from-source"] - Array of extra parameters passed to 'npm install'
 ```
 
 If you want to pass options to npm, eg `--registry`, you can usually define an

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
 "script": /path/to/script | https://url/to/script - Use a custom test script
 "sha": "<git-commit-sha>"    Test against a specific commit
 "envVar"                     Pass an environment variable before running
-"install": ["--build-from-source"] - Array of extra parameters passed to 'npm install'
+"install": ["--param1", "--param2"] - Array of extra command line parameters passed to 'npm install'
 ```
 
 If you want to pass options to npm, eg `--registry`, you can usually define an

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -91,6 +91,10 @@ function resolve(context, next) {
         context.emit('info','lookup-replace',url);
         context.module.raw = url;
       }
+      if (rep.install) {
+        context.emit('info','lookup-install',rep.install);
+        context.module.install = rep.install;
+      }
       if (rep.script) {
         context.emit('info','lookup-script',rep.script);
         context.options.script = rep.script;

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -92,7 +92,7 @@ function resolve(context, next) {
         context.module.raw = url;
       }
       if (rep.install) {
-        context.emit('info','lookup-install',rep.install);
+        context.emit('verbose', 'lookup-install', rep.install);
         context.module.install = rep.install;
       }
       if (rep.script) {

--- a/lib/npm/install.js
+++ b/lib/npm/install.js
@@ -15,6 +15,10 @@ function install(context, next) {
   var bailed = false;
   context.emit('data', 'info', 'npm:', 'install started');
 
+  if (context.module.install) {
+    args = args.concat(context.module.install);
+  }
+
   if (context.options.nodedir) {
     var nodedir = path.resolve(process.cwd(), context.options.nodedir);
     options.env.npm_config_nodedir = nodedir;

--- a/test/fixtures/custom-lookup-install.json
+++ b/test/fixtures/custom-lookup-install.json
@@ -1,0 +1,5 @@
+{
+  "omg-i-pass-with-install-param": {
+    "install": ["--extra-param"]
+  }
+}

--- a/test/fixtures/omg-i-pass-with-install-param/package.json
+++ b/test/fixtures/omg-i-pass-with-install-param/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "omg-i-pass-with-install-param",
+  "version": "3.0.0",
+  "description": "Test package for CITGM test suite",
+  "main": "index.js",
+  "scripts": {
+    "test": "exit 0",
+    "install": "node test_args.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bzoz/omg-i-pass-with-install-param.git"
+  },
+  "author": "Bartosz Sosnowski",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/bzoz/omg-i-pass-with-install-param/issues"
+  },
+  "homepage": "https://github.com/bzoz/omg-i-pass-with-install-param#readme"
+}

--- a/test/fixtures/omg-i-pass-with-install-param/test_args.js
+++ b/test/fixtures/omg-i-pass-with-install-param/test_args.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+if (!process.env['npm_config_extra_param'])
+  process.exit(1);

--- a/test/fixtures/omg-i-pass-with-install-param/test_args.js
+++ b/test/fixtures/omg-i-pass-with-install-param/test_args.js
@@ -1,4 +1,10 @@
 #!/usr/bin/env node
 
+/*
+  Test 'npm-install: extra install parameters' from 'npm/test-npm-install.js'
+  will try to install this package as 'npm install --extra-param'. Npm converts
+  extra parameters to env variables prefixed 'npm_config_'. In our example, npm
+  will set 'npm_config_extra_param' to true. 
+*/
 if (!process.env['npm_config_extra_param'])
   process.exit(1);

--- a/test/npm/test-npm-install.js
+++ b/test/npm/test-npm-install.js
@@ -14,14 +14,20 @@ var sandbox = path.join(os.tmpdir(), 'citgm-' + Date.now());
 var fixtures = path.join(__dirname, '..', 'fixtures');
 var moduleFixtures = path.join(fixtures, 'omg-i-pass');
 var moduleTemp = path.join(sandbox, 'omg-i-pass');
+var extraParamFixtures = path.join(fixtures, 'omg-i-pass-with-install-param');
+var extraParamTemp = path.join(sandbox, 'omg-i-pass-with-install-param');
 var badFixtures = path.join(fixtures, 'omg-bad-tree');
 var badTemp = path.join(sandbox, 'omg-bad-tree');
 
 test('npm-install: setup', function (t) {
-  t.plan(5);
+  t.plan(7);
   mkdirp(sandbox, function (err) {
     t.error(err);
     ncp(moduleFixtures, moduleTemp, function (e) {
+      t.error(e);
+      t.ok(fs.existsSync(path.join(moduleTemp, 'package.json')));
+    });
+    ncp(extraParamFixtures, extraParamTemp, function (e) {
       t.error(e);
       t.ok(fs.existsSync(path.join(moduleTemp, 'package.json')));
     });
@@ -38,6 +44,25 @@ test('npm-install: basic module', function (t) {
     path: sandbox,
     module: {
       name: 'omg-i-pass'
+    },
+    meta: {},
+    options: {
+      npmLevel: 'silly'
+    }
+  };
+  npmInstall(context, function (err) {
+    t.error(err);
+    t.end();
+  });
+});
+
+test('npm-install: extra install parameters', function (t) {
+  var context = {
+    emit: function() {},
+    path: sandbox,
+    module: {
+      name: 'omg-i-pass-with-install-param',
+      install: ['--extra-param']
     },
     meta: {},
     options: {

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -232,3 +232,29 @@ test('lookup: ensure lookup works', function (t) {
   t.ok(lookup, 'the lookup table should exist');
   t.end();
 });
+
+test('lookup: lookup with install', function (t) {
+  var context = {
+    module: {
+      name: 'omg-i-pass-with-install-param',
+      raw: null
+    },
+    meta: {
+      repository: '/dev/null',
+      version: '0.1.1'
+    },
+    options: {
+      lookup: 'test/fixtures/custom-lookup-install.json'
+    },
+    emit: function () {}
+  };
+  var expected = {
+    install: [/--extra-param/]
+  };
+
+  lookup(context, function (err) {
+    t.error(err);
+    t.match(context.module, expected, 'Read extra install parameter');
+    t.end();
+  });
+});


### PR DESCRIPTION
Adds `"install"` lookup.json attribute, for extra parameters passed to `npm install`.