### PR TITLE
lookup: add verify-node-gyp-called

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
 "sha": "<git-commit-sha>"    Test against a specific commit
 "envVar"                     Pass an environment variable before running
 "verify-node-gyp-called": true - Asserts that npm called node-gyp with either 'build' or 'rebuild'
-"vertify-node-gyp-not-called": true - Asserts that npm did not call node-gyp
+"verify-node-gyp-not-called": true - Asserts that npm did not call node-gyp
 ```
 
 If you want to pass options to npm, eg `--registry`, you can usually define an

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
 "script": /path/to/script | https://url/to/script - Use a custom test script
 "sha": "<git-commit-sha>"    Test against a specific commit
 "envVar"                     Pass an environment variable before running
+"verify-node-gyp-called": true - Asserts that npm called node-gyp with either 'build' or 'rebuild'
+"vertify-node-gyp-not-called": true - Asserts that npm did not call node-gyp
 ```
 
 If you want to pass options to npm, eg `--registry`, you can usually define an

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -96,6 +96,9 @@ function resolve(context, next) {
         context.options.script = rep.script;
       }
       context.module.flaky = context.options.failFlaky ? false : isMatch(rep.flaky);
+      context.module.verifyNodeGypCalled = rep['verify-node-gyp-called'] === true;
+      context.module.verifyNodeGypNotCalled = rep['verify-node-gyp-not-called'] === true;
+      context.module.verifyNodeGyp = context.module.verifyNodeGypCalled || context.module.verifyNodeGypNotCalled;
     } else {
       context.emit('info','lookup-notfound',detail.name);
     }

--- a/lib/npm/install.js
+++ b/lib/npm/install.js
@@ -6,6 +6,7 @@ var path = require('path');
 // local modules
 var spawn = require('../spawn');
 var createOptions = require('../create-options');
+var VerifyNodeGyp = require('./verify-node-gyp');
 
 function install(context, next) {
   var options =
@@ -25,6 +26,12 @@ function install(context, next) {
     context.emit('data', 'verbose','nodedir', 'Using --nodedir="' + nodedir + '"');
   }
 
+  var verifyNodeGyp;
+  if (context.module.verifyNodeGyp) {
+    verifyNodeGyp = new VerifyNodeGyp(context);
+    verifyNodeGyp.setOptions(options);
+  }
+  context.emit('data', 'verbose', 'npm install args', JSON.stringify(args));
   var proc = spawn('npm', args, options);
 
   // default timeout to 10 minutes if not provided
@@ -57,6 +64,13 @@ function install(context, next) {
     clearTimeout(timeout);
     if (code > 0) {
       return next(Error('Install Failed'));
+    }
+    if (verifyNodeGyp) {
+      var nodeGypCalled = verifyNodeGyp.wasCalled();
+      if (context.module.verifyNodeGypCalled && !nodeGypCalled)
+        return next(new Error('node-gyp was not called'));
+      if (context.module.verifyNodeGypNotCalled && nodeGypCalled)
+        return next(new Error('node-gyp was called'));
     }
     context.emit('data', 'info', 'npm:', 'install successfully completed');
     return next(null, context);

--- a/lib/npm/verify-node-gyp.js
+++ b/lib/npm/verify-node-gyp.js
@@ -1,0 +1,46 @@
+'use strict';
+var uuid = require('node-uuid');
+var path = require('path');
+var fs = require('fs');
+var which = require('which').sync;
+
+function VerifyNodeGyp(context) {
+  if (!(this instanceof VerifyNodeGyp))
+    return new VerifyNodeGyp(context);
+  this.verifyNodeGyp = context.module.verifyNodeGyp;
+  var id = uuid.v4();
+  var scriptFilename = id + '.js';
+  this.script = path.resolve(context.path, scriptFilename);
+  this.marker = path.resolve(context.path, id + '.tmp');
+
+  var npmLocation = which('npm');
+  var npmNodeGyp = process.platform === 'win32' ?
+    path.resolve(path.dirname(npmLocation), 'node_modules', 'npm', 'bin', 'node-gyp-bin', 'node-gyp.cmd') :
+    path.resolve(path.dirname(npmLocation), '..', 'lib', 'node_modules', 'npm', 'bin', 'node-gyp-bin', 'node-gyp');
+  var script = '#!/usr/bin/env node\n' +
+               'var args = process.argv.slice(1);\n' +
+               'if (args.indexOf(\'build\') != -1 || args.indexOf(\'rebuild\') != -1) {\n' +
+               '  require(\'fs\').writeFileSync(\'' + this.marker.replace(/\\/g, '\\\\') + '\', \'.\');\n' +
+               '}\n' +
+               'var npmNodeGyp = \'' + npmNodeGyp.replace(/\\/g, '\\\\') + '\';\n';
+  if (process.env['npm_config_node_gyp']) {
+    script += 'var useEnv = process.env;\n';
+    script += 'useEnv[\'npm_config_node_gyp\'] = \'' + process.env['npm_config_node_gyp'].replace(/\\/g, '\\\\') + '\';\n';
+  } else {
+    script += 'var useEnv = process.env;\n';
+    script += 'delete useEnv[\'npm_config_node_gyp\'];\n';
+  }
+  script += 'require(\'child_process\').spawn(npmNodeGyp, args, { shell: true, env: useEnv })\n' +
+            '  .on(\'close\', function(code) { process.exit(code); });\n';
+  fs.writeFileSync(this.script, script, {mode: parseInt('777', 8)});
+}
+
+VerifyNodeGyp.prototype.setOptions = function(options) {
+  options.env['npm_config_node_gyp'] = this.script;
+};
+
+VerifyNodeGyp.prototype.wasCalled = function() {
+  return fs.existsSync(this.marker);
+};
+
+module.exports = VerifyNodeGyp;

--- a/test/fixtures/custom-lookup-verify-node-gyp.json
+++ b/test/fixtures/custom-lookup-verify-node-gyp.json
@@ -1,0 +1,8 @@
+{
+    "omg-i-pass": {
+        "verify-node-gyp-called": true
+    },
+    "omg-i-pass-too": {
+        "verify-node-gyp-not-called": true
+    }
+}

--- a/test/fixtures/fakenodegyp/fakenodegyp.js
+++ b/test/fixtures/fakenodegyp/fakenodegyp.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+process.exit(0);

--- a/test/fixtures/omg-i-have-binding-gyp/package.json
+++ b/test/fixtures/omg-i-have-binding-gyp/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "omg-i-have-binding-gyp",
+  "version": "1.0.0",
+  "description": "Test package for CITGM test suite",
+  "main": "index.js",
+  "scripts": {
+    "test": "exit 0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bzoz/omg-i-have-binding-gyp.git"
+  },
+  "author": "Bartosz Sosnowski",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/bzoz/omg-i-have-binding-gyp/issues"
+  },
+  "homepage": "https://github.com/bzoz/omg-i-have-binding-gyp#readme",
+  "gypfile": true
+}

--- a/test/npm/test-npm-install.js
+++ b/test/npm/test-npm-install.js
@@ -16,9 +16,12 @@ var moduleFixtures = path.join(fixtures, 'omg-i-pass');
 var moduleTemp = path.join(sandbox, 'omg-i-pass');
 var badFixtures = path.join(fixtures, 'omg-bad-tree');
 var badTemp = path.join(sandbox, 'omg-bad-tree');
+var nodeGypFixtures = path.join(fixtures, 'omg-i-have-binding-gyp');
+var nodeGypTemp = path.join(sandbox, 'omg-i-have-binding-gyp');
+var fakeNodeGypJs = path.join(fixtures, 'fakenodegyp', 'fakenodegyp.js');
 
 test('npm-install: setup', function (t) {
-  t.plan(5);
+  t.plan(7);
   mkdirp(sandbox, function (err) {
     t.error(err);
     ncp(moduleFixtures, moduleTemp, function (e) {
@@ -28,6 +31,10 @@ test('npm-install: setup', function (t) {
     ncp(badFixtures, badTemp, function (e) {
       t.error(e);
       t.ok(fs.existsSync(path.join(badTemp, 'package.json')));
+    });
+    ncp(nodeGypFixtures, nodeGypTemp, function (e) {
+      t.error(e);
+      t.ok(fs.existsSync(path.join(nodeGypTemp, 'package.json')));
     });
   });
 });
@@ -101,6 +108,88 @@ test('npm-install: failed install', function (t) {
   };
   npmInstall(context, function (err) {
     t.equals(err && err.message, 'Install Failed');
+    t.end();
+  });
+});
+
+test('npm-install: verify-node-gyp-not-called passes if not called', function(t) {
+  var context = {
+    emit: function() {},
+    path: sandbox,
+    module: {
+      name: 'omg-i-pass',
+      verifyNodeGyp: true,
+      verifyNodeGypNotCalled: true
+    },
+    meta: {},
+    options: {
+      npmLevel: 'silly'
+    }
+  };
+  npmInstall(context, function (err) {
+    t.error(err);
+    t.end();
+  });
+});
+
+test('npm-install: verify-node-gyp-not-called fails if called', function(t) {
+  var context = {
+    emit: function() {},
+    path: sandbox,
+    module: {
+      name: 'omg-i-have-binding-gyp',
+      verifyNodeGyp: true,
+      verifyNodeGypNotCalled: true
+    },
+    meta: {},
+    options: {
+      npmLevel: 'silly'
+    }
+  };
+  process.env['npm_config_node_gyp'] =  fakeNodeGypJs;
+  npmInstall(context, function (err) {
+    t.equals(err && err.message, 'node-gyp was called');
+    t.end();
+  });
+});
+
+test('npm-install: verify-node-gyp-called passes if called', function(t) {
+  var context = {
+    emit: function() {},
+    path: sandbox,
+    module: {
+      name: 'omg-i-have-binding-gyp',
+      verifyNodeGyp: true,
+      verifyNodeGypCalled: true
+    },
+    meta: {},
+    options: {
+      npmLevel: 'silly'
+    }
+  };
+  process.env['npm_config_node_gyp'] =  fakeNodeGypJs;
+  npmInstall(context, function (err) {
+    t.error(err);
+    t.end();
+  });
+});
+
+test('npm-install: verify-node-gyp-called fails if not called', function(t) {
+  var context = {
+    emit: function() {},
+    path: sandbox,
+    module: {
+      name: 'omg-i-pass',
+      verifyNodeGyp: true,
+      verifyNodeGypCalled: true
+    },
+    meta: {},
+    options: {
+      npmLevel: 'silly'
+    }
+  };
+  npmInstall(context, function (err) {
+    t.equals(err && err.message, 'node-gyp was not called');
     t.end();
   });
 });

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -232,3 +232,51 @@ test('lookup: ensure lookup works', function (t) {
   t.ok(lookup, 'the lookup table should exist');
   t.end();
 });
+
+test('lookup: lookup with verify-node-gyp-called', function (t) {
+  var context = {
+    module: {
+      name: 'omg-i-pass',
+      raw: null
+    },
+    meta: {
+      repository: '/dev/null',
+      version: '0.1.1'
+    },
+    options: {
+      lookup: 'test/fixtures/custom-lookup-verify-node-gyp.json'
+    },
+    emit: function () {}
+  };
+
+  lookup(context, function (err) {
+    t.error(err);
+    t.ok(context.module.verifyNodeGyp, 'verifyNodeGyp set to true');
+    t.ok(context.module.verifyNodeGypCalled, 'verifyNodeGypCalled set to true');
+    t.end();
+  });
+});
+
+test('lookup: lookup with verify-node-gyp-not-called', function (t) {
+  var context = {
+    module: {
+      name: 'omg-i-pass-too',
+      raw: null
+    },
+    meta: {
+      repository: '/dev/null',
+      version: '0.1.1'
+    },
+    options: {
+      lookup: 'test/fixtures/custom-lookup-verify-node-gyp.json'
+    },
+    emit: function () {}
+  };
+
+  lookup(context, function (err) {
+    t.error(err);
+    t.ok(context.module.verifyNodeGyp, 'verifyNodeGyp set to true');
+    t.ok(context.module.verifyNodeGypNotCalled, 'verifyNodeGypNotCalled set to true');
+    t.end();
+  });
+});


### PR DESCRIPTION
This adds testing if `node-gyp`  was called by `npm`. It uses `npm_config_node_gyp` environment variable  to inject our version of `node-gyp` script to detect if it was called with either `'build'` or `'rebuild'` parameter.