### PR TITLE
reporter: remove escape characters

### DIFF
--- a/lib/reporter/util.js
+++ b/lib/reporter/util.js
@@ -34,7 +34,25 @@ function hasFailures(modules) {
 
 function sanitizeOutput(output, delimiter, xml) {
   if (!output || output === '') return '';
-  return _(output.split(/[\r\n]+/)).filter(function (item) {
+  /* eslint-disable no-control-regex */
+  // ([valid-range])|. matches anything but only captures valid-range
+  const validUtf8 = new RegExp('(' + [
+    /[\x09\x0A\x0D\x20-\x7E]/, // ASCII
+    /[\xC2-\xDF][\x80-\xBF]/, // Non-overlong 2-byte
+    /\xE0[\xA0-\xBF][\x80-\xBF]/, // Excluding overlongs
+    /[\xE1-\xEC\xEE\xEF][\x80-\xBF]{2}/, // Straight 3-byte
+    /\xED[\x80-\x9F][\x80-\xBF]/, // Excluding surrogates
+    /\xF0[\x90-\xBF][\x80-\xBF]{2}/, // Planes 1-3
+    /[\xF1-\xF3][\x80-\xBF]{3}/, // Planes 4-15
+    /\xF4[\x80-\x8F][\x80-\xBF]{2}/ // Plane 16
+  ].map(function(r) {
+    return r.source;
+  }).join('|') + ')|.', 'g');
+  /* eslint-enable no-control-regex */
+  // $1 matches the valid-range char if captured, or '' otherwise
+  // So this removes all invalid UTF-8
+  return _(output.replace(validUtf8, '$1').split(/[\r\n]+/)).filter(
+  function (item) {
     return item.length && item !== '\n' && item !== 'undefined';
   }).map(function (item) {
     if (xml) item = xmlSanitizer(item);

--- a/test/fixtures/CR-raw.txt
+++ b/test/fixtures/CR-raw.txt
@@ -1,5 +1,5 @@
   Route
-    ✓ should work without handlers
+ # this line contains escape characters    ✓ should work without handlers
     .all
       ✓ should add handler
       ✓ should handle VERBS

--- a/test/fixtures/CR-sanitized.txt
+++ b/test/fixtures/CR-sanitized.txt
@@ -1,6 +1,7 @@
 #   Route
-#     ✓ should work without handlers
+#  # this line contains escape characters
+#      should work without handlers
 #     .all
-#       ✓ should add handler
-#       ✓ should handle VERBS
-#       ✓ should stack
+#        should add handler
+#        should handle VERBS
+#        should stack

--- a/test/reporter/test-reporter-util.js
+++ b/test/reporter/test-reporter-util.js
@@ -94,7 +94,9 @@ test('util.sanitizeOutput', function (t) {
   // Var result = util.sanitizeOutput();
   const raw = fs.readFileSync(carriageReturnPath, 'utf-8');
   const expected = fs.readFileSync(carriageReturnExpectedPath, 'utf-8');
-  const result = util.sanitizeOutput(raw, '#');
-  t.equals(result, expected, 'there should be a # on every line');
+  let result = util.sanitizeOutput(raw, '#');
+  result += '\n';
+  t.equals(result, expected, 'there should be a # on every line & escape char' +
+  'should be removed');
   t.end();
 });


### PR DESCRIPTION
fixes https://github.com/nodejs/citgm/issues/251, currently we are seeing issues with certain modules outputting escape characters and breaking the jenkins tap-parser. This PR fixes this problem by replacing any instance of `\033` with a space.