### PR TITLE
travis: add osx to travis runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+os:
+  - linux
+  - osx
 node_js:
   - "7"
   - "6"


### PR DESCRIPTION
We should run our travis tests on osx as well as linux