### PR TITLE
bin: fix tap / junit output without string

### DIFF
--- a/bin/citgm.js
+++ b/bin/citgm.js
@@ -92,14 +92,13 @@ function launch(mod, options) {
     if (app.markdown) {
       reporter.markdown(log.bypass, module);
     }
-
-    if (typeof app.tap === 'string') {
-      var tap = (app.tap) ? app.tap : log.bypass;
+    if (app.tap) {
+      var tap = (typeof app.tap === 'string') ? app.tap : log.bypass;
       reporter.tap(tap, module, app.append);
     }
 
-    if (typeof app.junit === 'string') {
-      var junit = (app.junit) ? app.junit : log.bypass;
+    if (app.junit) {
+      var junit = (typeof app.junit === 'string') ? app.junit : log.bypass;
       reporter.junit(junit, module, app.append);
     }
 

--- a/lib/common-args.js
+++ b/lib/common-args.js
@@ -58,12 +58,10 @@ module.exports = function commonArgs (app) {
   })
   .option('tap', {
     alias: 't',
-    type: 'string',
     description: 'Output results in tap with optional file path'
   })
   .option('junit', {
     alias: 'x',
-    type: 'string',
     description: 'Output results in junit xml with optional file path'
   })
   .option('timeout', {

--- a/test/bin/test-citgm-all.js
+++ b/test/bin/test-citgm-all.js
@@ -50,9 +50,9 @@ test('citgm-all: /w bad lookup.json', function (t) {
   });
 });
 
-test('citgm-all: fail /w tap /w junit /w append', function (t) {
+test('citgm-all: fail /w tap /w junit', function (t) {
   t.plan(1);
-  var proc = spawn(citgmAllPath, ['-l', 'test/fixtures/custom-lookup-fail.json', '-t', '-x', '-a']);
+  var proc = spawn(citgmAllPath, ['-l', 'test/fixtures/custom-lookup-fail.json', '-t', '-x']);
   proc.on('error', function(err) {
     t.error(err);
   });
@@ -83,9 +83,9 @@ test('citgm-all: flaky-fail ignoring flakyness', function (t) {
   });
 });
 
-test('citgm-all: skip /w rootcheck /w tap to fs /w junit to fs', function (t) {
+test('citgm-all: skip /w rootcheck /w tap to fs /w junit to fs /w append', function (t) {
   t.plan(1);
-  var proc = spawn(citgmAllPath, ['-l', 'test/fixtures/custom-lookup-skip.json', '-s', '--tap', '/dev/null', '--junit', '/dev/null']);
+  var proc = spawn(citgmAllPath, ['-l', 'test/fixtures/custom-lookup-skip.json', '-s', '--tap', '/dev/null', '--junit', '/dev/null', '-a']);
   proc.on('error', function(err) {
     t.error(err);
   });

--- a/test/fixtures/omg-i-pass/package.json
+++ b/test/fixtures/omg-i-pass/package.json
@@ -2,15 +2,19 @@
   "name": "omg-i-pass",
   "version": "2.0.1",
   "description": "Test suite always passes",
-  "repository": "https://github.com/TheAlphaNerd/omg-i-pass",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TheAlphaNerd/omg-i-pass.git"
+  },
   "main": "index.js",
   "scripts": {
-    "test": "exit 0"
+    "test": "exit 0",
+    "install": "exit 0"
   },
   "keywords": [
     "always",
     "passes"
   ],
-  "author": "",
+  "author": "Myles Borins",
   "license": "MIT"
 }


### PR DESCRIPTION
Regression was found while going through coverage. After the switch to
yargs we broke printing tap and junit to stdout.