### PR TITLE
lookup: add thread-sleep to lookup.json

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -343,5 +343,9 @@
   "microtime": {
     "replace": true,
     "prefix": "v"
+  },
+  "thread-sleep": {
+    "replace": true,
+    "install": ["--build-from-source"]
   }
 }


### PR DESCRIPTION
Popular native module. See https://github.com/nodejs/citgm/issues/268