### PR TITLE
lookup: fix logging

### DIFF
--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -64,7 +64,7 @@ function resolve(context, next) {
     return;
   }
   var detail = context.module;
-  context.emit('info','lookup',detail.name);
+  context.emit('data','info','lookup',detail.name);
   var meta = context.meta;
   if (meta) {
     var rep = lookup[detail.name];
@@ -81,27 +81,27 @@ function resolve(context, next) {
           next(new Error('no-repository-field in package.json'));
           return;
         }
-        context.emit('info','lookup-found',detail.name);
+        context.emit('data','info','lookup-found',detail.name);
         var url = makeUrl(
           getRepo(rep.repo, meta),
           rep.master ? null : detail.spec,
           meta['dist-tags'],
           rep.master ? null : rep.prefix,
           context.options.sha || rep.sha);
-        context.emit('info','lookup-replace',url);
+        context.emit('data','info','lookup-replace',url);
         context.module.raw = url;
       }
       if (rep.install) {
-        context.emit('verbose', 'lookup-install', rep.install);
+        context.emit('data','verbose', 'lookup-install', rep.install);
         context.module.install = rep.install;
       }
       if (rep.script) {
-        context.emit('info','lookup-script',rep.script);
+        context.emit('data','info','lookup-script',rep.script);
         context.module.script = rep.script;
       }
       context.module.flaky = context.options.failFlaky ? false : isMatch(rep.flaky);
     } else {
-      context.emit('info','lookup-notfound',detail.name);
+      context.emit('data','info','lookup-notfound',detail.name);
     }
   }
 

--- a/test/fixtures/custom-lookup-log.json
+++ b/test/fixtures/custom-lookup-log.json
@@ -1,0 +1,9 @@
+{
+  "omg-i-pass": {
+    "install": ["--extra-param"],
+    "master": true,
+    "replace": true,
+    "repo": "https://github.com/nodejs/citgm",
+    "script": "./example-test-script-passing.sh"
+  }
+}

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -258,3 +258,40 @@ test('lookup: lookup with install', function (t) {
     t.end();
   });
 });
+
+test('lookup: logging', function (t) {
+  var expectedLogMsgs = [
+    { type: 'info', key: 'lookup', msg: 'omg-i-pass' },
+    { type: 'info', key: 'lookup-found', msg: 'omg-i-pass' },
+    { type: 'info',
+      key: 'lookup-replace',
+      msg: 'https://github.com/nodejs/citgm/archive/master.tar.gz' },
+    { type: 'verbose',
+      key: 'lookup-install',
+      msg: [ '--extra-param' ] },
+    { type: 'info',
+      key: 'lookup-script',
+      msg: './example-test-script-passing.sh' }
+  ];
+  var EventEmitter = require('events').EventEmitter;
+  var context = new EventEmitter();
+  var log = [];
+  context.meta = {
+    repository: '/dev/null',
+    version: '0.1.1'
+  };
+  context.module = {
+    name: 'omg-i-pass'
+  };
+  context.options = {
+    lookup: 'test/fixtures/custom-lookup-log.json'
+  };
+  context.on('data', function (type, key, msg) {
+    log.push({ type: type, key: key, msg: msg });
+  });
+  lookup(context, function () {
+    t.plan(1);
+    t.strictSame(log, expectedLogMsgs);
+    t.end();
+  });
+});


### PR DESCRIPTION
Add missing event name to `context.emit` calls. Without the event name passed in, citgm fails to log any of the messages from `lib/lookup.js`

e.g. before
```
-bash-4.2$ citgm-all -v info -l ./lookup.json
info:    starting            | nodereport
info:    npm:                | Downloading project: https://github.com/richardlau/nod
info:    npm:                | Project downloaded nodereport-1.0.7.tgz
info:    npm:                | install started
info:    npm:                | install successfully completed
info:    npm:                | test suite started
info:    duration            | test duration: 27565ms
info:    done                | The test suite for nodereport version 1.0.7 passed.
info:    passing module(s)   |
info:    module name:        | nodereport
info:    version:            | 1.0.7
info:    done                | The smoke test has passed.
-bash-4.2$
```

after (note `lookup`, `lookup-found` and `lookup-replace` messages)
```
-bash-4.2$ citgm-all -v info -l ./lookup.json
info:    starting            | nodereport
info:    lookup              | nodereport
info:    lookup-found        | nodereport
info:    lookup-replace      | https://github.com/richardlau/nodereport/archive/build
info:    npm:                | Downloading project: https://github.com/richardlau/nod
info:    npm:                | Project downloaded nodereport-1.0.7.tgz
info:    npm:                | install started
info:    npm:                | install successfully completed
info:    npm:                | test suite started
info:    duration            | test duration: 28013ms
info:    done                | The test suite for nodereport version 1.0.7 passed.
info:    passing module(s)   |
info:    module name:        | nodereport
info:    version:            | 1.0.7
info:    done                | The smoke test has passed.
-bash-4.2$
```
