### PR TITLE
lookup: add verify-node-gyp

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,15 @@ For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
 "install": ["--param1", "--param2"] - Array of extra command line parameters passed to 'npm install'
 "maintainers": ["user1", "user2"] - List of module maintainers to be contacted with issues
 "tags": ["tag1", "tag2"]     Specify which tags apply to the module
+"verify-node-gyp": "called" | "not called" - If set will check if npm called (or not) node-gyp with 
+                                             either 'build' or 'rebuild'
 ```
+
+When using `verify-node-gyp` CITGM will set `npm_config_node_gyp` environment
+variable to its `node-gyp` script, and `citgm_node_gyp_bin_filename` to the
+location of the real `node-gyp binary`. Provided script is used to detect if
+`node-gyp` was called with either `build` or `rebuild` and will run real
+`node-gyp` in the process.
 
 If you want to pass options to npm, eg `--registry`, you can usually define an
 environment variable, eg `"npm_config_registry": "https://www.xyz.com"`.

--- a/lib/citgm-node-gyp.js
+++ b/lib/citgm-node-gyp.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+'use strict';
+
+const child_process = require('child_process');
+
+const node_gyp_filename = process.env['citgm_node_gyp_bin_filename'];
+if (!node_gyp_filename) {
+  process.exit(1);
+}
+
+const args = process.argv.slice(1);
+if (args.indexOf('build') !== -1 || args.indexOf('rebuild') !== -1) {
+  console.log('citgm-verify-node-gyp-called: node-gyp was called!');
+}
+
+delete process.env['npm_config_node_gyp'];
+child_process.spawn(process.execPath, [node_gyp_filename].concat(args))
+  .on('close', function(code) {
+    process.exit(code);
+  });

--- a/lib/create-options.js
+++ b/lib/create-options.js
@@ -1,5 +1,6 @@
 'use strict';
 const _ = require('lodash');
+const path = require('path');
 
 function createOptions(cwd, context) {
   const options = {
@@ -18,6 +19,22 @@ function createOptions(cwd, context) {
       options.env[key] = val;
     });
   }
+
+  if (context.module && context.module.verifyNodeGyp !== undefined) {
+    if (process.env['npm_config_node_gyp']) {
+      options.env['citgm_node_gyp_bin_filename'] =
+        process.env['npm_config_node_gyp'];
+    } else {
+      options.env['citgm_node_gyp_bin_filename'] = path.join(__dirname, '..',
+                                                             'node_modules',
+                                                             'node-gyp',
+                                                             'bin',
+                                                             'node-gyp.js');
+    }
+    options.env['npm_config_node_gyp'] = path.join(__dirname,
+                                                   'citgm-node-gyp.js');
+  }
+
   return options;
 }
 

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -108,6 +108,16 @@ function resolve(context, next) {
           false : isMatch(rep.flaky);
       context.module.expectFail = context.options.expectFail ?
           false : isMatch(rep.expectFail);
+      if (rep['verify-node-gyp']) {
+        if (rep['verify-node-gyp'] === 'called') {
+          context.module.verifyNodeGyp = true;
+        } else if (rep['verify-node-gyp'] === 'not called') {
+          context.module.verifyNodeGyp = false;
+        } else {
+          next(new Error('unsupported verify-node-gyp value in package.json'));
+          return;
+        }
+      }
     } else {
       context.emit('data', 'info', 'lookup-notfound', detail.name);
     }

--- a/lib/npm/install.js
+++ b/lib/npm/install.js
@@ -87,6 +87,16 @@ function install(context, next) {
       context.testError = installError || '';
       return next(Error('Install Failed'));
     }
+    if (context.module.verifyNodeGyp !== undefined) {
+      const calledText = 'citgm-verify-node-gyp-called: node-gyp was called!';
+      const nodeGypCalled = installOutput.indexOf(calledText) !== -1;
+      if (context.module.verifyNodeGyp && !nodeGypCalled) {
+        return next(Error('node-gyp was not used to build module'));
+      }
+      if (!context.module.verifyNodeGyp && nodeGypCalled) {
+        return next(Error('node-gyp was used to build module'));
+      }
+    }
     context.emit('data', 'info', context.module.name + ' npm:',
         'npm install successfully completed');
     return next(null, context);

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "columnify": "^1.5.1",
     "lodash": "^4.12.0",
     "mkdirp": "^0.5.1",
+    "node-gyp": "~3.4.0",
     "normalize-git-url": "^3.0.2",
     "npm-package-arg": "^4.1.1",
     "osenv": "^0.1.3",

--- a/test/fixtures/custom-lookup-verify-node-gyp.json
+++ b/test/fixtures/custom-lookup-verify-node-gyp.json
@@ -1,0 +1,17 @@
+{
+  "omg-i-pass": {
+    "verify-node-gyp": "called",
+    "npm": true
+  },
+  "omg-i-pass-too": {
+    "verify-node-gyp": "not called",
+    "npm": true
+  },
+  "omg-i-fail": {
+    "verify-node-gyp": "wrong value",
+    "npm": true
+  },
+  "omg-i-have-binding-gyp": {
+    "npm": true
+  }
+}

--- a/test/fixtures/fakenodegyp/fakenodegyp.js
+++ b/test/fixtures/fakenodegyp/fakenodegyp.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+'use strict';
+
+process.exit(0);

--- a/test/fixtures/omg-i-have-binding-gyp/package.json
+++ b/test/fixtures/omg-i-have-binding-gyp/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "omg-i-have-binding-gyp",
+  "version": "1.0.0",
+  "description": "Test package for CITGM test suite",
+  "main": "index.js",
+  "scripts": {
+    "test": "exit 0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bzoz/omg-i-have-binding-gyp.git"
+  },
+  "author": "Bartosz Sosnowski",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/bzoz/omg-i-have-binding-gyp/issues"
+  },
+  "homepage": "https://github.com/bzoz/omg-i-have-binding-gyp#readme",
+  "gypfile": true
+}

--- a/test/npm/test-npm-install.js
+++ b/test/npm/test-npm-install.js
@@ -18,9 +18,12 @@ const extraParamFixtures = path.join(fixtures, 'omg-i-pass-with-install-param');
 const extraParamTemp = path.join(sandbox, 'omg-i-pass-with-install-param');
 const badFixtures = path.join(fixtures, 'omg-bad-tree');
 const badTemp = path.join(sandbox, 'omg-bad-tree');
+const nodeGypFixtures = path.join(fixtures, 'omg-i-have-binding-gyp');
+const nodeGypTemp = path.join(sandbox, 'omg-i-have-binding-gyp');
+const fakeNodeGypJs = path.join(fixtures, 'fakenodegyp', 'fakenodegyp.js');
 
 test('npm-install: setup', function (t) {
-  t.plan(7);
+  t.plan(9);
   mkdirp(sandbox, function (err) {
     t.error(err);
     ncp(moduleFixtures, moduleTemp, function (e) {
@@ -34,6 +37,10 @@ test('npm-install: setup', function (t) {
     ncp(badFixtures, badTemp, function (e) {
       t.error(e);
       t.ok(fs.existsSync(path.join(badTemp, 'package.json')));
+    });
+    ncp(nodeGypFixtures, nodeGypTemp, function (e) {
+      t.error(e);
+      t.ok(fs.existsSync(path.join(nodeGypTemp, 'package.json')));
     });
   });
 });
@@ -133,6 +140,84 @@ test('npm-install: failed install', function (t) {
   npmInstall(context, function (err) {
     t.equals(err && err.message, 'Install Failed');
     t.match(context, expected, 'Install error reported');
+    t.end();
+  });
+});
+
+test('npm-install: verify-node-gyp:not called ok if not called', function(t) {
+  const context = {
+    emit: function() {},
+    path: sandbox,
+    module: {
+      name: 'omg-i-pass',
+      verifyNodeGyp: false
+    },
+    meta: {},
+    options: {
+      npmLevel: 'silly'
+    }
+  };
+  npmInstall(context, function (err) {
+    t.error(err);
+    t.end();
+  });
+});
+
+test('npm-install: verify-node-gyp:not called fails if called', function(t) {
+  const context = {
+    emit: function() {},
+    path: sandbox,
+    module: {
+      name: 'omg-i-have-binding-gyp',
+      verifyNodeGyp: false
+    },
+    meta: {},
+    options: {
+      npmLevel: 'silly'
+    }
+  };
+  process.env['npm_config_node_gyp'] = fakeNodeGypJs;
+  npmInstall(context, function (err) {
+    t.equals(err && err.message, 'node-gyp was used to build module');
+    t.end();
+  });
+});
+
+test('npm-install: verify-node-gyp:called passes if called', function(t) {
+  const context = {
+    emit: function() {},
+    path: sandbox,
+    module: {
+      name: 'omg-i-have-binding-gyp',
+      verifyNodeGyp: true
+    },
+    meta: {},
+    options: {
+      npmLevel: 'silly'
+    }
+  };
+  process.env['npm_config_node_gyp'] = fakeNodeGypJs;
+  npmInstall(context, function (err) {
+    t.error(err);
+    t.end();
+  });
+});
+
+test('npm-install: verify-node-gyp:called fails if not called', function(t) {
+  const context = {
+    emit: function() {},
+    path: sandbox,
+    module: {
+      name: 'omg-i-pass',
+      verifyNodeGyp: true
+    },
+    meta: {},
+    options: {
+      npmLevel: 'silly'
+    }
+  };
+  npmInstall(context, function (err) {
+    t.equals(err && err.message, 'node-gyp was not used to build module');
     t.end();
   });
 });

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -274,3 +274,96 @@ test('lookup: logging', function (t) {
     t.end();
   });
 });
+
+test('lookup: lookup with verify-node-gyp:called', function (t) {
+  const context = {
+    module: {
+      name: 'omg-i-pass',
+      raw: null
+    },
+    meta: {
+      repository: '/dev/null',
+      version: '0.1.1'
+    },
+    options: {
+      lookup: 'test/fixtures/custom-lookup-verify-node-gyp.json'
+    },
+    emit: function () {}
+  };
+
+  lookup(context, function (err) {
+    t.error(err);
+    t.equal(context.module.verifyNodeGyp, true, 'verifyNodeGyp set to true');
+    t.end();
+  });
+});
+
+test('lookup: lookup with verify-node-gyp:not called', function (t) {
+  const context = {
+    module: {
+      name: 'omg-i-pass-too',
+      raw: null
+    },
+    meta: {
+      repository: '/dev/null',
+      version: '0.1.1'
+    },
+    options: {
+      lookup: 'test/fixtures/custom-lookup-verify-node-gyp.json'
+    },
+    emit: function () {}
+  };
+
+  lookup(context, function (err) {
+    t.error(err);
+    t.equal(context.module.verifyNodeGyp, false, 'verifyNodeGyp set to false');
+    t.end();
+  });
+});
+
+test('lookup: lookup with verify-node-gyp: unsupported value', function (t) {
+  const context = {
+    module: {
+      name: 'omg-i-fail',
+      raw: null
+    },
+    meta: {
+      repository: '/dev/null',
+      version: '0.1.1'
+    },
+    options: {
+      lookup: 'test/fixtures/custom-lookup-verify-node-gyp.json'
+    },
+    emit: function () {}
+  };
+
+  lookup(context, function (err) {
+    t.equals(err && err.message,
+      'unsupported verify-node-gyp value in package.json');
+    t.end();
+  });
+});
+
+test('lookup: lookup with verify-node-gyp:not set', function (t) {
+  const context = {
+    module: {
+      name: 'omg-i-have-binding-gyp',
+      raw: null
+    },
+    meta: {
+      repository: '/dev/null',
+      version: '0.1.1'
+    },
+    options: {
+      lookup: 'test/fixtures/custom-lookup-verify-node-gyp.json'
+    },
+    emit: function () {}
+  };
+
+  lookup(context, function (err) {
+    t.error(err);
+    t.equal(context.module.verifyNodeGyp, undefined,
+      'verifyNodeGyp set to undefined');
+    t.end();
+  });
+});


### PR DESCRIPTION
Continued from https://github.com/nodejs/citgm/pull/252:

This adds testing if `node-gyp`  was called by `npm`. It uses `npm_config_node_gyp` environment variable  to inject our version of `node-gyp` script to detect if it was called with either `'build'` or `'rebuild'` parameter.