### PR TITLE
linter: force `===` and `!==`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,10 @@
       "single"
     ],
     no-trailing-spaces: 2,
+    eqeqeq: [
+      "error",
+      "always"
+    ],
     "linebreak-style": [
       2,
       "unix"

--- a/lib/grab-module-data.js
+++ b/lib/grab-module-data.js
@@ -21,8 +21,8 @@ function grabModuleData(context, next) {
   proc.on('close', function(code) {
     if (code > 0) {
       context.emit('data', 'silly','npm-view','No npm package information available');
-      if (context.module.type == 'hosted' &&
-          context.module.hosted.type == 'github') {
+      if (context.module.type === 'hosted' &&
+          context.module.hosted.type === 'github') {
         context.meta = {
           repository : {
             type: 'git',


### PR DESCRIPTION
Currently we are not enforcing the use of `===` and `!==` in our linter, we should add this rule