### PR TITLE
chore: .eslint now proper json

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,8 +8,8 @@
       2,
       "single"
     ],
-    no-trailing-spaces: 2,
-    eqeqeq: [
+    "no-trailing-spaces": 2,
+    "eqeqeq": [
       "error",
       "always"
     ],


### PR DESCRIPTION
proper json has quotes.

eslint doesn't care, and even supports comments and other wacky things... but we should be consistent