### PR TITLE
lookup: mark failing CI modules as flaky

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -96,7 +96,7 @@
   "watchify": {
     "replace": true,
     "prefix": "v",
-    "flaky": ["ppc", "v7"]
+    "flaky": ["ppc", "v7", "s390"]
   },
   "stylus": {
     "replace": true
@@ -129,7 +129,8 @@
     "flaky": true
   },
   "ws": {
-    "replace": true
+    "replace": true,
+    "flaky": "s390"
   },
   "vinyl": {
     "replace": true,


### PR DESCRIPTION
these modules are currently failing in the community ci:
https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/nodes=rhel72-s390x/482/testReport/