### PR TITLE
Revert "lookup: skip pug until published version fixed"

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -48,8 +48,7 @@
     "replace": true,
     "flaky": {
       "ppc": ["v6", "v7"]
-    },
-    "skip": true
+    }
   },
   "socket.io": {
     "replace": true,


### PR DESCRIPTION
This reverts commit d4ed829891bc73f1a954560892239a5164d61349.