### PR TITLE
lib: use bl to store npm output

### DIFF
--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -4,6 +4,7 @@ const util = require('util');
 
 const async = require('async');
 const npa = require('npm-package-arg');
+const BufferList = require('bl');
 let which = require('which'); // Mocked in tests
 
 const grabModuleData = require('./grab-module-data');
@@ -85,8 +86,8 @@ function Tester(mod, options) {
   EventEmitter.call(this);
   this.module = extractDetail(mod);
   this.options = options;
-  this.testOutput = '';
-  this.testError = '';
+  this.testOutput = new BufferList();
+  this.testError = new BufferList();
   this.cleanexit = false;
 }
 
@@ -122,10 +123,10 @@ Tester.prototype.run = function() {
         payload.error = 'this module should have failed';
       }
       if (this.testOutput !== '') {
-        payload.testOutput += this.testOutput + '\n';
+        payload.testOutput += this.testOutput.toString() + '\n';
       }
       if (this.testError !== '') {
-        payload.testOutput += this.testError + '\n';
+        payload.testOutput += this.testError.toString() + '\n';
       }
       tempDirectory.remove(this, () => {
         this.emit('end', payload);

--- a/lib/npm/install.js
+++ b/lib/npm/install.js
@@ -48,34 +48,29 @@ function install(context, next) {
     return next(Error('Install Timed Out'));
   }
 
-  let installOutput = '';
-  let installError = '';
-
   proc.stderr.on('data', function (chunk) {
+    context.testError.append(chunk);
     if (context.module.stripAnsi) {
       chunk = stripAnsi(chunk.toString());
       chunk = chunk.replace(/\r/g, '\n');
     }
     context.emit('data', 'warn', context.module.name + ' npm-install:',
-        chunk.toString());
-    installError += chunk;
+      chunk.toString());
   });
 
   proc.stdout.on('data', function (chunk) {
+    context.testOutput.append(chunk);
     if (context.module.stripAnsi) {
       chunk = stripAnsi(chunk.toString());
       chunk = chunk.replace(/\r/g, '\n');
     }
     context.emit('data', 'verbose', context.module.name + ' npm-install:',
-        chunk.toString());
-    installOutput += chunk;
+      chunk.toString());
   });
 
   proc.on('error', function() {
     bailed = true;
     clearTimeout(timeout);
-    context.testOutput = installOutput || '';
-    context.testError = installError || '';
     return next(new Error('Install Failed'));
   });
 
@@ -83,8 +78,6 @@ function install(context, next) {
     if (bailed) return;
     clearTimeout(timeout);
     if (code > 0) {
-      context.testOutput = installOutput || '';
-      context.testError = installError || '';
       return next(Error('Install Failed'));
     }
     context.emit('data', 'info', context.module.name + ' npm:',

--- a/lib/npm/test.js
+++ b/lib/npm/test.js
@@ -57,16 +57,16 @@ function test(context, next) {
     const proc = spawn(nodeBin, [npmBin, 'test', '--loglevel=' +
         context.options.npmLevel], options);
     proc.stdout.on('data', function (data) {
+      context.testOutput.append(data);
       if (context.module.stripAnsi) {
         data = stripAnsi(data.toString());
         data = data.replace(/\r/g, '\n');
       }
-      context.testOutput += data;
       context.emit('data', 'verbose', context.module.name + ' npm-test:',
           data.toString());
     });
     proc.stderr.on('data', function (data) {
-      context.testError += data;
+      context.testError.append(data);
       context.emit('data', 'verbose', context.module.name + ' npm-test:',
           data.toString());
     });

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "^2.1.2",
+    "bl": "^1.2.0",
     "chalk": "^1.1.3",
     "columnify": "^1.5.1",
     "lodash": "^4.12.0",

--- a/test/helpers/make-context.js
+++ b/test/helpers/make-context.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const BufferList = require('bl');
+
+function npmContext(mod, path, options) {
+  if (typeof mod === 'string') {
+    mod = {
+      name: mod
+    };
+  }
+  if (!options) options = {};
+  const context = {
+    emit: function() {},
+    path: path,
+    module: mod,
+    testOutput: new BufferList(),
+    testError: new BufferList(),
+    meta: {},
+    options: options
+  };
+  return context;
+}
+
+module.exports = {
+  npmContext: npmContext
+};

--- a/test/npm/test-npm-install.js
+++ b/test/npm/test-npm-install.js
@@ -9,6 +9,7 @@ const rimraf = require('rimraf');
 const ncp = require('ncp');
 
 const npmInstall = require('../../lib/npm/install');
+const makeContext = require('../helpers/make-context');
 
 const sandbox = path.join(os.tmpdir(), 'citgm-' + Date.now());
 const fixtures = path.join(__dirname, '..', 'fixtures');
@@ -39,17 +40,9 @@ test('npm-install: setup', function (t) {
 });
 
 test('npm-install: basic module', function (t) {
-  const context = {
-    emit: function() {},
-    path: sandbox,
-    module: {
-      name: 'omg-i-pass'
-    },
-    meta: {},
-    options: {
-      npmLevel: 'silly'
-    }
-  };
+  const context = makeContext.npmContext('omg-i-pass', sandbox, {
+    npmLevel: 'silly'
+  });
   npmInstall(context, function (err) {
     t.error(err);
     t.end();
@@ -57,18 +50,12 @@ test('npm-install: basic module', function (t) {
 });
 
 test('npm-install: extra install parameters', function (t) {
-  const context = {
-    emit: function() {},
-    path: sandbox,
-    module: {
-      name: 'omg-i-pass-with-install-param',
-      install: ['--extra-param']
-    },
-    meta: {},
-    options: {
-      npmLevel: 'silly'
-    }
-  };
+  const context = makeContext.npmContext({
+    name: 'omg-i-pass-with-install-param',
+    install: ['--extra-param']
+  }, sandbox, {
+    npmLevel: 'silly'
+  });
   npmInstall(context, function (err) {
     t.error(err);
     t.end();
@@ -76,17 +63,9 @@ test('npm-install: extra install parameters', function (t) {
 });
 
 test('npm-install: no package.json', function (t) {
-  const context = {
-    emit: function() {},
-    path: sandbox,
-    module: {
-      name: 'omg-i-fail'
-    },
-    meta: {},
-    options: {
-      npmLevel: 'silly'
-    }
-  };
+  const context = makeContext.npmContext('omg-i-fail', sandbox, {
+    npmLevel: 'silly'
+  });
   npmInstall(context, function (err) {
     t.equals(err && err.message, 'Install Failed');
     t.end();
@@ -94,18 +73,10 @@ test('npm-install: no package.json', function (t) {
 });
 
 test('npm-install: timeout', function (t) {
-  const context = {
-    emit: function() {},
-    path: sandbox,
-    module: {
-      name: 'omg-i-pass'
-    },
-    meta: {},
-    options: {
-      npmLevel: 'silly',
-      timeoutLength: 100
-    }
-  };
+  const context = makeContext.npmContext('omg-i-pass', sandbox, {
+    npmLevel: 'silly',
+    timeoutLength: 100
+  });
   npmInstall(context, function (err) {
     t.equals(err && err.message, 'Install Timed Out');
     t.end();
@@ -113,22 +84,13 @@ test('npm-install: timeout', function (t) {
 });
 
 test('npm-install: failed install', function (t) {
-  const context = {
-    emit: function() {},
-    path: sandbox,
-    module: {
-      name: 'omg-bad-tree'
-    },
-    meta: {},
-    options: {
-      npmLevel: 'http'
-    }
-  };
-
+  const context = makeContext.npmContext('omg-bad-tree', sandbox, {
+    npmLevel: 'http'
+  });
   const expected = {
     testOutput: /^$/,
-    testError: 'npm ERR! 404 Registry returned 404 for GET on'
-    + ' https://registry.npmjs.org/THIS-WILL-FAIL'
+    testError: new RegExp(['npm ERR! 404 Registry returned 404 for GET on',
+      'https://registry.npmjs.org/THIS-WILL-FAIL'].join(' '))
   };
   npmInstall(context, function (err) {
     t.equals(err && err.message, 'Install Failed');

--- a/test/npm/test-npm-test.js
+++ b/test/npm/test-npm-test.js
@@ -9,6 +9,7 @@ const rimraf = require('rimraf');
 const ncp = require('ncp');
 const rewire = require('rewire');
 
+const makeContext = require('../helpers/make-context');
 const npmTest = rewire('../../lib/npm/test');
 
 const sandbox = path.join(os.tmpdir(), 'citgm-' + Date.now());
@@ -43,17 +44,9 @@ test('npm-test: setup', function (t) {
 });
 
 test('npm-test: basic module passing', function (t) {
-  const context = {
-    emit: function() {},
-    path: sandbox,
-    module: {
-      name: 'omg-i-pass'
-    },
-    meta: {},
-    options: {
-      npmLevel: 'silly'
-    }
-  };
+  const context = makeContext.npmContext('omg-i-pass', sandbox, {
+    npmLevel: 'silly'
+  });
   npmTest(context, function (err) {
     t.error(err);
     t.end();
@@ -61,15 +54,7 @@ test('npm-test: basic module passing', function (t) {
 });
 
 test('npm-test: basic module failing', function (t) {
-  const context = {
-    emit: function() {},
-    path: sandbox,
-    module: {
-      name: 'omg-i-fail'
-    },
-    meta: {},
-    options: {}
-  };
+  const context = makeContext.npmContext('omg-i-fail', sandbox);
   npmTest(context, function (err) {
     t.equals(err && err.message, 'The canary is dead:');
     t.end();
@@ -77,15 +62,8 @@ test('npm-test: basic module failing', function (t) {
 });
 
 test('npm-test: basic module no test script', function (t) {
-  const context = {
-    emit: function() {},
-    path: sandbox,
-    module: {
-      name: 'omg-i-do-not-support-testing'
-    },
-    meta: {},
-    options: {}
-  };
+  const context =
+    makeContext.npmContext('omg-i-do-not-support-testing', sandbox);
   npmTest(context, function (err) {
     t.equals(err && err.message, 'Module does not support npm-test!');
     t.end();
@@ -93,15 +71,7 @@ test('npm-test: basic module no test script', function (t) {
 });
 
 test('npm-test: no package.json', function (t) {
-  const context = {
-    emit: function() {},
-    path: sandbox,
-    module: {
-      name: 'omg-i-dont-exist'
-    },
-    meta: {},
-    options: {}
-  };
+  const context = makeContext.npmContext('omg-i-dont-exist', sandbox);
   npmTest(context, function (err) {
     t.equals(err && err.message, 'Package.json Could not be found');
     t.end();
@@ -112,18 +82,10 @@ test('npm-test: alternative test-path', function (t) {
   // Same test as 'basic module passing', except with alt node bin which fails.
   const nodeBinName = npmTest.__get__('nodeBinName');
   npmTest.__set__('nodeBinName', 'fake-node');
-  const context = {
-    emit: function() {},
-    path: sandbox,
-    module: {
-      name: 'omg-i-pass'
-    },
-    meta: {},
-    options: {
-      npmLevel: 'silly',
-      testPath: path.resolve(__dirname, '..', 'fixtures', 'fakenodebin')
-    }
-  };
+  const context = makeContext.npmContext('omg-i-pass', sandbox, {
+    npmLevel: 'silly',
+    testPath: path.resolve(__dirname, '..', 'fixtures', 'fakenodebin')
+  });
   npmTest(context, function (err) {
     npmTest.__set__('nodeBinName', nodeBinName);
     t.equals(err && err.message, 'The canary is dead:');


### PR DESCRIPTION
When we currently run npm in a childprocess we have been keeping the output
as a string on the context, this is used later to report the results of the
test run.

Rather than storing the information in plain text we can use a BufferList
to store the original buffers, and only call toString() when dealing with
the final buffer.

This PR also abstracted out making a context into a helper function.