### PR TITLE
Add modules to lookup.json

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -388,5 +388,16 @@
   "node-report": {
     "prefix": "v",
     "maintainers": ["rnchamberlain", "richardlau"]
+  },
+  "thread-sleep": {
+    "install": ["--build-from-source"],
+    "maintainers": ["forbeslindesay", "timothygu"]
+  },
+  "bufferutil": {
+    "prefix": "v",
+    "maintainers": ["3rdeden", "einaros", "lpinca"]
+  },
+  "weak": {
+    "maintainers": "tootallnate"
   }
 }


### PR DESCRIPTION
Continuing from https://github.com/nodejs/citgm/issues/268 - this adds `thread-sleep`, `utf-8-validate`, `bufferutul`, `weak` and `hiredis` to `lookup.json`.