### PR TITLE
npm: fix `npm test` script to work on both windows and unix.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "test": "npm run lint && npm run tap",
-    "tap": "TAP_TIMEOUT=90 tap 'test/**/**/test-*.js'",
+    "tap": "tap --timeout 90 \"test/**/test-*.js\"",
     "coverage": "npm run tap -- --coverage",
     "coverage-html": "npm run tap -- --coverage --coverage-report=html",
     "lint": "eslint bin/* lib/ test/"


### PR DESCRIPTION
Currently the `npm test` script doesn't work on windows. I have fixed
this and also made it consistent with the way that community runs tests