### PR TITLE
script: change script to be stored in `context.module.script`

### DIFF
--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -45,6 +45,11 @@ function find(app, context, next) {
 }
 
 function init(context,next) {
+  // Script is passed as an option to citgm, but it needs to also apply to the
+  // single module that citgm is testing.
+  if (context.options.script) {
+    context.module.script = context.options.script;
+  }
   if (!windows) {
     if (context.options.uid)
       context.emit('data', 'verbose', context.module.name + ' using-uid', context.options.uid);

--- a/test/bin/test-citgm.js
+++ b/test/bin/test-citgm.js
@@ -54,6 +54,30 @@ test('bin: omg-i-pass /w custom script /w tap to file /w junit to file /w append
   });
 });
 
+test('bin: omg-i-fail /w custom test script passing', function (t) {
+  t.plan(1);
+  var proc = spawn(citgmPath, ['omg-i-fail', './test/fixtures/example-test-script-passing.sh']);
+  proc.on('error', function(err) {
+    t.error(err);
+    t.fail('we should not get an error running the custom test script');
+  });
+  proc.on('close', function (code) {
+    t.equal(code, 0, 'the test script should pass and exit with a code of zero');
+  });
+});
+
+test('bin: omg-i-pass /w custom test script failing', function (t) {
+  t.plan(1);
+  var proc = spawn(citgmPath, ['omg-i-pass', './test/fixtures/example-test-script-failing.sh']);
+  proc.on('error', function(err) {
+    t.error(err);
+    t.fail('we should not get an error running the custom test script');
+  });
+  proc.on('close', function (code) {
+    t.equal(code, 1, 'the test script should fail and exit with a code of one');
+  });
+});
+
 test('bin: no module /w root check', function (t) {
   t.plan(1);
   var proc = spawn(citgmPath, ['-s']);


### PR DESCRIPTION
change script to be stored in `context.module.script` rather than `context.options.script` for `citgm.js` to be consistent with `citgm-all.js`. This was broken in https://github.com/nodejs/citgm/pull/245