### PR TITLE
lookup: add expectFail

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
 "prefix": "v"                Specify the prefix used in the module version.
 "flaky": true                Ignore failures
 "skip": true                 Completely skip the module
+"expectFail"                 Expect the module to fail, error if it passes
 "repo": "https://github.com/pugjs/jade" - Use a different github repo
 "skipAnsi": true             Strip ansi data from output stream of npm
 "script": /path/to/script | https://url/to/script - Use a custom test script

--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -114,11 +114,15 @@ Tester.prototype.run = function() {
       var payload = {
         name: self.module.name || self.module.raw,
         version: self.module.version,
-        flaky: self.module.flaky
+        flaky: self.module.flaky,
+        expectFail: self.module.expectFail
       };
-      if (err) {
+      if (err && !payload.expectFail) {
         self.emit('fail', err);
         payload.error = err;
+      } else if (!err && payload.expectFail) {
+        self.emit('fail', 'this module should have failed');
+        payload.error = 'this module should have failed';
       }
       if (self.testOutput !== '') {
         payload.testOutput += self.testOutput + '\n';

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -103,6 +103,7 @@ function resolve(context, next) {
         context.module.script = rep.script;
       }
       context.module.flaky = context.options.failFlaky ? false : isMatch(rep.flaky);
+      context.module.expectFail = context.options.expectFail ? false : isMatch(rep.expectFail);
     } else {
       context.emit('data', 'info', 'lookup-notfound', detail.name);
     }

--- a/lib/reporter/logger.js
+++ b/lib/reporter/logger.js
@@ -27,10 +27,15 @@ function logger(log, modules) {
   var passed = util.getPassing(modules);
   var flaky = util.getFlakyFails(modules);
   var failed = util.getFails(modules);
+  var expectFail = util.getExpectedFails(modules);
 
   if (passed.length > 0) {
     log.info('passing module(s)');
     logModules(log, 'info', passed);
+  }
+  if (expectFail.length > 0) {
+    log.info('expected to fail:');
+    logModules(log, 'error', expectFail);
   }
   if (flaky.length > 0) {
     log.warn('flaky module(s)');

--- a/lib/reporter/util.js
+++ b/lib/reporter/util.js
@@ -14,9 +14,15 @@ function getFlakyFails(modules) {
   });
 }
 
+function getExpectedFails(modules) {
+  return _.filter(modules, function (mod) {
+    return (mod.expectFail && mod.error);
+  });
+}
+
 function getFails(modules) {
   return _.filter(modules, function (mod) {
-    return (mod.error && !mod.flaky);
+    return (mod.error && !mod.flaky && !mod.expectFail);
   });
 }
 
@@ -40,6 +46,7 @@ module.exports = {
   getPassing: getPassing,
   getFails: getFails,
   getFlakyFails: getFlakyFails,
+  getExpectedFails: getExpectedFails,
   hasFailures: hasFailures,
   sanitizeOutput: sanitizeOutput
 };

--- a/test/bin/test-citgm-all.js
+++ b/test/bin/test-citgm-all.js
@@ -72,6 +72,28 @@ test('citgm-all: flaky-fail', function (t) {
   });
 });
 
+test('citgm-all: fail expectFail', function (t) {
+  t.plan(1);
+  var proc = spawn(citgmAllPath, ['-l', 'test/fixtures/custom-lookup-expectFail.json']);
+  proc.on('error', function(err) {
+    t.error(err);
+  });
+  proc.on('close', function (code) {
+    t.equals(code, 0, 'citgm-all should exit with signal 0');
+  });
+});
+
+test('citgm-all: pass expectFail', function (t) {
+  t.plan(1);
+  var proc = spawn(citgmAllPath, ['-l', 'test/fixtures/custom-lookup-expectFail-fail.json']);
+  proc.on('error', function(err) {
+    t.error(err);
+  });
+  proc.on('close', function (code) {
+    t.equals(code, 1, 'citgm-all should exit with signal 1');
+  });
+});
+
 test('citgm-all: test with replace', function (t) {
   t.plan(1);
   var proc = spawn(citgmAllPath, ['-l', 'test/fixtures/custom-lookup-backwards-compatibilty.json']);

--- a/test/fixtures/custom-lookup-expectFail-fail.json
+++ b/test/fixtures/custom-lookup-expectFail-fail.json
@@ -1,0 +1,11 @@
+{
+  "omg-i-pass": {
+    "npm": true,
+    "expectFail": true
+  },
+  "omg-i-pass-too": {
+    "prefix": "v",
+    "stripAnsi": true,
+    "expectFail": true
+  }
+}

--- a/test/fixtures/custom-lookup-expectFail.json
+++ b/test/fixtures/custom-lookup-expectFail.json
@@ -1,0 +1,10 @@
+{
+  "omg-i-fail": {
+    "flaky": true,
+    "expectFail": true
+  },
+  "omg-i-fail": {
+    "npm": true,
+    "expectFail": true
+  }
+}


### PR DESCRIPTION
This PR adds the ability to use `expectFail` in the same way as flaky
but instead will mean that the module MUST fail. Discussed in https://github.com/nodejs/citgm/issues/212