### PR TITLE
flaky: add fips support

### DIFF
--- a/lib/match-conditions.js
+++ b/lib/match-conditions.js
@@ -13,6 +13,12 @@ var platform = process.platform;
 var arch = process.arch;
 var distro = '';
 var release = '';
+var fips = '';
+
+if (process.versions.openssl.indexOf('fips') !== -1) {
+  //when in fips mode include `fips` as a match condition
+  fips = 'fips';
+}
 
 if (fs.existsSync('/etc/os-release')) {
   var osRelease = require('dotenv').config({path: '/etc/os-release', silent: true});
@@ -31,7 +37,7 @@ var endian = process.config.variables.node_byteorder || '';
 function isStringMatch(conditions) {
   if (semver.validRange(conditions) && semver.satisfies(semVersion, conditions))
     return true;
-  var checks = [distro, release, version, [platform, arch].join('-'), endian];
+  var checks = [distro, release, version, [platform, arch].join('-'), endian, fips];
   return _.some(checks, function (check) {
     return check.search(conditions) !== -1;
   });


### PR DESCRIPTION
Allows you to mark flaky, skip and expectFail as fips
ie `"flaky": "fips"`