### PR TITLE
Refactor require calls

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -20,5 +20,6 @@
     func-call-spacing: [2, never]
     semi-spacing: 2
     strict: 2
+    no-var: 2
 
   extends: eslint:recommended

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -19,5 +19,6 @@
     eol-last: [2, always]
     func-call-spacing: [2, never]
     semi-spacing: 2
+    strict: 2
 
   extends: eslint:recommended

--- a/bin/citgm-all.js
+++ b/bin/citgm-all.js
@@ -31,9 +31,9 @@ const yargs = commonArgs(require('yargs'))
     description: 'Auto detect number of cores to use to run tests in parallel'
   });
 
-var app = yargs.argv;
+const app = yargs.argv;
 
-var log = logger({
+const log = logger({
   level: app.verbose,
   nocolor: app.color
 });
@@ -47,7 +47,7 @@ if (!app.su) {
   log.warn('root', 'Running as root! Use caution!');
 }
 
-var options = {
+const options = {
   lookup: app.lookup,
   nodedir: app.nodedir,
   testPath: app.testPath,
@@ -58,13 +58,13 @@ var options = {
   tmpDir: app.tmpDir
 };
 
-var lookup = getLookup(options);
+const lookup = getLookup(options);
 if (!lookup) {
   log.error('the json file cannot be found or there is an error in the file!');
   process.exit(1);
 }
 
-var cpus = os.cpus().length;
+const cpus = os.cpus().length;
 if (app.autoParallel || (app.parallel && app.parallel > cpus)) {
   app.parallel = cpus;
   log.info('cores', 'running tests using ' + app.parallel + ' cores');
@@ -74,9 +74,9 @@ if (app.parallel && ((app.parallel + 1) > process.getMaxListeners())) {
 }
 
 if (!citgm.windows) {
-  var uidnumber = require('uid-number');
-  var uid = app.uid || process.getuid();
-  var gid = app.gid || process.getgid();
+  const uidnumber = require('uid-number');
+  const uid = app.uid || process.getuid();
+  const gid = app.gid || process.getgid();
   uidnumber(uid, gid, function(err, uid, gid) {
     options.uid = uid;
     options.gid = gid;
@@ -86,16 +86,16 @@ if (!citgm.windows) {
   launch(options);
 }
 
-var modules = [];
+const modules = [];
 
 function runCitgm (mod, name, next) {
   if (isMatch(mod.skip)) {
     return next();
   }
 
-  var start = new Date();
-  var runner = citgm.Tester(name, options);
-  var bailed = false;
+  const start = new Date();
+  const runner = citgm.Tester(name, options);
+  let bailed = false;
 
   function cleanup() {
     bailed = true;
@@ -148,9 +148,9 @@ function filterLookup(result, value, key) {
 }
 
 function launch() {
-  var collection = _.reduce(lookup, filterLookup, []);
+  const collection = _.reduce(lookup, filterLookup, []);
 
-  var q = async.queue(runTask, app.parallel || 1);
+  const q = async.queue(runTask, app.parallel || 1);
   q.push(collection);
   function done () {
     q.drain = null;
@@ -165,12 +165,12 @@ function launch() {
       // If not use `log.bypass` which is currently process.stdout.write
       // TODO check that we can write to that path, perhaps require a flag to
       // Overwrite
-      var tap = (typeof app.tap === 'string') ? app.tap : log.bypass;
+      const tap = (typeof app.tap === 'string') ? app.tap : log.bypass;
       reporter.tap(tap, modules, app.append);
     }
 
     if (app.junit) {
-      var junit = (typeof app.junit === 'string') ? app.junit : log.bypass;
+      const junit = (typeof app.junit === 'string') ? app.junit : log.bypass;
       reporter.junit(junit, modules, app.append);
     }
 

--- a/bin/citgm-all.js
+++ b/bin/citgm-all.js
@@ -1,20 +1,19 @@
 #!/usr/bin/env node
 'use strict';
-var yargs = require('yargs');
-var os = require('os');
+const os = require('os');
 
-var async = require('async');
-var _ = require('lodash');
+const async = require('async');
+const _ = require('lodash');
 
-var update = require('../lib/update');
-var citgm = require('../lib/citgm');
-var logger = require('../lib/out');
-var reporter = require('../lib/reporter');
-var getLookup = require('../lib/lookup').get;
-var commonArgs = require('../lib/common-args');
-var isMatch = require('../lib/match-conditions');
+const update = require('../lib/update');
+const citgm = require('../lib/citgm');
+const logger = require('../lib/out');
+const reporter = require('../lib/reporter');
+const getLookup = require('../lib/lookup').get;
+const commonArgs = require('../lib/common-args');
+const isMatch = require('../lib/match-conditions');
 
-yargs = commonArgs(yargs)
+const yargs = commonArgs(require('yargs'))
   .usage('citgm-all [options]')
   .option('fail-flaky', {
     alias: 'f',

--- a/bin/citgm-all.js
+++ b/bin/citgm-all.js
@@ -2,16 +2,16 @@
 'use strict';
 const os = require('os');
 
-const async = require('async');
 const _ = require('lodash');
+const async = require('async');
 
-const update = require('../lib/update');
 const citgm = require('../lib/citgm');
+const commonArgs = require('../lib/common-args');
+const getLookup = require('../lib/lookup').get;
+const isMatch = require('../lib/match-conditions');
 const logger = require('../lib/out');
 const reporter = require('../lib/reporter');
-const getLookup = require('../lib/lookup').get;
-const commonArgs = require('../lib/common-args');
-const isMatch = require('../lib/match-conditions');
+const update = require('../lib/update');
 
 const yargs = commonArgs(require('yargs'))
   .usage('citgm-all [options]')

--- a/bin/citgm.js
+++ b/bin/citgm.js
@@ -6,8 +6,8 @@ const logger = require('../lib/out');
 const reporter = require('../lib/reporter');
 const update = require('../lib/update');
 
-var mod;
-var script;
+let mod;
+let script;
 
 const yargs = commonArgs(require('yargs'))
   .usage('citgm [options] <module> [script]')
@@ -17,12 +17,12 @@ const yargs = commonArgs(require('yargs'))
     description: 'Install module from commit-sha'
   });
 
-var app = yargs.argv;
+const app = yargs.argv;
 
 mod = app._[0];
 script = app._[1];
 
-var log = logger({
+const log = logger({
   level:app.verbose,
   nocolor: app.noColor
 });
@@ -41,7 +41,7 @@ if (!mod) {
   process.exit(0);
 }
 
-var options = {
+const options = {
   script: script,
   lookup: app.lookup,
   nodedir: app.nodedir,
@@ -66,9 +66,9 @@ if (!citgm.windows) {
   launch(mod, options);
 }
 
-var start = new Date();
+const start = new Date();
 function launch(mod, options) {
-  var runner = citgm.Tester(mod, options);
+  const runner = citgm.Tester(mod, options);
 
   function cleanup() {
     runner.cleanup();

--- a/bin/citgm.js
+++ b/bin/citgm.js
@@ -54,9 +54,9 @@ const options = {
 };
 
 if (!citgm.windows) {
-  var uidnumber = require('uid-number');
-  var uid = app.uid || process.getuid();
-  var gid = app.gid || process.getgid();
+  const uidnumber = require('uid-number');
+  const uid = app.uid || process.getuid();
+  const gid = app.gid || process.getgid();
   uidnumber(uid, gid, function(err, uid, gid) {
     options.uid = uid;
     options.gid = gid;
@@ -93,12 +93,12 @@ function launch(mod, options) {
       reporter.markdown(log.bypass, module);
     }
     if (app.tap) {
-      var tap = (typeof app.tap === 'string') ? app.tap : log.bypass;
+      const tap = (typeof app.tap === 'string') ? app.tap : log.bypass;
       reporter.tap(tap, module, app.append);
     }
 
     if (app.junit) {
-      var junit = (typeof app.junit === 'string') ? app.junit : log.bypass;
+      const junit = (typeof app.junit === 'string') ? app.junit : log.bypass;
       reporter.junit(junit, module, app.append);
     }
 

--- a/bin/citgm.js
+++ b/bin/citgm.js
@@ -1,16 +1,15 @@
 #!/usr/bin/env node
 'use strict';
-var update = require('../lib/update');
-var citgm = require('../lib/citgm');
-var logger = require('../lib/out');
-var reporter = require('../lib/reporter');
-var commonArgs = require('../lib/common-args');
-var yargs = require('yargs');
+const update = require('../lib/update');
+const citgm = require('../lib/citgm');
+const logger = require('../lib/out');
+const reporter = require('../lib/reporter');
+const commonArgs = require('../lib/common-args');
 
 var mod;
 var script;
 
-yargs = commonArgs(yargs)
+const yargs = commonArgs(require('yargs'))
   .usage('citgm [options] <module> [script]')
   .option('sha', {
     alias: 'c',

--- a/bin/citgm.js
+++ b/bin/citgm.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 'use strict';
-const update = require('../lib/update');
 const citgm = require('../lib/citgm');
+const commonArgs = require('../lib/common-args');
 const logger = require('../lib/out');
 const reporter = require('../lib/reporter');
-const commonArgs = require('../lib/common-args');
+const update = require('../lib/update');
 
 var mod;
 var script;

--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -61,14 +61,14 @@ function init(context, next) {
 }
 
 function sha1(mod) {
-  var crypto = require('crypto');
-  var shasum = crypto.createHash('sha1');
+  const crypto = require('crypto');
+  const shasum = crypto.createHash('sha1');
   shasum.update(mod);
   return shasum.digest('hex');
 }
 
 function extractDetail(mod) {
-  var detail = npa(mod); // Will throw on failure
+  const detail = npa(mod); // Will throw on failure
   detail.name = detail.name || sha1(mod);
   return detail;
 }
@@ -100,7 +100,7 @@ function Tester(mod, options) {
 util.inherits(Tester, EventEmitter);
 
 Tester.prototype.run = function() {
-  var self = this;
+  const self = this;
   this.emit('start', this.module.raw, this.options);
 
   async.waterfall([
@@ -116,7 +116,7 @@ Tester.prototype.run = function() {
     npm.test
   ], function(err) {
     if (!self.cleanexit) {
-      var payload = {
+      const payload = {
         name: self.module.name || self.module.raw,
         version: self.module.version,
         flaky: self.module.flaky,
@@ -144,9 +144,9 @@ Tester.prototype.run = function() {
 };
 
 Tester.prototype.cleanup = function () {
-  var self = this;
+  const self = this;
   self.cleanexit = true;
-  var payload = {
+  const payload = {
     name: self.module.name || self.module.raw,
     error: Error('Process Interrupted')
   };

--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -1,23 +1,23 @@
 'use strict';
 
 // Node modules
-var util = require('util');
-var EventEmitter = require('events').EventEmitter;
+const util = require('util');
+const EventEmitter = require('events').EventEmitter;
 
 // Npm modules
-var async = require('async');
-var npa = require('npm-package-arg');
-var which = require('which');
+const async = require('async');
+const npa = require('npm-package-arg');
+let which = require('which'); // Mocked in tests
 
 // Local modules
-var lookup = require('./lookup');
-var grabProject = require('./grab-project');
-var unpack = require('./unpack');
-var tempDirectory = require('./temp-directory');
-var grabModuleData = require('./grab-module-data');
-var npm = require('./npm');
+const lookup = require('./lookup');
+const grabProject = require('./grab-project');
+const unpack = require('./unpack');
+const tempDirectory = require('./temp-directory');
+const grabModuleData = require('./grab-module-data');
+const npm = require('./npm');
 
-var windows = (process.platform === 'win32');
+const windows = (process.platform === 'win32');
 exports.windows = windows;
 
 /**

--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -1,21 +1,17 @@
 'use strict';
-
-// Node modules
-const util = require('util');
 const EventEmitter = require('events').EventEmitter;
+const util = require('util');
 
-// Npm modules
 const async = require('async');
 const npa = require('npm-package-arg');
 let which = require('which'); // Mocked in tests
 
-// Local modules
-const lookup = require('./lookup');
-const grabProject = require('./grab-project');
-const unpack = require('./unpack');
-const tempDirectory = require('./temp-directory');
 const grabModuleData = require('./grab-module-data');
+const grabProject = require('./grab-project');
+const lookup = require('./lookup');
 const npm = require('./npm');
+const tempDirectory = require('./temp-directory');
+const unpack = require('./unpack');
 
 const windows = (process.platform === 'win32');
 exports.windows = windows;

--- a/lib/common-args.js
+++ b/lib/common-args.js
@@ -1,6 +1,6 @@
 'use strict';
-var citgm = require('./citgm');
-var pkg = require('../package.json');
+const citgm = require('./citgm');
+const pkg = require('../package.json');
 
 module.exports = function commonArgs (app) {
   app = app

--- a/lib/create-options.js
+++ b/lib/create-options.js
@@ -2,7 +2,7 @@
 const _ = require('lodash');
 
 function createOptions(cwd, context) {
-  var options = {
+  const options = {
     cwd: cwd
   };
   if (!(process.platform === 'win32')) {

--- a/lib/create-options.js
+++ b/lib/create-options.js
@@ -1,3 +1,4 @@
+'use strict';
 const _ = require('lodash');
 
 function createOptions(cwd, context) {

--- a/lib/create-options.js
+++ b/lib/create-options.js
@@ -1,4 +1,5 @@
-var _ = require('lodash');
+const _ = require('lodash');
+
 function createOptions(cwd, context) {
   var options = {
     cwd: cwd

--- a/lib/grab-module-data.js
+++ b/lib/grab-module-data.js
@@ -5,14 +5,14 @@ const spawn = require('./spawn');
 function grabModuleData(context, next) {
   // Launch npm info as a child process, using the tmp directory
   // As the working directory.
-  var proc =
+  const proc =
     spawn(
       'npm',
       ['view', '--json', context.module.raw],
       createOptions(
         context.path,
         context));
-  var data = '';
+  let data = '';
   proc.stdout.on('data', function(chunk) {
     data += chunk;
   });

--- a/lib/grab-module-data.js
+++ b/lib/grab-module-data.js
@@ -1,3 +1,4 @@
+'use strict';
 const spawn = require('./spawn');
 const createOptions = require('./create-options');
 

--- a/lib/grab-module-data.js
+++ b/lib/grab-module-data.js
@@ -1,6 +1,6 @@
 'use strict';
-const spawn = require('./spawn');
 const createOptions = require('./create-options');
+const spawn = require('./spawn');
 
 function grabModuleData(context, next) {
   // Launch npm info as a child process, using the tmp directory

--- a/lib/grab-module-data.js
+++ b/lib/grab-module-data.js
@@ -1,5 +1,5 @@
-var spawn = require('./spawn');
-var createOptions = require('./create-options');
+const spawn = require('./spawn');
+const createOptions = require('./create-options');
 
 function grabModuleData(context, next) {
   // Launch npm info as a child process, using the tmp directory

--- a/lib/grab-project.js
+++ b/lib/grab-project.js
@@ -8,15 +8,15 @@ function grabProject(context, next) {
   if (context.meta)
     context.emit('data', 'silly', context.module.name + ' package-meta',
         context.meta);
-  var packageName = context.module.raw;
+  let packageName = context.module.raw;
   if (context.module.type === 'local') {
     context.module.raw = context.module.name = path.basename(packageName);
     packageName = path.resolve(process.cwd(), packageName);
   }
-  var bailed = false;
+  let bailed = false;
   context.emit('data', 'info', context.module.name + ' npm:',
       'Downloading project: ' + packageName);
-  var proc =
+  const proc =
     spawn(
       'npm',
       ['pack', packageName],
@@ -24,10 +24,10 @@ function grabProject(context, next) {
         context.path,
         context));
 
-  var filename = '';
+  let filename = '';
 
   // Default timeout to 10 minutes if not provided
-  var timeout = setTimeout(cleanup, context.options.timeoutLength
+  const timeout = setTimeout(cleanup, context.options.timeoutLength
         || 1000 * 60 * 10);
 
   function cleanup() {

--- a/lib/grab-project.js
+++ b/lib/grab-project.js
@@ -1,9 +1,9 @@
 // Node modules
-var path = require('path');
+const path = require('path');
 
 // Local modules
-var spawn = require('./spawn');
-var createOptions = require('./create-options');
+const spawn = require('./spawn');
+const createOptions = require('./create-options');
 
 function grabProject(context, next) {
   if (context.meta)

--- a/lib/grab-project.js
+++ b/lib/grab-project.js
@@ -1,3 +1,4 @@
+'use strict';
 // Node modules
 const path = require('path');
 

--- a/lib/grab-project.js
+++ b/lib/grab-project.js
@@ -1,10 +1,8 @@
 'use strict';
-// Node modules
 const path = require('path');
 
-// Local modules
-const spawn = require('./spawn');
 const createOptions = require('./create-options');
+const spawn = require('./spawn');
 
 function grabProject(context, next) {
   if (context.meta)

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -24,7 +24,7 @@ function makeUrl(repo, spec, tags, prefix, sha) {
 // If necessary, and replace the git:// prefx with https://
 // If necessary
 function getRepo(repo, meta) {
-  var ret = normgit(repo || meta.repository.url).url;
+  let ret = normgit(repo || meta.repository.url).url;
   ret = ret.replace(/\.git$/, '');
   ret = ret.replace(/^git:/, 'https:');
   ret = ret.replace(/^ssh:\/\/git@/, 'https://');
@@ -33,7 +33,7 @@ function getRepo(repo, meta) {
 
 function getLookupTable(options) {
   try {
-    var name = './lookup.json';
+    let name = './lookup.json';
     if (typeof options.lookup === 'string') {
       name = path.resolve(process.cwd(), options.lookup);
     }
@@ -59,16 +59,16 @@ function getLookupTable(options) {
  * the path to a different lookup json file can be specified
  **/
 function resolve(context, next) {
-  var lookup = getLookupTable(context.options);
+  const lookup = getLookupTable(context.options);
   if (!lookup) {
     next(Error('Lookup table could not be loaded'));
     return;
   }
-  var detail = context.module;
+  const detail = context.module;
   context.emit('data', 'info', 'lookup', detail.name);
-  var meta = context.meta;
+  const meta = context.meta;
   if (meta) {
-    var rep = lookup[detail.name];
+    const rep = lookup[detail.name];
     context.module.version = meta.version;
     if (rep) {
       if (rep.envVar){
@@ -86,7 +86,7 @@ function resolve(context, next) {
           return;
         }
         context.emit('data', 'info', 'lookup-found', detail.name);
-        var url = makeUrl(
+        const url = makeUrl(
           getRepo(rep.repo, meta),
           rep.master ? null : detail.spec,
           meta['dist-tags'],

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -8,7 +8,7 @@ const isMatch = require('./match-conditions');
 
 // Construct the tarball url using the repo, spec and prefix config
 function makeUrl(repo, spec, tags, prefix, sha) {
-  var version = (!spec || spec === '') ? 'master' : tags[spec];
+  let version = (!spec || spec === '') ? 'master' : tags[spec];
   prefix = prefix || '';
 
   if (sha) {

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -1,9 +1,9 @@
 'use strict';
-var normgit = require('normalize-git-url');
-var util = require('util');
-var path = require('path');
+const normgit = require('normalize-git-url');
+const util = require('util');
+const path = require('path');
 
-var isMatch = require('./match-conditions');
+const isMatch = require('./match-conditions');
 
 // Construct the tarball url using the repo, spec and prefix config
 function makeUrl(repo, spec, tags, prefix, sha) {

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -1,7 +1,8 @@
 'use strict';
-const normgit = require('normalize-git-url');
-const util = require('util');
 const path = require('path');
+const util = require('util');
+
+const normgit = require('normalize-git-url');
 
 const isMatch = require('./match-conditions');
 

--- a/lib/match-conditions.js
+++ b/lib/match-conditions.js
@@ -21,7 +21,7 @@ if (process.versions.openssl.indexOf('fips') !== -1) {
 }
 
 if (fs.existsSync('/etc/os-release')) {
-  var osRelease = fs.readFileSync('/etc/os-release', 'utf8');
+  const osRelease = fs.readFileSync('/etc/os-release', 'utf8');
   distro = osRelease.match(/\n\s*ID="?(.*)"?/)[1] || '';
   release = osRelease.match(/\n\s*VERSION_ID="?(.*)"?/)[1] || '';
 } else if (platform === 'darwin') {
@@ -32,12 +32,12 @@ if (fs.existsSync('/etc/os-release')) {
   release = release.replace(/(\r\n|\n|\r)/gm, '') || '';
 }
 
-var endian = process.config.variables.node_byteorder || '';
+const endian = process.config.variables.node_byteorder || '';
 
 function isStringMatch(conditions) {
   if (semver.validRange(conditions) && semver.satisfies(semVersion, conditions))
     return true;
-  var checks = [distro, release, version, [platform, arch].join('-'),
+  const checks = [distro, release, version, [platform, arch].join('-'),
     endian, fips];
   return _.some(checks, function (check) {
     return check.search(conditions) !== -1;

--- a/lib/match-conditions.js
+++ b/lib/match-conditions.js
@@ -1,19 +1,20 @@
 'use strict';
 
-var fs = require('fs');
-var execSync = require('child_process').execSync;
-var _ = require('lodash');
-var semver = require('semver');
+const fs = require('fs');
+const execSync = require('child_process').execSync;
+const _ = require('lodash');
+const semver = require('semver');
 
-var version = process.version;
-var semVersion = semver.major(process.version) + '.' +
+// Mocked in tests
+let version = process.version;
+let semVersion = semver.major(process.version) + '.' +
                  semver.minor(process.version) + '.' +
                  semver.patch(process.version);
-var platform = process.platform;
-var arch = process.arch;
-var distro = '';
-var release = '';
-var fips = '';
+let platform = process.platform;
+let arch = process.arch;
+let distro = '';
+let release = '';
+let fips = '';
 
 if (process.versions.openssl.indexOf('fips') !== -1) {
   // When in fips mode include `fips` as a match condition

--- a/lib/match-conditions.js
+++ b/lib/match-conditions.js
@@ -1,8 +1,7 @@
 'use strict';
-
-const fs = require('fs');
-const execSync = require('child_process').execSync;
 const _ = require('lodash');
+const execSync = require('child_process').execSync;
+const fs = require('fs');
 const semver = require('semver');
 
 // Mocked in tests

--- a/lib/npm/index.js
+++ b/lib/npm/index.js
@@ -1,8 +1,6 @@
 'use strict';
-
-// Local modules
-const test = require('./test');
 const install = require('./install');
+const test = require('./test');
 
 module.exports = {
   install: install,

--- a/lib/npm/index.js
+++ b/lib/npm/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
 // Local modules
-var test = require('./test');
-var install = require('./install');
+const test = require('./test');
+const install = require('./install');
 
 module.exports = {
   install: install,

--- a/lib/npm/install.js
+++ b/lib/npm/install.js
@@ -7,11 +7,11 @@ const createOptions = require('../create-options');
 const spawn = require('../spawn');
 
 function install(context, next) {
-  var options =
+  const options =
     createOptions(
       path.join(context.path, context.module.name), context);
-  var args = ['install', '--loglevel', context.options.npmLevel];
-  var bailed = false;
+  let args = ['install', '--loglevel', context.options.npmLevel];
+  let bailed = false;
   context.emit('data', 'info', context.module.name + ' npm:',
       'npm install started');
 
@@ -23,7 +23,7 @@ function install(context, next) {
   }
 
   if (context.options.nodedir) {
-    var nodedir = path.resolve(process.cwd(), context.options.nodedir);
+    let nodedir = path.resolve(process.cwd(), context.options.nodedir);
     options.env.npm_config_nodedir = nodedir;
     if (process.platform === 'win32') {
       nodedir = nodedir.replace(/\\/g, '\\\\');
@@ -33,10 +33,10 @@ function install(context, next) {
         'Using --nodedir="' + nodedir + '"');
   }
 
-  var proc = spawn('npm', args, options);
+  const proc = spawn('npm', args, options);
 
   // Default timeout to 10 minutes if not provided
-  var timeout = setTimeout(cleanup, context.options.timeoutLength
+  const timeout = setTimeout(cleanup, context.options.timeoutLength
         || 1000 * 60 * 10);
 
   function cleanup() {
@@ -48,8 +48,8 @@ function install(context, next) {
     return next(Error('Install Timed Out'));
   }
 
-  var installOutput = '';
-  var installError = '';
+  let installOutput = '';
+  let installError = '';
 
   proc.stderr.on('data', function (chunk) {
     if (context.module.stripAnsi) {

--- a/lib/npm/install.js
+++ b/lib/npm/install.js
@@ -1,14 +1,10 @@
 'use strict';
-
-// Node modules
 const path = require('path');
 
-// Npm modules
 const stripAnsi = require('strip-ansi');
 
-// Local modules
-const spawn = require('../spawn');
 const createOptions = require('../create-options');
+const spawn = require('../spawn');
 
 function install(context, next) {
   var options =

--- a/lib/npm/install.js
+++ b/lib/npm/install.js
@@ -1,14 +1,14 @@
 'use strict';
 
 // Node modules
-var path = require('path');
+const path = require('path');
 
 // Npm modules
-var stripAnsi = require('strip-ansi');
+const stripAnsi = require('strip-ansi');
 
 // Local modules
-var spawn = require('../spawn');
-var createOptions = require('../create-options');
+const spawn = require('../spawn');
+const createOptions = require('../create-options');
 
 function install(context, next) {
   var options =

--- a/lib/npm/script/fetch.js
+++ b/lib/npm/script/fetch.js
@@ -8,11 +8,11 @@ let request = require('request'); // Mocked in tests
 
 function fetchScript(context, script, next) {
   script = String(script);
-  var dest = path.resolve(context.path, uuid.v4());
-  var res = url.parse(script);
-  var readStream;
+  const dest = path.resolve(context.path, uuid.v4());
+  const res = url.parse(script);
+  let readStream;
   if (res.protocol !== 'http:' && res.protocol !== 'https:') {
-    var _path;
+    let _path;
     if (context.options && context.options.lookup && script[0] !== '/') {
       _path = path.resolve(path.dirname(context.options.lookup), script);
     } else {

--- a/lib/npm/script/fetch.js
+++ b/lib/npm/script/fetch.js
@@ -1,10 +1,8 @@
 'use strict';
-// Node modules
-const path = require('path');
 const fs = require('fs');
+const path = require('path');
 const url = require('url');
 
-// Npm modules
 const uuid = require('uuid');
 let request = require('request'); // Mocked in tests
 

--- a/lib/npm/script/fetch.js
+++ b/lib/npm/script/fetch.js
@@ -1,3 +1,4 @@
+'use strict';
 // Node modules
 const path = require('path');
 const fs = require('fs');

--- a/lib/npm/script/fetch.js
+++ b/lib/npm/script/fetch.js
@@ -1,11 +1,11 @@
 // Node modules
-var path = require('path');
-var fs = require('fs');
-var url = require('url');
+const path = require('path');
+const fs = require('fs');
+const url = require('url');
 
 // Npm modules
-var uuid = require('uuid');
-var request = require('request');
+const uuid = require('uuid');
+let request = require('request'); // Mocked in tests
 
 function fetchScript(context, script, next) {
   script = String(script);

--- a/lib/npm/script/index.js
+++ b/lib/npm/script/index.js
@@ -1,5 +1,5 @@
-var fetch = require('./fetch');
-var run = require('./run');
+const fetch = require('./fetch');
+const run = require('./run');
 
 module.exports = {
   fetch: fetch,

--- a/lib/npm/script/index.js
+++ b/lib/npm/script/index.js
@@ -1,3 +1,4 @@
+'use strict';
 const fetch = require('./fetch');
 const run = require('./run');
 

--- a/lib/npm/script/run.js
+++ b/lib/npm/script/run.js
@@ -9,7 +9,7 @@ const createOptions = require('../../create-options');
 const spawn = require('../../spawn');
 
 function runScript(context, script, msg, next) {
-  var _path = path.resolve(process.cwd(), script);
+  const _path = path.resolve(process.cwd(), script);
   if (typeof msg === 'function') {
     next = msg;
     msg = util.format('Script %s failed', _path);
@@ -19,8 +19,8 @@ function runScript(context, script, msg, next) {
     if (err || !stat.isFile()) {
       return next(err);
     }
-    var options = createOptions(context.path, context);
-    var proc = spawn(_path, [], options);
+    const options = createOptions(context.path, context);
+    const proc = spawn(_path, [], options);
     proc.stdout.on('data', function (data) {
       if (context.module.stripAnsi) {
         data = stripAnsi(data.toString());

--- a/lib/npm/script/run.js
+++ b/lib/npm/script/run.js
@@ -1,13 +1,10 @@
 'use strict';
-// Node modules
-const path = require('path');
 const fs = require('fs');
+const path = require('path');
 const util = require('util');
 
-// Npm modules
 const stripAnsi = require('strip-ansi');
 
-// Local modules
 const createOptions = require('../../create-options');
 const spawn = require('../../spawn');
 

--- a/lib/npm/script/run.js
+++ b/lib/npm/script/run.js
@@ -1,3 +1,4 @@
+'use strict';
 // Node modules
 const path = require('path');
 const fs = require('fs');

--- a/lib/npm/script/run.js
+++ b/lib/npm/script/run.js
@@ -1,14 +1,14 @@
 // Node modules
-var path = require('path');
-var fs = require('fs');
-var util = require('util');
+const path = require('path');
+const fs = require('fs');
+const util = require('util');
 
 // Npm modules
-var stripAnsi = require('strip-ansi');
+const stripAnsi = require('strip-ansi');
 
 // Local modules
-var createOptions = require('../../create-options');
-var spawn = require('../../spawn');
+const createOptions = require('../../create-options');
+const spawn = require('../../spawn');
 
 function runScript(context, script, msg, next) {
   var _path = path.resolve(process.cwd(), script);

--- a/lib/npm/test.js
+++ b/lib/npm/test.js
@@ -16,7 +16,7 @@ const npmBinName = 'npm';
 
 function authorName(author) {
   if (typeof author === 'string') return author;
-  var parts = [];
+  let parts = [];
   if (author.name) parts.push(author.name);
   if (author.email) parts.push('<' + author.email + '>');
   if (author.url) parts.push('(' + author.url + ')');
@@ -37,7 +37,7 @@ function test(context, next) {
 
     return;
   }
-  var wd = path.join(context.path, context.module.name);
+  const wd = path.join(context.path, context.module.name);
   context.emit('data', 'info', context.module.name + ' npm:',
       'test suite started');
   readPackage(path.join(wd, 'package.json'), false, function(err, data) {
@@ -56,8 +56,8 @@ function test(context, next) {
       return;
     }
 
-    var options = createOptions(wd, context);
-    var nodeBin = 'node';
+    const options = createOptions(wd, context);
+    let nodeBin = 'node';
     if (context.options.testPath) {
       options.env.PATH = context.options.testPath + ':' + process.env.PATH;
       nodeBin = which(nodeBinName, {path: options.env.PATH
@@ -69,7 +69,7 @@ function test(context, next) {
       npmBin = path.join(path.dirname(npmBin), 'node_modules', 'npm', 'bin',
           'npm-cli.js');
     }
-    var proc = spawn(nodeBin, [npmBin, 'test', '--loglevel=' +
+    const proc = spawn(nodeBin, [npmBin, 'test', '--loglevel=' +
         context.options.npmLevel], options);
     proc.stdout.on('data', function (data) {
       if (context.module.stripAnsi) {

--- a/lib/npm/test.js
+++ b/lib/npm/test.js
@@ -1,18 +1,14 @@
 'use strict';
-
-// Node modules
-const path = require('path');
 const fs = require('fs');
+const path = require('path');
 
-// Npm modules
 const readPackage = require('read-package-json');
 const stripAnsi = require('strip-ansi');
 const which = require('which').sync;
 
-// Local modules
-const spawn = require('../spawn');
 const createOptions = require('../create-options');
 const script = require('./script');
+const spawn = require('../spawn');
 
 const windows = (process.platform === 'win32');
 let nodeBinName = 'node'; // Mocked in tests

--- a/lib/npm/test.js
+++ b/lib/npm/test.js
@@ -1,22 +1,22 @@
 'use strict';
 
 // Node modules
-var path = require('path');
-var fs = require('fs');
+const path = require('path');
+const fs = require('fs');
 
 // Npm modules
-var readPackage = require('read-package-json');
-var stripAnsi = require('strip-ansi');
-var which = require('which').sync;
+const readPackage = require('read-package-json');
+const stripAnsi = require('strip-ansi');
+const which = require('which').sync;
 
 // Local modules
-var spawn = require('../spawn');
-var createOptions = require('../create-options');
-var script = require('./script');
+const spawn = require('../spawn');
+const createOptions = require('../create-options');
+const script = require('./script');
 
-var windows = (process.platform === 'win32');
-var nodeBinName = 'node';
-var npmBinName = 'npm';
+const windows = (process.platform === 'win32');
+let nodeBinName = 'node'; // Mocked in tests
+const npmBinName = 'npm';
 
 function authorName(author) {
   if (typeof author === 'string') return author;

--- a/lib/npm/test.js
+++ b/lib/npm/test.js
@@ -63,7 +63,7 @@ function test(context, next) {
       nodeBin = which(nodeBinName, {path: options.env.PATH
             || process.env.PATH});
     }
-    var npmBin = which(npmBinName, {path: options.env.PATH
+    let npmBin = which(npmBinName, {path: options.env.PATH
           || process.env.PATH});
     if (windows) {
       npmBin = path.join(path.dirname(npmBin), 'node_modules', 'npm', 'bin',

--- a/lib/out.js
+++ b/lib/out.js
@@ -11,7 +11,7 @@ logger.add(logger.transports.Console, {
 });
 
 function output(tag, message, dest) {
-  var obj;
+  let obj;
   if (typeof message === 'object') {
     obj = JSON.stringify(message, null, 2);
     message = '';
@@ -38,7 +38,7 @@ function output(tag, message, dest) {
 }
 
 module.exports = function(options) {
-  var colorize;
+  let colorize;
   options = options || {
     level: 'warn'
   };

--- a/lib/out.js
+++ b/lib/out.js
@@ -1,8 +1,8 @@
 'use strict';
-const logger = require('winston');
 const chalk = require('chalk');
-let supportscolor = require('supports-color'); // Mocked in tests
 const columnify = require('columnify');
+const logger = require('winston');
+let supportscolor = require('supports-color'); // Mocked in tests
 
 logger.remove(logger.transports.Console);
 logger.add(logger.transports.Console, {

--- a/lib/out.js
+++ b/lib/out.js
@@ -1,8 +1,8 @@
 'use strict';
-var logger = require('winston');
-var chalk = require('chalk');
-var supportscolor = require('supports-color');
-var columnify = require('columnify');
+const logger = require('winston');
+const chalk = require('chalk');
+let supportscolor = require('supports-color'); // Mocked in tests
+const columnify = require('columnify');
 
 logger.remove(logger.transports.Console);
 logger.add(logger.transports.Console, {

--- a/lib/out.js
+++ b/lib/out.js
@@ -16,7 +16,7 @@ function output(tag, message, dest) {
     obj = JSON.stringify(message, null, 2);
     message = '';
   }
-  var msg = columnify(
+  const msg = columnify(
     [{tag:tag, message:message}],
     {
       showHeaders: false,

--- a/lib/reporter/index.js
+++ b/lib/reporter/index.js
@@ -1,11 +1,11 @@
 'use strict';
 
 // Local modules
-var markdown = require('./markdown');
-var junit = require('./junit');
-var logger = require('./logger');
-var util = require('./util');
-var tap = require('./tap');
+const markdown = require('./markdown');
+const junit = require('./junit');
+const logger = require('./logger');
+const util = require('./util');
+const tap = require('./tap');
 
 module.exports = {
   markdown: markdown,

--- a/lib/reporter/index.js
+++ b/lib/reporter/index.js
@@ -1,16 +1,14 @@
 'use strict';
-
-// Local modules
-const markdown = require('./markdown');
 const junit = require('./junit');
 const logger = require('./logger');
-const util = require('./util');
+const markdown = require('./markdown');
 const tap = require('./tap');
+const util = require('./util');
 
 module.exports = {
-  markdown: markdown,
   junit: junit,
   logger: logger,
-  util: util,
-  tap: tap
+  markdown: markdown,
+  tap: tap,
+  util: util
 };

--- a/lib/reporter/junit.js
+++ b/lib/reporter/junit.js
@@ -7,8 +7,8 @@ const builder = require('xmlbuilder');
 const util = require('./util');
 
 function generateTest(xml, mod) {
-  var output =util.sanitizeOutput(mod.testOutput, '', true);
-  var item = xml.ele('testcase');
+  const output =util.sanitizeOutput(mod.testOutput, '', true);
+  const item = xml.ele('testcase');
   item.att('name', [mod.name, 'v' + mod.version].join('-'));
   item.att('time', mod.duration / 1000);
   item.ele('system-out').dat(output);
@@ -23,7 +23,7 @@ function generateTest(xml, mod) {
 }
 
 function generateJunit(modules) {
-  var xml = builder.create('testsuite', {headless: false});
+  const xml = builder.create('testsuite', {headless: false});
   xml.att('name', 'citgm');
   _.reduce(modules, generateTest, xml);
   xml.end({ pretty: true });
@@ -34,7 +34,7 @@ function junit(logger, modules, append) {
   if (!(modules instanceof Array)) {
     modules = [modules];
   }
-  var payload = generateJunit(modules);
+  const payload = generateJunit(modules);
   if (typeof logger === 'string') {
     if (append){
       fs.appendFileSync(logger, payload + '\n');

--- a/lib/reporter/junit.js
+++ b/lib/reporter/junit.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var fs = require('fs');
+const fs = require('fs');
 
-var _ = require('lodash');
-var builder = require('xmlbuilder');
+const _ = require('lodash');
+const builder = require('xmlbuilder');
 
-var util = require('./util');
+const util = require('./util');
 
 function generateTest(xml, mod) {
   var output =util.sanitizeOutput(mod.testOutput, '', true);

--- a/lib/reporter/junit.js
+++ b/lib/reporter/junit.js
@@ -1,5 +1,4 @@
 'use strict';
-
 const fs = require('fs');
 
 const _ = require('lodash');

--- a/lib/reporter/logger.js
+++ b/lib/reporter/logger.js
@@ -23,10 +23,10 @@ function logger(log, modules) {
   if (!(modules instanceof Array)) {
     modules = [modules];
   }
-  var passed = util.getPassing(modules);
-  var flaky = util.getFlakyFails(modules);
-  var failed = util.getFails(modules);
-  var expectFail = util.getExpectedFails(modules);
+  const passed = util.getPassing(modules);
+  const flaky = util.getFlakyFails(modules);
+  const failed = util.getFails(modules);
+  const expectFail = util.getExpectedFails(modules);
 
   if (passed.length > 0) {
     log.info('passing module(s)');

--- a/lib/reporter/logger.js
+++ b/lib/reporter/logger.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var _ = require('lodash');
-var chalk = require('chalk');
+const _ = require('lodash');
+const chalk = require('chalk');
 
-var util = require('./util');
+const util = require('./util');
 
 function logModule(log, logType, module) {
   log[logType](chalk.yellow('module name:'), module.name);

--- a/lib/reporter/logger.js
+++ b/lib/reporter/logger.js
@@ -1,5 +1,4 @@
 'use strict';
-
 const _ = require('lodash');
 const chalk = require('chalk');
 

--- a/lib/reporter/markdown.js
+++ b/lib/reporter/markdown.js
@@ -25,9 +25,9 @@ function markdown(logger, modules) {
     modules = [modules];
   }
 
-  var passed = util.getPassing(modules);
-  var flaky = util.getFlakyFails(modules);
-  var failed = util.getFails(modules);
+  const passed = util.getPassing(modules);
+  const flaky = util.getFlakyFails(modules);
+  const failed = util.getFails(modules);
 
   if (failed.length === 0) {
     logger('## 🎉🎉 CITGM Passed 🎉🎉');

--- a/lib/reporter/markdown.js
+++ b/lib/reporter/markdown.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var _ = require('lodash');
+const _ = require('lodash');
 
-var util = require('./util');
+const util = require('./util');
 
 function printModulesMarkdown(logger, title, modules) {
   if (modules.length > 0) {

--- a/lib/reporter/markdown.js
+++ b/lib/reporter/markdown.js
@@ -1,5 +1,4 @@
 'use strict';
-
 const _ = require('lodash');
 
 const util = require('./util');

--- a/lib/reporter/tap.js
+++ b/lib/reporter/tap.js
@@ -6,21 +6,21 @@ const _ = require('lodash');
 const util = require('./util');
 
 function generateTest(mod, count) {
-  var result = (!mod.error || mod.flaky) ? 'ok' : 'not ok';
-  var directive = (mod.flaky && mod.error) ? ' # SKIP' : '';
+  const result = (!mod.error || mod.flaky) ? 'ok' : 'not ok';
+  const directive = (mod.flaky && mod.error) ? ' # SKIP' : '';
   if (mod.error && mod.error.message) {
     mod.error = mod.error.message;
   }
-  var error = mod.error ? [directive, mod.error].join(' ') : '';
-  var duration = '\n  duration_ms: ' + mod.duration;
-  var output = mod.testOutput ? '\n' + util.sanitizeOutput(mod.testOutput,
+  const error = mod.error ? [directive, mod.error].join(' ') : '';
+  const duration = '\n  duration_ms: ' + mod.duration;
+  const output = mod.testOutput ? '\n' + util.sanitizeOutput(mod.testOutput,
         '  #') : '';
   return [result, count + 1, '-', mod.name, 'v' + mod.version + error +
       '\n  ---' + output + duration + '\n  ...'].join(' ');
 }
 
 function generateTap(modules) {
-  var modulesTap = _.map(modules, generateTest).join('\n');
+  const modulesTap = _.map(modules, generateTest).join('\n');
   return 'TAP version 13\n' + modulesTap + '\n1..' + modules.length;
 }
 
@@ -28,7 +28,7 @@ function tap(logger, modules, append) {
   if (!(modules instanceof Array)) {
     modules = [modules];
   }
-  var payload = generateTap(modules);
+  const payload = generateTap(modules);
   if (typeof logger === 'string') {
     if (append){
       fs.appendFileSync(logger, payload + '\n');

--- a/lib/reporter/tap.js
+++ b/lib/reporter/tap.js
@@ -1,9 +1,9 @@
 'use strict';
-var fs = require('fs');
+const fs = require('fs');
 
-var _ = require('lodash');
+const _ = require('lodash');
 
-var util = require('./util');
+const util = require('./util');
 
 function generateTest(mod, count) {
   var result = (!mod.error || mod.flaky) ? 'ok' : 'not ok';

--- a/lib/reporter/util.js
+++ b/lib/reporter/util.js
@@ -1,6 +1,6 @@
 'use strict';
-var _ = require('lodash');
-var xmlSanitizer = require('xml-sanitizer');
+const _ = require('lodash');
+const xmlSanitizer = require('xml-sanitizer');
 
 function getPassing(modules) {
   return _.filter(modules, function (mod) {

--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -1,5 +1,5 @@
 // Node modules
-var child = require('child_process');
+const child = require('child_process');
 
 function spawn(cmd, args, options) {
   if (process.platform === 'win32') {

--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -1,5 +1,4 @@
 'use strict';
-// Node modules
 const child = require('child_process');
 
 function spawn(cmd, args, options) {

--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -1,3 +1,4 @@
+'use strict';
 // Node modules
 const child = require('child_process');
 

--- a/lib/temp-directory.js
+++ b/lib/temp-directory.js
@@ -1,12 +1,10 @@
 'use strict';
-// Node modules
 let path = require('path'); // Mocked in tests
 
-// Npm modules
 const mkdirp = require('mkdirp');
+const osenv = require('osenv');
 const rimraf = require('rimraf');
 const uuid = require('uuid');
-const osenv = require('osenv');
 
 function create(context, next) {
   if (context.options && context.options.tmpDir) {

--- a/lib/temp-directory.js
+++ b/lib/temp-directory.js
@@ -1,11 +1,11 @@
 // Node modules
-var path = require('path');
+let path = require('path'); // Mocked in tests
 
 // Npm modules
-var mkdirp = require('mkdirp');
-var rimraf = require('rimraf');
-var uuid = require('uuid');
-var osenv = require('osenv');
+const mkdirp = require('mkdirp');
+const rimraf = require('rimraf');
+const uuid = require('uuid');
+const osenv = require('osenv');
 
 function create(context, next) {
   if (context.options && context.options.tmpDir) {

--- a/lib/temp-directory.js
+++ b/lib/temp-directory.js
@@ -1,3 +1,4 @@
+'use strict';
 // Node modules
 let path = require('path'); // Mocked in tests
 

--- a/lib/unpack.js
+++ b/lib/unpack.js
@@ -11,13 +11,13 @@ function unpack(context, next) {
       if (exists) {
         context.emit('data', 'silly', context.module.name +
             ' gzip-unpack-start', context.unpack);
-        var gzip = zlib.createGunzip();
-        var inp = fs.createReadStream(context.unpack);
-        var out = tar.Extract({
+        const gzip = zlib.createGunzip();
+        const inp = fs.createReadStream(context.unpack);
+        const out = tar.Extract({
           path: path.join(context.path, context.module.name),
           strip: 1
         });
-        var res = inp.pipe(gzip).pipe(out);
+        const res = inp.pipe(gzip).pipe(out);
         res.on('end', function() {
           context.emit('data', 'silly', context.module.name +
               ' gzip-unpack-end', context.unpack);

--- a/lib/unpack.js
+++ b/lib/unpack.js
@@ -1,10 +1,10 @@
 // Node modules
-var fs = require('fs');
-var zlib = require('zlib');
-var path = require('path');
+const fs = require('fs');
+const zlib = require('zlib');
+const path = require('path');
 
 // Npm modules
-var tar = require('tar');
+const tar = require('tar');
 
 function unpack(context, next) {
   if (typeof context.unpack === 'string') {

--- a/lib/unpack.js
+++ b/lib/unpack.js
@@ -1,3 +1,4 @@
+'use strict';
 // Node modules
 const fs = require('fs');
 const zlib = require('zlib');

--- a/lib/unpack.js
+++ b/lib/unpack.js
@@ -1,10 +1,8 @@
 'use strict';
-// Node modules
 const fs = require('fs');
-const zlib = require('zlib');
 const path = require('path');
+const zlib = require('zlib');
 
-// Npm modules
 const tar = require('tar');
 
 function unpack(context, next) {

--- a/lib/update.js
+++ b/lib/update.js
@@ -1,8 +1,8 @@
 'use strict';
-var updateNotifier = require('update-notifier');
-var pkg = require('../package.json');
-var semver = require('semver');
-var util = require('util');
+const updateNotifier = require('update-notifier');
+const pkg = require('../package.json');
+const semver = require('semver');
+const util = require('util');
 
 module.exports = function(log) {
   updateNotifier({

--- a/lib/update.js
+++ b/lib/update.js
@@ -1,8 +1,10 @@
 'use strict';
-const updateNotifier = require('update-notifier');
-const pkg = require('../package.json');
-const semver = require('semver');
 const util = require('util');
+
+const semver = require('semver');
+const updateNotifier = require('update-notifier');
+
+const pkg = require('../package.json');
 
 module.exports = function(log) {
   updateNotifier({

--- a/test/bin/test-citgm-all.js
+++ b/test/bin/test-citgm-all.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var test = require('tap').test;
-var spawn = require('../../lib/spawn');
+const test = require('tap').test;
+const spawn = require('../../lib/spawn');
 
-var citgmAllPath = require.resolve('../../bin/citgm-all.js');
+const citgmAllPath = require.resolve('../../bin/citgm-all.js');
 
 test('citgm-all: /w markdown /w -j', function (t) {
   t.plan(1);
-  var proc = spawn(citgmAllPath, ['-l', 'test/fixtures/custom-lookup.json',
+  const proc = spawn(citgmAllPath, ['-l', 'test/fixtures/custom-lookup.json',
     '-m', '-j', '1']);
   proc.on('error', function(err) {
     t.error(err);
@@ -20,7 +20,7 @@ test('citgm-all: /w markdown /w -j', function (t) {
 
 test('citgm-all: envVar /w -J', function (t) {
   t.plan(1);
-  var proc = spawn(citgmAllPath, ['-l',
+  const proc = spawn(citgmAllPath, ['-l',
     'test/fixtures/custom-lookup-envVar.json', '-J']);
   proc.on('error', function(err) {
     t.error(err);
@@ -32,7 +32,7 @@ test('citgm-all: envVar /w -J', function (t) {
 
 test('citgm-all: /w missing lookup.json', function (t) {
   t.plan(1);
-  var proc = spawn(citgmAllPath, ['-l',
+  const proc = spawn(citgmAllPath, ['-l',
     'test/fixtures/this-does-not-exist-json']);
   proc.on('error', function(err) {
     t.error(err);
@@ -45,7 +45,7 @@ test('citgm-all: /w missing lookup.json', function (t) {
 
 test('citgm-all: /w bad lookup.json', function (t) {
   t.plan(1);
-  var proc = spawn(citgmAllPath, ['-l',
+  const proc = spawn(citgmAllPath, ['-l',
     'test/fixtures/custom-lookup-broken.json']);
   proc.on('error', function(err) {
     t.error(err);
@@ -58,8 +58,8 @@ test('citgm-all: /w bad lookup.json', function (t) {
 
 test('citgm-all: fail /w tap /w junit', function (t) {
   t.plan(1);
-  var proc = spawn(citgmAllPath, ['-l', 'test/fixtures/custom-lookup-fail.json',
-    '-t', '-x']);
+  const proc = spawn(citgmAllPath, ['-l',
+    'test/fixtures/custom-lookup-fail.json', '-t', '-x']);
   proc.on('error', function(err) {
     t.error(err);
   });
@@ -70,7 +70,7 @@ test('citgm-all: fail /w tap /w junit', function (t) {
 
 test('citgm-all: flaky-fail', function (t) {
   t.plan(1);
-  var proc = spawn(citgmAllPath, ['-l',
+  const proc = spawn(citgmAllPath, ['-l',
     'test/fixtures/custom-lookup-flaky.json']);
   proc.on('error', function(err) {
     t.error(err);
@@ -82,7 +82,7 @@ test('citgm-all: flaky-fail', function (t) {
 
 test('citgm-all: fail expectFail', function (t) {
   t.plan(1);
-  var proc = spawn(citgmAllPath, ['-l',
+  const proc = spawn(citgmAllPath, ['-l',
     'test/fixtures/custom-lookup-expectFail.json']);
   proc.on('error', function(err) {
     t.error(err);
@@ -94,7 +94,7 @@ test('citgm-all: fail expectFail', function (t) {
 
 test('citgm-all: pass expectFail', function (t) {
   t.plan(1);
-  var proc = spawn(citgmAllPath, ['-l',
+  const proc = spawn(citgmAllPath, ['-l',
     'test/fixtures/custom-lookup-expectFail-fail.json']);
   proc.on('error', function(err) {
     t.error(err);
@@ -106,7 +106,7 @@ test('citgm-all: pass expectFail', function (t) {
 
 test('citgm-all: test with replace', function (t) {
   t.plan(1);
-  var proc = spawn(citgmAllPath, ['-l',
+  const proc = spawn(citgmAllPath, ['-l',
     'test/fixtures/custom-lookup-backwards-compatibilty.json']);
   proc.on('error', function(err) {
     t.error(err);
@@ -118,7 +118,7 @@ test('citgm-all: test with replace', function (t) {
 
 test('citgm-all: flaky-fail ignoring flakyness', function (t) {
   t.plan(1);
-  var proc = spawn(citgmAllPath, ['-f', '-l',
+  const proc = spawn(citgmAllPath, ['-f', '-l',
     'test/fixtures/custom-lookup-flaky.json']);
   proc.on('error', function(err) {
     t.error(err);
@@ -131,8 +131,9 @@ test('citgm-all: flaky-fail ignoring flakyness', function (t) {
 test('citgm-all: skip /w rootcheck /w tap to fs /w junit to fs /w append',
 function (t) {
   t.plan(1);
-  var proc = spawn(citgmAllPath, ['-l', 'test/fixtures/custom-lookup-skip.json',
-    '-s', '--tap', '/dev/null', '--junit', '/dev/null', '-a']);
+  const proc = spawn(citgmAllPath, ['-l',
+    'test/fixtures/custom-lookup-skip.json', '-s', '--tap', '/dev/null',
+    '--junit', '/dev/null', '-a']);
   proc.on('error', function(err) {
     t.error(err);
   });
@@ -144,7 +145,7 @@ function (t) {
 test('bin: sigterm', function (t) {
   t.plan(1);
 
-  var proc = spawn(citgmAllPath, ['-l', 'test/fixtures/custom-lookup.json',
+  const proc = spawn(citgmAllPath, ['-l', 'test/fixtures/custom-lookup.json',
     '-m']);
   proc.on('error', function(err) {
     t.error(err);

--- a/test/bin/test-citgm.js
+++ b/test/bin/test-citgm.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var test = require('tap').test;
+const test = require('tap').test;
 
-var spawn = require('../../lib/spawn');
+const spawn = require('../../lib/spawn');
 
-var citgmPath = require.resolve('../../bin/citgm.js');
+const citgmPath = require.resolve('../../bin/citgm.js');
 
 test('bin: omg-i-pass /w tap output /w junit', function (t) {
   t.plan(1);

--- a/test/bin/test-citgm.js
+++ b/test/bin/test-citgm.js
@@ -8,7 +8,7 @@ const citgmPath = require.resolve('../../bin/citgm.js');
 
 test('bin: omg-i-pass /w tap output /w junit', function (t) {
   t.plan(1);
-  var proc = spawn(citgmPath, ['omg-i-pass', '-t', '-x']);
+  const proc = spawn(citgmPath, ['omg-i-pass', '-t', '-x']);
   proc.on('error', function(err) {
     t.error(err);
     t.fail('we should not get an error testing omg-i-pass');
@@ -20,7 +20,7 @@ test('bin: omg-i-pass /w tap output /w junit', function (t) {
 
 test('bin: omg-i-fail /w markdown output /w nodedir', function (t) {
   t.plan(1);
-  var proc = spawn(citgmPath, ['omg-i-fail', '-m', '-d', '/dev/null']);
+  const proc = spawn(citgmPath, ['omg-i-fail', '-m', '-d', '/dev/null']);
   proc.on('error', function(err) {
     t.error(err);
     t.fail('we should not get an error testing omg-i-pass');
@@ -32,7 +32,7 @@ test('bin: omg-i-fail /w markdown output /w nodedir', function (t) {
 
 test('bin: omg-i-pass /w local module', function (t) {
   t.plan(1);
-  var proc = spawn(citgmPath, ['./test/fixtures/omg-i-pass']);
+  const proc = spawn(citgmPath, ['./test/fixtures/omg-i-pass']);
   proc.on('error', function(err) {
     t.error(err);
     t.fail('we should not get an error testing omg-i-pass');
@@ -45,7 +45,7 @@ test('bin: omg-i-pass /w local module', function (t) {
 test('bin: omg-i-fail /w custom script /w tap to file /w'
   + ' junit to file /w append', function (t) {
   t.plan(1);
-  var proc = spawn(citgmPath, ['omg-i-fail', '-l',
+  const proc = spawn(citgmPath, ['omg-i-fail', '-l',
     './test/fixtures/custom-lookup-script.json', '--tap', '/dev/null',
     '--junit', '/dev/null', '--append']);
   proc.on('error', function(err) {
@@ -60,7 +60,7 @@ test('bin: omg-i-fail /w custom script /w tap to file /w'
 test('bin: omg-i-pass /w custom script /w tap to file /w junit to file'
   + ' /w append', function (t) {
   t.plan(1);
-  var proc = spawn(citgmPath, ['omg-i-pass', '-l',
+  const proc = spawn(citgmPath, ['omg-i-pass', '-l',
     './test/fixtures/custom-lookup-script.json', '--tap', '/dev/null',
     '--junit', '/dev/null', '--append']);
   proc.on('error', function(err) {
@@ -74,7 +74,7 @@ test('bin: omg-i-pass /w custom script /w tap to file /w junit to file'
 
 test('bin: omg-i-fail /w custom test script passing', function (t) {
   t.plan(1);
-  var proc = spawn(citgmPath, ['omg-i-fail',
+  const proc = spawn(citgmPath, ['omg-i-fail',
     './test/fixtures/example-test-script-passing.sh']);
   proc.on('error', function(err) {
     t.error(err);
@@ -88,7 +88,7 @@ test('bin: omg-i-fail /w custom test script passing', function (t) {
 
 test('bin: omg-i-pass /w custom test script failing', function (t) {
   t.plan(1);
-  var proc = spawn(citgmPath, ['omg-i-pass',
+  const proc = spawn(citgmPath, ['omg-i-pass',
     './test/fixtures/example-test-script-failing.sh']);
   proc.on('error', function(err) {
     t.error(err);
@@ -101,7 +101,7 @@ test('bin: omg-i-pass /w custom test script failing', function (t) {
 
 test('bin: no module /w root check', function (t) {
   t.plan(1);
-  var proc = spawn(citgmPath, ['-s']);
+  const proc = spawn(citgmPath, ['-s']);
   proc.on('error', function(err) {
     t.error(err);
     t.fail('we should not get an error');
@@ -114,7 +114,7 @@ test('bin: no module /w root check', function (t) {
 test('bin: sigterm', function (t) {
   t.plan(1);
 
-  var proc = spawn(citgmPath, ['omg-i-pass', '-v', 'verbose']);
+  const proc = spawn(citgmPath, ['omg-i-pass', '-v', 'verbose']);
   proc.on('error', function(err) {
     t.error(err);
     t.fail('we should not get an error testing omg-i-pass');
@@ -129,7 +129,7 @@ test('bin: sigterm', function (t) {
 
 test('bin: install from sha', function (t) {
   t.plan(1);
-  var proc = spawn(citgmPath, ['omg-i-pass', '-t', '-c',
+  const proc = spawn(citgmPath, ['omg-i-pass', '-t', '-c',
     '37c34bad563599782c622baf3aaf55776fbc38a8']);
   proc.on('error', function(err) {
     t.error(err);

--- a/test/fixtures/omg-i-pass-with-install-param/test_args.js
+++ b/test/fixtures/omg-i-pass-with-install-param/test_args.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+'use strict';
 
 /*
   Test 'npm-install: extra install parameters' from 'npm/test-npm-install.js'

--- a/test/fixtures/request-mock.js
+++ b/test/fixtures/request-mock.js
@@ -1,5 +1,5 @@
-var EventEmitter = require('events').EventEmitter;
-var util = require('util');
+const EventEmitter = require('events').EventEmitter;
+const util = require('util');
 
 function RequestMock() {
   if (!(this instanceof RequestMock))

--- a/test/fixtures/request-mock.js
+++ b/test/fixtures/request-mock.js
@@ -1,3 +1,4 @@
+'use strict';
 const EventEmitter = require('events').EventEmitter;
 const util = require('util');
 

--- a/test/npm/test-npm-author-name.js
+++ b/test/npm/test-npm-author-name.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var test = require('tap').test;
-var rewire = require('rewire');
+const test = require('tap').test;
+const rewire = require('rewire');
 
-var npmTest = rewire('../../lib/npm/test');
+const npmTest = rewire('../../lib/npm/test');
 
-var authorName = npmTest.__get__('authorName');
+const authorName = npmTest.__get__('authorName');
 
 test('npm.test() authorName:', function (t) {
   var name = 'titus';

--- a/test/npm/test-npm-author-name.js
+++ b/test/npm/test-npm-author-name.js
@@ -8,13 +8,13 @@ const npmTest = rewire('../../lib/npm/test');
 const authorName = npmTest.__get__('authorName');
 
 test('npm.test() authorName:', function (t) {
-  var name = 'titus';
-  var author = {
+  const name = 'titus';
+  const author = {
     name: 'Randy Savage',
     email: 'randy@wwe.rekt',
     url: 'omg.html'
   };
-  var authorExpected = 'Randy Savage <randy@wwe.rekt> (omg.html)';
+  const authorExpected = 'Randy Savage <randy@wwe.rekt> (omg.html)';
   t.equals(authorName(name), name, 'it should return any string');
   t.equals(authorName(author), authorExpected, 'it should return the expected'
     + ' string when given an object');
@@ -22,15 +22,15 @@ test('npm.test() authorName:', function (t) {
 });
 
 test('npm.test() authorName partial data:', function (t) {
-  var name = 'titus';
-  var authorOne = {
+  const name = 'titus';
+  const authorOne = {
     name: 'Randy Savage'
   };
-  var authorOneExpected = 'Randy Savage';
-  var authorTwo = {
+  const authorOneExpected = 'Randy Savage';
+  const authorTwo = {
     email: 'thedude@abides.net'
   };
-  var authorTwoExpected = '<thedude@abides.net>';
+  const authorTwoExpected = '<thedude@abides.net>';
   t.equals(authorName(name), name, 'it should return any string');
   t.equals(authorName(authorOne), authorOneExpected, 'it should return the'
     + ' expected string when given an object');

--- a/test/npm/test-npm-install.js
+++ b/test/npm/test-npm-install.js
@@ -1,23 +1,23 @@
 'use strict';
-var os = require('os');
-var path = require('path');
-var fs = require('fs');
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
 
-var test = require('tap').test;
-var mkdirp = require('mkdirp');
-var rimraf = require('rimraf');
-var ncp = require('ncp');
+const test = require('tap').test;
+const mkdirp = require('mkdirp');
+const rimraf = require('rimraf');
+const ncp = require('ncp');
 
-var npmInstall = require('../../lib/npm/install');
+const npmInstall = require('../../lib/npm/install');
 
-var sandbox = path.join(os.tmpdir(), 'citgm-' + Date.now());
-var fixtures = path.join(__dirname, '..', 'fixtures');
-var moduleFixtures = path.join(fixtures, 'omg-i-pass');
-var moduleTemp = path.join(sandbox, 'omg-i-pass');
-var extraParamFixtures = path.join(fixtures, 'omg-i-pass-with-install-param');
-var extraParamTemp = path.join(sandbox, 'omg-i-pass-with-install-param');
-var badFixtures = path.join(fixtures, 'omg-bad-tree');
-var badTemp = path.join(sandbox, 'omg-bad-tree');
+const sandbox = path.join(os.tmpdir(), 'citgm-' + Date.now());
+const fixtures = path.join(__dirname, '..', 'fixtures');
+const moduleFixtures = path.join(fixtures, 'omg-i-pass');
+const moduleTemp = path.join(sandbox, 'omg-i-pass');
+const extraParamFixtures = path.join(fixtures, 'omg-i-pass-with-install-param');
+const extraParamTemp = path.join(sandbox, 'omg-i-pass-with-install-param');
+const badFixtures = path.join(fixtures, 'omg-bad-tree');
+const badTemp = path.join(sandbox, 'omg-bad-tree');
 
 test('npm-install: setup', function (t) {
   t.plan(7);

--- a/test/npm/test-npm-install.js
+++ b/test/npm/test-npm-install.js
@@ -39,7 +39,7 @@ test('npm-install: setup', function (t) {
 });
 
 test('npm-install: basic module', function (t) {
-  var context = {
+  const context = {
     emit: function() {},
     path: sandbox,
     module: {
@@ -57,7 +57,7 @@ test('npm-install: basic module', function (t) {
 });
 
 test('npm-install: extra install parameters', function (t) {
-  var context = {
+  const context = {
     emit: function() {},
     path: sandbox,
     module: {
@@ -76,7 +76,7 @@ test('npm-install: extra install parameters', function (t) {
 });
 
 test('npm-install: no package.json', function (t) {
-  var context = {
+  const context = {
     emit: function() {},
     path: sandbox,
     module: {
@@ -94,7 +94,7 @@ test('npm-install: no package.json', function (t) {
 });
 
 test('npm-install: timeout', function (t) {
-  var context = {
+  const context = {
     emit: function() {},
     path: sandbox,
     module: {
@@ -113,7 +113,7 @@ test('npm-install: timeout', function (t) {
 });
 
 test('npm-install: failed install', function (t) {
-  var context = {
+  const context = {
     emit: function() {},
     path: sandbox,
     module: {
@@ -125,7 +125,7 @@ test('npm-install: failed install', function (t) {
     }
   };
 
-  var expected = {
+  const expected = {
     testOutput: /^$/,
     testError: 'npm ERR! 404 Registry returned 404 for GET on'
     + ' https://registry.npmjs.org/THIS-WILL-FAIL'

--- a/test/npm/test-npm-script-fetch.js
+++ b/test/npm/test-npm-script-fetch.js
@@ -1,27 +1,27 @@
 'use strict';
 
-var path = require('path');
-var fs = require('fs');
-var os = require('os');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
 
-var test = require('tap').test;
-var mkdirp = require('mkdirp');
-var rimraf = require('rimraf');
-var rewire = require('rewire');
+const test = require('tap').test;
+const mkdirp = require('mkdirp');
+const rimraf = require('rimraf');
+const rewire = require('rewire');
 
-var fetch = rewire('../../lib/npm/script/fetch');
-var RequestMock = require('../fixtures/request-mock');
+const fetch = rewire('../../lib/npm/script/fetch');
+const RequestMock = require('../fixtures/request-mock');
 
-var fixtures = path.join(__dirname, '..', 'fixtures');
-var passing = path.join(fixtures, 'example-test-script-passing.sh');
-var uriHttp = 'http://gist.githubusercontent.com/MylesBorins/0bf45af05c7580c4d8'
-    + '0f/raw/08e52f1a64410e91203c909a6a90255d48273b75/example-test-script-'
+const fixtures = path.join(__dirname, '..', 'fixtures');
+const passing = path.join(fixtures, 'example-test-script-passing.sh');
+const uriHttp = 'http://gist.githubusercontent.com/MylesBorins/0bf45af05c7580'
+    + 'c4d80f/raw/08e52f1a64410e91203c909a6a90255d48273b75/example-test-script-'
     + 'passing.sh';
-var uriHttps = 'https://gist.githubusercontent.com/MylesBorins/0bf45af05c7580c4'
-    + 'd80f/raw/08e52f1a64410e91203c909a6a90255d48273b75/example-test-script-'
-    + 'passing.sh';
+const uriHttps = 'https://gist.githubusercontent.com/MylesBorins/0bf45af05c75'
+    + '80c4d80f/raw/08e52f1a64410e91203c909a6a90255d48273b75/example-test-'
+    + 'script-passing.sh';
 
-var sandbox = path.join(os.tmpdir(), 'citgm-' + Date.now());
+const sandbox = path.join(os.tmpdir(), 'citgm-' + Date.now());
 
 test('fetch: setup', function (t) {
   mkdirp(sandbox, function (err) {

--- a/test/npm/test-npm-script-fetch.js
+++ b/test/npm/test-npm-script-fetch.js
@@ -31,7 +31,7 @@ test('fetch: setup', function (t) {
 });
 
 test('fetch: given a file path', function (t) {
-  var context = {
+  const context = {
     path: sandbox,
     emit: function () {},
     module: {
@@ -52,7 +52,7 @@ test('fetch: given a file path', function (t) {
 });
 
 test('fetch: given a custom lookup table and relative path', function (t) {
-  var context = {
+  const context = {
     path: sandbox,
     emit: function () {},
     module: {
@@ -76,7 +76,7 @@ test('fetch: given a custom lookup table and relative path', function (t) {
 });
 
 test('fetch: given a uri with http', function (t) {
-  var context = {
+  const context = {
     path: sandbox,
     emit: function () {},
     module: {
@@ -95,7 +95,7 @@ test('fetch: given a uri with http', function (t) {
 });
 
 test('fetch: given a uri with https', function (t) {
-  var context = {
+  const context = {
     path: sandbox,
     emit: function () {},
     module: {
@@ -114,7 +114,7 @@ test('fetch: given a uri with https', function (t) {
 });
 
 test('fetch: properly handle errors from request', function (t) {
-  var context = {
+  const context = {
     path: sandbox,
     emit: function () {},
     module: {
@@ -122,9 +122,9 @@ test('fetch: properly handle errors from request', function (t) {
     }
   };
 
-  var request = fetch.__get__('request');
-  var fs = fetch.__get__('fs');
-  var createWriteStream = fs.createWriteStream;
+  const request = fetch.__get__('request');
+  const fs = fetch.__get__('fs');
+  const createWriteStream = fs.createWriteStream;
   fs.createWriteStream = function () {};
   fetch.__set__('request', RequestMock);
   fetch(context, 'http://do-nothing.com', function (err) {

--- a/test/npm/test-npm-script-run.js
+++ b/test/npm/test-npm-script-run.js
@@ -1,20 +1,20 @@
-var test = require('tap').test;
-var path = require('path');
-var os = require('os');
+const test = require('tap').test;
+const path = require('path');
+const os = require('os');
 
-var mkdirp = require('mkdirp');
-var rimraf = require('rimraf');
-var rewire = require('rewire');
+const mkdirp = require('mkdirp');
+const rimraf = require('rimraf');
+const rewire = require('rewire');
 
-var run = rewire('../../lib/npm/script/run');
+const run = rewire('../../lib/npm/script/run');
 
-var fixtures = path.join(__dirname, '..', 'fixtures');
+const fixtures = path.join(__dirname, '..', 'fixtures');
 
-var passingScript = path.join(fixtures, 'example-test-script-passing.sh');
-var failingScript = path.join(fixtures, 'example-test-script-failing.sh');
-var badPath = path.join(fixtures, 'example-test-script-does-not-exist');
+const passingScript = path.join(fixtures, 'example-test-script-passing.sh');
+const failingScript = path.join(fixtures, 'example-test-script-failing.sh');
+const badPath = path.join(fixtures, 'example-test-script-does-not-exist');
 
-var sandbox = path.join(os.tmpdir(), 'citgm-' + Date.now() + 'run-test');
+const sandbox = path.join(os.tmpdir(), 'citgm-' + Date.now() + 'run-test');
 
 test('npm.script.run: setup', function (t) {
   mkdirp(sandbox, function (err) {

--- a/test/npm/test-npm-script-run.js
+++ b/test/npm/test-npm-script-run.js
@@ -25,7 +25,7 @@ test('npm.script.run: setup', function (t) {
 });
 
 test('npm.script.run: should pass with passing script', function (t) {
-  var context = {
+  const context = {
     path: sandbox,
     emit: function () {},
     module: {
@@ -41,7 +41,7 @@ test('npm.script.run: should pass with passing script', function (t) {
 });
 
 test('npm.script.run: should fail with failing script', function (t) {
-  var context = {
+  const context = {
     path: sandbox,
     emit: function () {},
     module: {
@@ -49,7 +49,7 @@ test('npm.script.run: should fail with failing script', function (t) {
     },
     options: {}
   };
-  var failingMsg = 'the canary is dead';
+  const failingMsg = 'the canary is dead';
   run(context, failingScript, failingMsg, function (err) {
     t.equals(err && err.message, failingMsg);
     t.end();
@@ -57,7 +57,7 @@ test('npm.script.run: should fail with failing script', function (t) {
 });
 
 test('npm.script.run: should fail with failing script (no msg)', function (t) {
-  var context = {
+  const context = {
     path: sandbox,
     emit: function () {},
     module: {
@@ -72,7 +72,7 @@ test('npm.script.run: should fail with failing script (no msg)', function (t) {
 });
 
 test('npm.script.run: should fail with a bad path', function (t) {
-  var context = {
+  const context = {
     path: sandbox,
     emit: function () {},
     module: {

--- a/test/npm/test-npm-script-run.js
+++ b/test/npm/test-npm-script-run.js
@@ -1,3 +1,4 @@
+'use strict';
 const test = require('tap').test;
 const path = require('path');
 const os = require('os');

--- a/test/npm/test-npm-test.js
+++ b/test/npm/test-npm-test.js
@@ -1,29 +1,29 @@
 'use strict';
-var os = require('os');
-var path = require('path');
-var fs = require('fs');
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
 
-var test = require('tap').test;
-var mkdirp = require('mkdirp');
-var rimraf = require('rimraf');
-var ncp = require('ncp');
-var rewire = require('rewire');
+const test = require('tap').test;
+const mkdirp = require('mkdirp');
+const rimraf = require('rimraf');
+const ncp = require('ncp');
+const rewire = require('rewire');
 
-var npmTest = rewire('../../lib/npm/test');
+const npmTest = rewire('../../lib/npm/test');
 
-var sandbox = path.join(os.tmpdir(), 'citgm-' + Date.now());
-var fixtures = path.join(__dirname, '..', 'fixtures');
+const sandbox = path.join(os.tmpdir(), 'citgm-' + Date.now());
+const fixtures = path.join(__dirname, '..', 'fixtures');
 
-var passFixtures = path.join(fixtures, 'omg-i-pass');
-var passTemp = path.join(sandbox, 'omg-i-pass');
+const passFixtures = path.join(fixtures, 'omg-i-pass');
+const passTemp = path.join(sandbox, 'omg-i-pass');
 
-var failFixtures = path.join(fixtures, 'omg-i-fail');
-var failTemp = path.join(sandbox, 'omg-i-fail');
+const failFixtures = path.join(fixtures, 'omg-i-fail');
+const failTemp = path.join(sandbox, 'omg-i-fail');
 
-var badFixtures = path.join(fixtures, 'omg-i-do-not-support-testing');
-var badTemp = path.join(sandbox, 'omg-i-do-not-support-testing');
+const badFixtures = path.join(fixtures, 'omg-i-do-not-support-testing');
+const badTemp = path.join(sandbox, 'omg-i-do-not-support-testing');
 
-var customScript = path.join(fixtures, 'example-test-script-passing.sh');
+const customScript = path.join(fixtures, 'example-test-script-passing.sh');
 
 test('npm-test: setup', function (t) {
   t.plan(7);

--- a/test/npm/test-npm-test.js
+++ b/test/npm/test-npm-test.js
@@ -45,7 +45,7 @@ test('npm-test: setup', function (t) {
 });
 
 test('npm-test: basic module passing', function (t) {
-  var context = {
+  const context = {
     emit: function() {},
     path: sandbox,
     module: {
@@ -63,7 +63,7 @@ test('npm-test: basic module passing', function (t) {
 });
 
 test('npm-test: basic module failing', function (t) {
-  var context = {
+  const context = {
     emit: function() {},
     path: sandbox,
     module: {
@@ -79,7 +79,7 @@ test('npm-test: basic module failing', function (t) {
 });
 
 test('npm-test: basic module no test script', function (t) {
-  var context = {
+  const context = {
     emit: function() {},
     path: sandbox,
     module: {
@@ -95,7 +95,7 @@ test('npm-test: basic module no test script', function (t) {
 });
 
 test('npm-test: no package.json', function (t) {
-  var context = {
+  const context = {
     emit: function() {},
     path: sandbox,
     module: {
@@ -111,7 +111,7 @@ test('npm-test: no package.json', function (t) {
 });
 
 test('npm-test: custom script', function (t) {
-  var context = {
+  const context = {
     emit: function() {},
     path: sandbox,
     module: {
@@ -130,7 +130,7 @@ test('npm-test: custom script', function (t) {
 });
 
 test('npm-test: custom script does not exist', function (t) {
-  var context = {
+  const context = {
     emit: function() {},
     path: sandbox,
     module: {
@@ -150,9 +150,9 @@ test('npm-test: custom script does not exist', function (t) {
 
 test('npm-test: alternative test-path', function (t) {
   // Same test as 'basic module passing', except with alt node bin which fails.
-  var nodeBinName = npmTest.__get__('nodeBinName');
+  const nodeBinName = npmTest.__get__('nodeBinName');
   npmTest.__set__('nodeBinName', 'fake-node');
-  var context = {
+  const context = {
     emit: function() {},
     path: sandbox,
     module: {

--- a/test/reporter/test-reporter-junit.js
+++ b/test/reporter/test-reporter-junit.js
@@ -1,50 +1,51 @@
 'use strict';
-var fs = require('fs');
-var path = require('path');
-var os = require('os');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
 
-var test = require('tap').test;
-var mkdirp = require('mkdirp');
-var rimraf = require('rimraf');
-var _ = require('lodash');
-var parseString = require('xml2js').parseString;
+const test = require('tap').test;
+const mkdirp = require('mkdirp');
+const rimraf = require('rimraf');
+const _ = require('lodash');
+const parseString = require('xml2js').parseString;
 
-var junit = require('../../lib/reporter/junit');
-var fixtures = require('../fixtures/reporter-fixtures');
+const junit = require('../../lib/reporter/junit');
+const fixtures = require('../fixtures/reporter-fixtures');
 
-var fixturesPath = path.join(__dirname, '..', 'fixtures');
-var sandbox = path.join(os.tmpdir(), 'citgm-' + Date.now());
-var outputFile = path.join(sandbox, 'test.xml');
-var outputFileAppend = path.join(sandbox, 'test-append.xml');
+const fixturesPath = path.join(__dirname, '..', 'fixtures');
+const sandbox = path.join(os.tmpdir(), 'citgm-' + Date.now());
+const outputFile = path.join(sandbox, 'test.xml');
+const outputFileAppend = path.join(sandbox, 'test-append.xml');
 
-var appendStartFilePath = path.join(fixturesPath, 'appendTestFileStart.txt');
+const appendStartFilePath = path.join(fixturesPath, 'appendTestFileStart.txt');
 
-var passingInput = [
+const passingInput = [
   fixtures.iPass,
   fixtures.iFlakyPass
 ];
 
-var passingExpectedPath = path.join(fixturesPath, 'test-out-xml-passing.txt');
-var passingExpectedPathAppend = path.join(fixturesPath,
+const passingExpectedPath = path.join(fixturesPath, 'test-out-xml-passing.txt');
+const passingExpectedPathAppend = path.join(fixturesPath,
       'test-out-xml-passing-append.txt');
 
-var passingExpected = fs.readFileSync(passingExpectedPath, 'utf-8');
-var passingExpectedAppend = fs.readFileSync(passingExpectedPathAppend, 'utf-8');
+const passingExpected = fs.readFileSync(passingExpectedPath, 'utf-8');
+const passingExpectedAppend = fs.readFileSync(passingExpectedPathAppend,
+      'utf-8');
 
-var failingInput = [
+const failingInput = [
   fixtures.iPass,
   fixtures.iFlakyFail,
   fixtures.iFail
 ];
 
-var junitParserExpected = require('../fixtures/parsed-junit.json');
-var failingExpectedPath = path.join(fixturesPath, 'test-out-xml-failing.txt');
-var failingExpected = fs.readFileSync(failingExpectedPath, 'utf-8');
+const junitParserExpected = require('../fixtures/parsed-junit.json');
+const failingExpectedPath = path.join(fixturesPath, 'test-out-xml-failing.txt');
+const failingExpected = fs.readFileSync(failingExpectedPath, 'utf-8');
 
-var badOutputPath = path.join(fixturesPath, 'badOutput');
-var badOutputTooPath = path.join(fixturesPath, 'badOutput2');
-var badOutput = fs.readFileSync(badOutputPath, 'utf-8');
-var badOutputToo = fs.readFileSync(badOutputTooPath, 'utf-8');
+const badOutputPath = path.join(fixturesPath, 'badOutput');
+const badOutputTooPath = path.join(fixturesPath, 'badOutput2');
+const badOutput = fs.readFileSync(badOutputPath, 'utf-8');
+const badOutputToo = fs.readFileSync(badOutputTooPath, 'utf-8');
 
 test('reporter.junit(): setup', function (t) {
   mkdirp(sandbox, function (err) {

--- a/test/reporter/test-reporter-junit.js
+++ b/test/reporter/test-reporter-junit.js
@@ -55,7 +55,7 @@ test('reporter.junit(): setup', function (t) {
 });
 
 test('reporter.junit(): passing', function (t) {
-  var output = '';
+  let output = '';
   function logger(message) {
     output += message;
     output += '\n';
@@ -69,15 +69,15 @@ test('reporter.junit(): passing', function (t) {
 
 test('reporter.junit(): bad output', function (t) {
   t.plan(3);
-  var output = '';
+  let output = '';
   function logger(message) {
     output += message;
     output += '\n';
   }
 
-  var corruptXml = _.cloneDeep(passingInput);
+  const corruptXml = _.cloneDeep(passingInput);
   corruptXml[0].testOutput = badOutput;
-  var corruptXmlToo = _.cloneDeep(passingInput);
+  const corruptXmlToo = _.cloneDeep(passingInput);
   corruptXmlToo[0].testOutput = badOutputToo;
 
   t.doesNotThrow(function () {
@@ -92,7 +92,7 @@ test('reporter.junit(): bad output', function (t) {
 });
 
 test('reporter.junit(): failing', function (t) {
-  var output = '';
+  let output = '';
   function logger(message) {
     output += message;
     output += '\n';
@@ -105,7 +105,7 @@ test('reporter.junit(): failing', function (t) {
 });
 
 test('reporter.junit(): parser', function (t) {
-  var output = '';
+  let output = '';
   function logger(message) {
     output += message;
     output += '\n';
@@ -121,17 +121,17 @@ test('reporter.junit(): parser', function (t) {
 
 test('reporter.junit(): write to disk', function (t) {
   junit(outputFile, passingInput);
-  var expected = fs.readFileSync(outputFile, 'utf8');
+  const expected = fs.readFileSync(outputFile, 'utf8');
   t.equals(expected, passingExpected), 'the file on disk should match the'
   + ' expected output';
   t.end();
 });
 
 test('reporter.junit(): append to disk', function (t) {
-  var appendStartFile = fs.readFileSync(appendStartFilePath, 'utf-8');
+  const appendStartFile = fs.readFileSync(appendStartFilePath, 'utf-8');
   fs.writeFileSync(outputFileAppend, appendStartFile);
   junit(outputFileAppend, passingInput, true);
-  var expected = fs.readFileSync(outputFileAppend, 'utf-8');
+  const expected = fs.readFileSync(outputFileAppend, 'utf-8');
   t.equals(expected, passingExpectedAppend), 'the file on disk should match the'
   + ' expected output';
   t.end();

--- a/test/reporter/test-reporter-logger.js
+++ b/test/reporter/test-reporter-logger.js
@@ -1,10 +1,10 @@
 'use strict';
-var test = require('tap').test;
+const test = require('tap').test;
 
-var loggerReporter = require('../../lib/reporter/logger');
-var fixtures = require('../fixtures/reporter-fixtures');
+const loggerReporter = require('../../lib/reporter/logger');
+const fixtures = require('../fixtures/reporter-fixtures');
 
-var output = '';
+let output = '';
 
 function metaLogger(title, msg) {
   output += title;
@@ -12,7 +12,7 @@ function metaLogger(title, msg) {
     output += msg;
   }
 }
-var logger = {
+const logger = {
   info: metaLogger,
   error: metaLogger,
   warn: metaLogger

--- a/test/reporter/test-reporter-logger.js
+++ b/test/reporter/test-reporter-logger.js
@@ -19,7 +19,7 @@ const logger = {
 };
 
 test('single passing module:', function (t) {
-  var expected = 'passing module(s)';
+  let expected = 'passing module(s)';
   expected += 'module name:' + 'iPass';
   expected += 'version:' + '4.2.2';
   expected += 'done';
@@ -31,7 +31,7 @@ test('single passing module:', function (t) {
 });
 
 test('single failing module:', function (t) {
-  var expected = 'failing module(s)';
+  let expected = 'failing module(s)';
   expected += 'module name:' + 'iFail';
   expected += 'version:' + '3.0.1';
   expected += 'error:' + 'I dun wurk';
@@ -45,7 +45,7 @@ test('single failing module:', function (t) {
 });
 
 test('multiple modules passing, with a flaky module that fails:', function (t) {
-  var expected = 'passing module(s)';
+  let expected = 'passing module(s)';
   expected += 'module name:' + 'iPass';
   expected += 'version:' + '4.2.2';
   expected += 'module name:' + 'iFlakyPass';

--- a/test/reporter/test-reporter-markdown.js
+++ b/test/reporter/test-reporter-markdown.js
@@ -1,15 +1,15 @@
 'use strict';
-var test = require('tap').test;
+const test = require('tap').test;
 
-var markdown = require('../../lib/reporter/markdown');
-var fixtures = require('../fixtures/reporter-fixtures');
+const markdown = require('../../lib/reporter/markdown');
+const fixtures = require('../fixtures/reporter-fixtures');
 
 test('single passing module:', function (t) {
-  var output = '';
+  let output = '';
   markdown(function logger(data) {
     output += data;
   }, fixtures.iPass);
-  var expected = '## 🎉🎉 CITGM Passed 🎉🎉';
+  let expected = '## 🎉🎉 CITGM Passed 🎉🎉';
   expected += '### Passing Modules';
   expected += '  * iPass v4.2.2 duration:50ms';
   t.equals(output, expected, 'we should have the expected markdown output');
@@ -17,11 +17,11 @@ test('single passing module:', function (t) {
 });
 
 test('single failing module:', function (t) {
-  var output = '';
+  let output = '';
   markdown(function logger(data) {
     output += data;
   }, fixtures.iFail);
-  var expected = '## 🔥⚠️🔥 CITGM FAILED 🔥⚠️🔥';
+  let expected = '## 🔥⚠️🔥 CITGM FAILED 🔥⚠️🔥';
   expected += '### Failing Modules';
   expected += '  * iFail v3.0.1 duration:50ms';
   expected += '    - I dun wurk';
@@ -31,11 +31,11 @@ test('single failing module:', function (t) {
 });
 
 test('multiple modules passing, with a flaky module that fails:', function (t) {
-  var output = '';
+  let output = '';
   markdown(function logger(data) {
     output += data;
   }, [fixtures.iPass, fixtures.iFlakyPass, fixtures.iFlakyFail]);
-  var expected = '## 🎉🎉 CITGM Passed 🎉🎉';
+  let expected = '## 🎉🎉 CITGM Passed 🎉🎉';
   expected += '## 📛 But with Flaky Failures 📛';
   expected += '### Passing Modules';
   expected += '  * iPass v4.2.2 duration:50ms';

--- a/test/reporter/test-reporter-tap.js
+++ b/test/reporter/test-reporter-tap.js
@@ -1,47 +1,48 @@
 // TODO this test does not test any functionality currently
 'use strict';
-var fs = require('fs');
-var path = require('path');
-var os = require('os');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
 
-var test = require('tap').test;
-var mkdirp = require('mkdirp');
-var rimraf = require('rimraf');
-var parser = require('tap-parser');
-var str = require('string-to-stream');
+const test = require('tap').test;
+const mkdirp = require('mkdirp');
+const rimraf = require('rimraf');
+const parser = require('tap-parser');
+const str = require('string-to-stream');
 
-var tap = require('../../lib/reporter/tap');
-var fixtures = require('../fixtures/reporter-fixtures');
+const tap = require('../../lib/reporter/tap');
+const fixtures = require('../fixtures/reporter-fixtures');
 
-var fixturesPath = path.join(__dirname, '..', 'fixtures');
-var sandbox = path.join(os.tmpdir(), 'citgm-' + Date.now());
-var outputFile = path.join(sandbox, 'test.tap');
-var outputFileAppend = path.join(sandbox, 'test-append.tap');
-var outputFileAppendBlank = path.join(sandbox, 'test-append-blank.tap');
+const fixturesPath = path.join(__dirname, '..', 'fixtures');
+const sandbox = path.join(os.tmpdir(), 'citgm-' + Date.now());
+const outputFile = path.join(sandbox, 'test.tap');
+const outputFileAppend = path.join(sandbox, 'test-append.tap');
+const outputFileAppendBlank = path.join(sandbox, 'test-append-blank.tap');
 
-var appendStartFilePath = path.join(fixturesPath, 'appendTestFileStart.txt');
+const appendStartFilePath = path.join(fixturesPath, 'appendTestFileStart.txt');
 
-var passingInput = [
+const passingInput = [
   fixtures.iPass,
   fixtures.iFlakyPass
 ];
 
-var passingExpectedPath = path.join(fixturesPath, 'test-out-tap-passing.txt');
-var passingExpectedPathAppend = path.join(fixturesPath,
+const passingExpectedPath = path.join(fixturesPath, 'test-out-tap-passing.txt');
+const passingExpectedPathAppend = path.join(fixturesPath,
     'test-out-tap-passing-append.txt');
 
-var tapParserExpected = require('../fixtures/parsed-tap.json');
-var passingExpected = fs.readFileSync(passingExpectedPath, 'utf-8');
-var passingExpectedAppend = fs.readFileSync(passingExpectedPathAppend, 'utf-8');
+const tapParserExpected = require('../fixtures/parsed-tap.json');
+const passingExpected = fs.readFileSync(passingExpectedPath, 'utf-8');
+const passingExpectedAppend = fs.readFileSync(passingExpectedPathAppend,
+  'utf-8');
 
-var failingInput = [
+const failingInput = [
   fixtures.iPass,
   fixtures.iFlakyFail,
   fixtures.iFail
 ];
 
-var failingExpectedPath = path.join(fixturesPath, 'test-out-tap-failing.txt');
-var failingExpected = fs.readFileSync(failingExpectedPath, 'utf-8');
+const failingExpectedPath = path.join(fixturesPath, 'test-out-tap-failing.txt');
+const failingExpected = fs.readFileSync(failingExpectedPath, 'utf-8');
 
 test('reporter.tap(): setup', function (t) {
   mkdirp(sandbox, function (err) {
@@ -51,7 +52,7 @@ test('reporter.tap(): setup', function (t) {
 });
 
 test('reporter.tap(): passing', function (t) {
-  var output = '';
+  let output = '';
   function logger(message) {
     output += message;
     output += '\n';
@@ -64,7 +65,7 @@ test('reporter.tap(): passing', function (t) {
 });
 
 test('reporter.tap(): failing', function (t) {
-  var output = '';
+  let output = '';
   function logger(message) {
     output += message;
     output += '\n';
@@ -77,7 +78,7 @@ test('reporter.tap(): failing', function (t) {
 });
 
 test('reporter.tap(): parser', function (t) {
-  var output = '';
+  let output = '';
   function logger(message) {
     output += message;
   }
@@ -93,17 +94,17 @@ test('reporter.tap(): parser', function (t) {
 
 test('reporter.tap(): write to disk', function (t) {
   tap(outputFile, passingInput);
-  var expected = fs.readFileSync(outputFile, 'utf8');
+  const expected = fs.readFileSync(outputFile, 'utf8');
   t.equals(expected, passingExpected), 'the file on disk should match the'
   + ' expected output';
   t.end();
 });
 
 test('reporter.tap(): append to disk', function (t) {
-  var appendStartFile = fs.readFileSync(appendStartFilePath, 'utf-8');
+  const appendStartFile = fs.readFileSync(appendStartFilePath, 'utf-8');
   fs.writeFileSync(outputFileAppend, appendStartFile);
   tap(outputFileAppend, passingInput, true);
-  var expected = fs.readFileSync(outputFileAppend, 'utf8');
+  const expected = fs.readFileSync(outputFileAppend, 'utf8');
   t.equals(expected, passingExpectedAppend), 'the file on disk should match the'
   + ' expected output';
   t.end();
@@ -111,7 +112,7 @@ test('reporter.tap(): append to disk', function (t) {
 
 test('reporter.tap(): append to disk when file does not exist', function (t) {
   tap(outputFileAppendBlank, passingInput, true);
-  var expected = fs.readFileSync(outputFileAppendBlank, 'utf8');
+  const expected = fs.readFileSync(outputFileAppendBlank, 'utf8');
   t.equals(expected, passingExpected), 'the file on disk should match the'
   + ' expected output';
   t.end();

--- a/test/reporter/test-reporter-tap.js
+++ b/test/reporter/test-reporter-tap.js
@@ -84,7 +84,7 @@ test('reporter.tap(): parser', function (t) {
   }
 
   tap(logger, failingInput);
-  var p = parser(function (results) {
+  const p = parser(function (results) {
     t.deepEquals(results, tapParserExpected), 'the tap parser should correctly'
     + ' parse the tap file';
     t.end();

--- a/test/reporter/test-reporter-util.js
+++ b/test/reporter/test-reporter-util.js
@@ -1,17 +1,17 @@
 'use strict';
-var fs = require('fs');
-var path = require('path');
+const fs = require('fs');
+const path = require('path');
 
-var test = require('tap').test;
+const test = require('tap').test;
 
-var util = require('../../lib/reporter/util');
-var fixtures = require('../fixtures/reporter-fixtures');
+const util = require('../../lib/reporter/util');
+const fixtures = require('../fixtures/reporter-fixtures');
 
-var fixturesPath = path.join(__dirname, '..', 'fixtures');
-var carriageReturnPath = path.join(fixturesPath, 'CR-raw.txt');
-var carriageReturnExpectedPath = path.join(fixturesPath, 'CR-sanitized.txt');
+const fixturesPath = path.join(__dirname, '..', 'fixtures');
+const carriageReturnPath = path.join(fixturesPath, 'CR-raw.txt');
+const carriageReturnExpectedPath = path.join(fixturesPath, 'CR-sanitized.txt');
 
-var noPassing = [
+const noPassing = [
   fixtures.iFail,
   fixtures.iFail,
   fixtures.iFail,
@@ -21,20 +21,20 @@ var noPassing = [
   fixtures.iFlakyFail
 ];
 
-var somePassing = [
+const somePassing = [
   fixtures.iPass,
   fixtures.iFlakyPass,
   fixtures.iFlakyFail,
   fixtures.iFail
 ];
 
-var allPassing = [
+const allPassing = [
   fixtures.iPass,
   fixtures.iFlakyPass,
   fixtures.iPass
 ];
 
-var flakeCityUsa = [
+const flakeCityUsa = [
   fixtures.iFlakyFail,
   fixtures.iFlakyFail,
   fixtures.iFlakyPass,
@@ -92,9 +92,9 @@ test('hasFailures:', function (t) {
 
 test('util.sanitizeOutput', function (t) {
   // Var result = util.sanitizeOutput();
-  var raw = fs.readFileSync(carriageReturnPath, 'utf-8');
-  var expected = fs.readFileSync(carriageReturnExpectedPath, 'utf-8');
-  var result = util.sanitizeOutput(raw, '#');
+  const raw = fs.readFileSync(carriageReturnPath, 'utf-8');
+  const expected = fs.readFileSync(carriageReturnExpectedPath, 'utf-8');
+  const result = util.sanitizeOutput(raw, '#');
   t.equals(result, expected, 'there should be a # on every line');
   t.end();
 });

--- a/test/reporter/test-reporter.js
+++ b/test/reporter/test-reporter.js
@@ -1,8 +1,8 @@
 // TODO this test does not test any functionality currently
 'use strict';
-var test = require('tap').test;
+const test = require('tap').test;
 
-var reporter = require('../../lib/reporter');
+const reporter = require('../../lib/reporter');
 
 test('reporter.markdown():', function (t) {
   t.ok(reporter.markdown, 'it should have a markdown reporter');

--- a/test/test-citgm.js
+++ b/test/test-citgm.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var test = require('tap').test;
-var rewire = require('rewire');
+const test = require('tap').test;
+const rewire = require('rewire');
 
-var citgm = rewire('../lib/citgm');
-var find = citgm.__get__('find');
+const citgm = rewire('../lib/citgm');
+const find = citgm.__get__('find');
 
 test('citgm: omg-i-pass', function (t) {
-  var options = {
+  const options = {
     script: null,
     hmac: null,
     lookup: null,
@@ -15,7 +15,7 @@ test('citgm: omg-i-pass', function (t) {
     level: null
   };
 
-  var mod = 'omg-i-pass';
+  const mod = 'omg-i-pass';
 
   citgm.Tester(mod, options)
   .on('start', function (name) {
@@ -29,7 +29,7 @@ test('citgm: omg-i-pass', function (t) {
 });
 
 test('citgm: omg-i-pass from git url', function (t) {
-  var options = {
+  const options = {
     script: null,
     hmac: null,
     lookup: null,
@@ -37,7 +37,7 @@ test('citgm: omg-i-pass from git url', function (t) {
     level: null
   };
 
-  var mod = 'git+https://github.com/MylesBorins/omg-i-pass';
+  const mod = 'git+https://github.com/MylesBorins/omg-i-pass';
 
   citgm.Tester(mod, options)
   .on('start', function (name) {
@@ -51,7 +51,7 @@ test('citgm: omg-i-pass from git url', function (t) {
 });
 
 test('citgm: internal function find with error', function (t) {
-  var which = citgm.__get__('which');
+  const which = citgm.__get__('which');
   citgm.__set__('which', function (app, next) {
     return next('Error');
   });

--- a/test/test-create-options.js
+++ b/test/test-create-options.js
@@ -1,23 +1,23 @@
 'use strict';
-var test = require('tap').test;
+const test = require('tap').test;
 
-var createOptions = require('../lib/create-options');
+const createOptions = require('../lib/create-options');
 
 test('create-options:', function (t) {
-  var cwd = __dirname;
+  const cwd = __dirname;
 
-  var context = {
+  const context = {
     options: {},
     npmConfigTmp: 'npm_config_tmp',
     module: {envVar: {testenvVar: 'thisisatest'}}
   };
 
-  var env = Object.create(process.env);
+  const env = Object.create(process.env);
   env['npm_loglevel'] = 'error';
   env['npm_config_tmp'] = 'npm_config_tmp';
   env['testenvVar'] = 'thisisatest';
 
-  var options = createOptions(cwd, context);
+  const options = createOptions(cwd, context);
 
   t.equals(typeof options, 'object', 'We should get back an object');
   t.notOk(options.uid, 'There should not be a uid in the options');
@@ -28,16 +28,16 @@ test('create-options:', function (t) {
 });
 
 test('create-options: with uid / gid', function (t) {
-  var cwd = __dirname;
+  const cwd = __dirname;
 
-  var context = {
+  const context = {
     options: {
       uid: 1337,
       gid: 1337
     }
   };
 
-  var options = createOptions(cwd, context);
+  const options = createOptions(cwd, context);
 
   t.equals(typeof options, 'object', 'We should get back an object');
   t.equals(options.uid, 1337, 'The uid should be set to the expected value');

--- a/test/test-grab-module-data.js
+++ b/test/test-grab-module-data.js
@@ -2,12 +2,12 @@
 // FIXME this is not a real unit test
 // FIXME it does not stub npm
 
-var test = require('tap').test;
+const test = require('tap').test;
 
-var grabModuleData = require('../lib/grab-module-data');
+const grabModuleData = require('../lib/grab-module-data');
 
 test('grab-module-data: lodash', function (t) {
-  var context = {
+  const context = {
     path: __dirname,
     module: {
       raw: 'lodash',
@@ -33,7 +33,7 @@ test('grab-module-data: lodash', function (t) {
 });
 
 test('grab-module-data: does not exist', function (t) {
-  var context = {
+  const context = {
     path: __dirname,
     module: {
       raw: 'FAIL',
@@ -54,7 +54,7 @@ test('grab-module-data: does not exist', function (t) {
 });
 
 test('grab-module-data: hosted', function (t) {
-  var context = {
+  const context = {
     path: __dirname,
     module: {
       raw: 'FAIL',
@@ -68,7 +68,7 @@ test('grab-module-data: hosted', function (t) {
     options: {}
   };
 
-  var expected = {
+  const expected = {
     repository: {
       type: 'git',
       url: context.module.hosted.gitUrl

--- a/test/test-grab-project.js
+++ b/test/test-grab-project.js
@@ -3,18 +3,18 @@
 // FIXME npm should be stubbed
 // TODO Test for local module... what does it even mean?
 
-var os = require('os');
-var path = require('path');
-var fs = require('fs');
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
 
-var test = require('tap').test;
-var mkdirp = require('mkdirp');
-var rimraf = require('rimraf');
+const test = require('tap').test;
+const mkdirp = require('mkdirp');
+const rimraf = require('rimraf');
 
-var grabProject = require('../lib/grab-project');
+const grabProject = require('../lib/grab-project');
 
-var sandbox = path.join(os.tmpdir(), 'citgm-' + Date.now());
-var fixtures = path.join(__dirname, 'fixtures');
+const sandbox = path.join(os.tmpdir(), 'citgm-' + Date.now());
+const fixtures = path.join(__dirname, 'fixtures');
 
 test('grab-project: setup', function (t) {
   mkdirp(sandbox, function (err) {
@@ -24,7 +24,7 @@ test('grab-project: setup', function (t) {
 });
 
 test('grab-project: npm module', function (t) {
-  var context = {
+  const context = {
     emit: function() {},
     path: sandbox,
     module: {
@@ -44,7 +44,7 @@ test('grab-project: npm module', function (t) {
 });
 
 test('grab-project: local', function (t) {
-  var context = {
+  const context = {
     emit: function() {},
     path: sandbox,
     module: {
@@ -65,7 +65,7 @@ test('grab-project: local', function (t) {
 });
 
 test('grab-project: lookup table', function (t) {
-  var context = {
+  const context = {
     emit: function() {},
     path: sandbox,
     module: {
@@ -85,7 +85,7 @@ test('grab-project: lookup table', function (t) {
 });
 
 test('grab-project: local', function (t) {
-  var context = {
+  const context = {
     emit: function() {},
     path: sandbox,
     module: {
@@ -107,7 +107,7 @@ test('grab-project: local', function (t) {
 });
 
 test('grab-project: module does not exist', function (t) {
-  var context = {
+  const context = {
     emit: function() {},
     path: sandbox,
     module: {
@@ -122,7 +122,7 @@ test('grab-project: module does not exist', function (t) {
 });
 
 test('grab-project: timeout', function (t) {
-  var context = {
+  const context = {
     emit: function() {},
     path: sandbox,
     module: {

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -1,26 +1,26 @@
 'use strict';
 
-var test = require('tap').test;
-var rewire = require('rewire');
+const test = require('tap').test;
+const rewire = require('rewire');
 
-var lookup = rewire('../lib/lookup');
+const lookup = rewire('../lib/lookup');
 
-var makeUrl = lookup.__get__('makeUrl');
-var getLookupTable = lookup.get;
+const makeUrl = lookup.__get__('makeUrl');
+const getLookupTable = lookup.get;
 
 test('lookup: makeUrl', function (t) {
-  var repo = 'https://github.com/nodejs/citgm';
+  const repo = 'https://github.com/nodejs/citgm';
 
-  var tags = {
+  const tags = {
     latest: '0.1.0'
   };
 
-  var prefix = 'v';
+  const prefix = 'v';
 
-  var sha = 'abc123';
+  const sha = 'abc123';
 
-  var expected = repo + '/archive/master.tar.gz';
-  var url = makeUrl(repo);
+  let expected = repo + '/archive/master.tar.gz';
+  let url = makeUrl(repo);
   t.equal(url, expected, 'by default makeUrl should give a link to master');
 
   expected = repo + '/archive/' + tags.latest + '.tar.gz';
@@ -142,7 +142,7 @@ test('lookup: module in table', function (t) {
 });
 
 test('lookup: no table', function (t) {
-  var context = {
+  const context = {
     options: {
       lookup: 'test/fixtures/custom-lookup-does-not-exist.json'
     }
@@ -155,7 +155,7 @@ test('lookup: no table', function (t) {
 });
 
 test('lookup: replace with no repo', function (t) {
-  var context = {
+  const context = {
     module: {
       name: 'omg-i-pass',
       raw: null
@@ -177,7 +177,7 @@ test('lookup: replace with no repo', function (t) {
 });
 
 test('lookup: lookup with script', function (t) {
-  var context = {
+  const context = {
     module: {
       name: 'omg-i-have-script',
       raw: null
@@ -200,7 +200,7 @@ test('lookup: lookup with script', function (t) {
 });
 
 test('lookup: --fail-flaky', function (t) {
-  var context = {
+  const context = {
     lookup: null,
     module: {
       name: 'lodash',
@@ -235,7 +235,7 @@ test('lookup: ensure lookup works', function (t) {
 });
 
 test('lookup: lookup with install', function (t) {
-  var context = {
+  const context = {
     module: {
       name: 'omg-i-pass-with-install-param',
       raw: null
@@ -261,7 +261,7 @@ test('lookup: lookup with install', function (t) {
 });
 
 test('lookup: logging', function (t) {
-  var expectedLogMsgs = [
+  const expectedLogMsgs = [
     { type: 'info', key: 'lookup', msg: 'omg-i-pass' },
     { type: 'info', key: 'lookup-found', msg: 'omg-i-pass' },
     { type: 'info',
@@ -274,9 +274,9 @@ test('lookup: logging', function (t) {
       key: 'omg-i-pass lookup-script',
       msg: './example-test-script-passing.sh' }
   ];
-  var EventEmitter = require('events').EventEmitter;
-  var context = new EventEmitter();
-  var log = [];
+  const EventEmitter = require('events').EventEmitter;
+  const context = new EventEmitter();
+  const log = [];
   context.meta = {
     repository: '/dev/null',
     version: '0.1.1'

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -42,8 +42,9 @@ test('lookup: makeUrl', function (t) {
 });
 
 test('lookup[getLookupTable]:', function (t) {
+  let table;
   try {
-    var table = getLookupTable({
+    table = getLookupTable({
       lookup: null
     });
   } catch (e) {
@@ -57,8 +58,9 @@ test('lookup[getLookupTable]:', function (t) {
 });
 
 test('lookup[getLookupTable]: custom table', function (t) {
+  let table;
   try {
-    var table = getLookupTable({
+    table = getLookupTable({
       lookup: 'test/fixtures/custom-lookup.json'
     });
   } catch (e) {
@@ -78,8 +80,9 @@ test('lookup[getLookupTable]: custom table', function (t) {
 });
 
 test('lookup[getLookupTable]: custom table that does not exist', function (t) {
+  let table;
   try {
-    var table = getLookupTable({
+    table = getLookupTable({
       lookup: 'test/fixtures/i-am-not-a.json'
     });
   } catch (e) {
@@ -91,7 +94,7 @@ test('lookup[getLookupTable]: custom table that does not exist', function (t) {
 });
 
 test('lookup: module not in table', function (t) {
-  var context = {
+  const context = {
     lookup: null,
     module: {
       name: 'omg-i-pass',
@@ -115,7 +118,7 @@ test('lookup: module not in table', function (t) {
 });
 
 test('lookup: module in table', function (t) {
-  var context = {
+  const context = {
     lookup: null,
     module: {
       name: 'lodash',
@@ -225,8 +228,9 @@ test('lookup: --fail-flaky', function (t) {
 });
 
 test('lookup: ensure lookup works', function (t) {
+  let lookup;
   try {
-    var lookup = require('../lib/lookup.json');
+    lookup = require('../lib/lookup.json');
   } catch (err) {
     t.error(err);
   }
@@ -249,7 +253,7 @@ test('lookup: lookup with install', function (t) {
     },
     emit: function () {}
   };
-  var expected = {
+  const expected = {
     install: [/--extra-param/]
   };
 

--- a/test/test-match-conditions.js
+++ b/test/test-match-conditions.js
@@ -1,28 +1,28 @@
 'use strict';
 
-var test = require('tap').test;
-var rewire = require('rewire');
+const test = require('tap').test;
+const rewire = require('rewire');
 
-var isMatch = rewire('../lib/match-conditions');
+const isMatch = rewire('../lib/match-conditions');
 
-var platformCache = isMatch.__get__('platform');
-var versionCache = isMatch.__get__('version');
-var archCache = isMatch.__get__('arch');
-var semVersionCache = isMatch.__get__('semVersion');
-var distroCache = isMatch.__get__('distro');
-var releaseCache = isMatch.__get__('release');
+const platformCache = isMatch.__get__('platform');
+const versionCache = isMatch.__get__('version');
+const archCache = isMatch.__get__('arch');
+const semVersionCache = isMatch.__get__('semVersion');
+const distroCache = isMatch.__get__('distro');
+const releaseCache = isMatch.__get__('release');
 
-var match = {
+const match = {
   v5: ['darwin', 'hurd', 'x86']
 };
 
-var notMatch = {
+const notMatch = {
   v4: ['darwin', 'hurd', 'x86'],
   x86: 'hurd',
   darwin: 'v0.10'
 };
 
-var invalid = {
+const invalid = {
   'v5': [123, false, false]
 };
 

--- a/test/test-match-conditions.js
+++ b/test/test-match-conditions.js
@@ -124,20 +124,20 @@ function testObjects(t, testFunction) {
 }
 
 test('isStringMatch', function (t) {
-  var isStringMatch = isMatch.__get__('isStringMatch');
+  const isStringMatch = isMatch.__get__('isStringMatch');
   testVersions(t, isStringMatch);
   testPlatforms(t, isStringMatch);
   t.end();
 });
 
 test('isObjectMatch', function (t) {
-  var isObjectMatch = isMatch.__get__('isObjectMatch');
+  const isObjectMatch = isMatch.__get__('isObjectMatch');
   testObjects(t, isObjectMatch);
   t.end();
 });
 
 test('isArrayMatch', function (t) {
-  var isArrayMatch = isMatch.__get__('isArrayMatch');
+  const isArrayMatch = isMatch.__get__('isArrayMatch');
   testArrays(t, isArrayMatch);
   t.end();
 });

--- a/test/test-out.js
+++ b/test/test-out.js
@@ -1,11 +1,11 @@
 // TODO this test does not test any functionality currently
 'use strict';
-var test = require('tap').test;
-var rewire = require('rewire');
-var Logger = rewire('../lib/out.js');
+const test = require('tap').test;
+const rewire = require('rewire');
+const Logger = rewire('../lib/out.js');
 
 test('out: no color', function (t) {
-  var log = Logger();
+  const log = Logger();
   t.ok(log.silly, 'there should be a silly logging level');
   t.ok(log.verbose, 'there should be a verbose logging level');
   t.ok(log.info, 'there should be a info logging level');
@@ -15,15 +15,15 @@ test('out: no color', function (t) {
 });
 
 test('out: with color', function (t) {
-  var supportscolor = Logger.__get__('supportscolor');
+  const supportscolor = Logger.__get__('supportscolor');
   Logger.__set__('supportscolor', function () {
     return true;
   });
-  var output = Logger.__get__('output');
+  const output = Logger.__get__('output');
   Logger.__set__('output', function () {
     return true;
   });
-  var log = Logger();
+  const log = Logger();
   t.notok(log.silly(), 'there should be a silly logging level that is a'
   + ' function with no return');
   t.notok(log.verbose(),

--- a/test/test-spawn.js
+++ b/test/test-spawn.js
@@ -1,15 +1,15 @@
 'use strict';
 
-var test = require('tap').test;
-var rewire = require('rewire');
+const test = require('tap').test;
+const rewire = require('rewire');
 
-var spawn = rewire('../lib/spawn');
+const spawn = rewire('../lib/spawn');
 
 test('spawn:', function (t) {
-  var child = spawn('echo', ['Hello world.']);
+  const child = spawn('echo', ['Hello world.']);
 
-  var error = '';
-  var message = '';
+  let error = '';
+  let message = '';
 
   child.stdout.on('data', function (chunk) {
     message += chunk;
@@ -26,9 +26,9 @@ test('spawn:', function (t) {
 });
 
 test('spawn: windows mock', function (t) {
-  var child = spawn.__get__('child');
-  var sp = child.spawn;
-  var platform = process.platform;
+  const child = spawn.__get__('child');
+  const sp = child.spawn;
+  const platform = process.platform;
   Object.defineProperty(process, 'platform', {
     value: 'win32'
   });
@@ -41,8 +41,8 @@ test('spawn: windows mock', function (t) {
     };
   };
 
-  var result = spawn('echo', ['Hello world.']);
-  var expected = {
+  const result = spawn('echo', ['Hello world.']);
+  const expected = {
     cmd: 'cmd',
     args: [
       '/c',

--- a/test/test-temp-directory.js
+++ b/test/test-temp-directory.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var fs = require('fs');
+const fs = require('fs');
 
-var test = require('tap').test;
-var rewire = require('rewire');
+const test = require('tap').test;
+const rewire = require('rewire');
 
-var tempDirectory = rewire('../lib/temp-directory');
+const tempDirectory = rewire('../lib/temp-directory');
 
-var context = {
+const context = {
   path: null,
   emit: function () {},
   module: {
@@ -15,7 +15,7 @@ var context = {
   }
 };
 
-var contextTmpDir = {
+const contextTmpDir = {
   options: {
     tmpDir: 'thisisatest'
   },
@@ -26,7 +26,7 @@ var contextTmpDir = {
   }
 };
 
-var badContext = {
+const badContext = {
   path: null,
   emit: function () {},
   module: {
@@ -61,7 +61,7 @@ test('tempDirectory.create --tmpDir:', function (t) {
 });
 
 test('tempDirectory.create: bad path', function (t) {
-  var path = tempDirectory.__get__('path');
+  const path = tempDirectory.__get__('path');
   tempDirectory.__set__('path', {
     join: function () {
       return '/dev/null';

--- a/test/test-unpack.js
+++ b/test/test-unpack.js
@@ -1,15 +1,15 @@
 'use strict';
 
-var fs = require('fs');
-var path = require('path');
+const fs = require('fs');
+const path = require('path');
 
-var test = require('tap').test;
+const test = require('tap').test;
 
-var tempDirectory = require('../lib/temp-directory');
-var unpack = require('../lib/unpack');
+const tempDirectory = require('../lib/temp-directory');
+const unpack = require('../lib/unpack');
 
 test('unpack: context.unpack = null', function (t) {
-  var context = {
+  const context = {
     unpack: null,
     emit: function () {}
   };
@@ -22,7 +22,7 @@ test('unpack: context.unpack = null', function (t) {
 });
 
 test('unpack: context.unpack is invalid path', function (t) {
-  var context = {
+  const context = {
     unpack: path.join(__dirname, '..', 'fixtures', 'do-not-exist.tar.gz'),
     emit: function () {}
   };
@@ -35,7 +35,7 @@ test('unpack: context.unpack is invalid path', function (t) {
 });
 
 test('unpack: valid unpack', function (t) {
-  var context = {
+  const context = {
     module: {
       name: 'omg-i-pass'
     },

--- a/test/test-update.js
+++ b/test/test-update.js
@@ -1,9 +1,9 @@
-var test = require('tap').test;
-var rewire = require('rewire');
+const test = require('tap').test;
+const rewire = require('rewire');
 
-var update = rewire('../lib/update');
+const update = rewire('../lib/update');
 
-var pkg = update.__get__('pkg');
+const pkg = update.__get__('pkg');
 
 pkg.version = '0.0.0';
 

--- a/test/test-update.js
+++ b/test/test-update.js
@@ -1,3 +1,4 @@
+'use strict';
 const test = require('tap').test;
 const rewire = require('rewire');
 

--- a/test/test-update.js
+++ b/test/test-update.js
@@ -9,7 +9,7 @@ const pkg = update.__get__('pkg');
 pkg.version = '0.0.0';
 
 test('update: /w callback', function (t) {
-  var log = {
+  const log = {
     warn: function (data) {
       t.equals(data, 'update-available');
       t.end();


### PR DESCRIPTION
Ref: #302

A lot of tests don't pass because of the use of the rewire module.
I'm still opening this for discussion. What do we want to do about it?
- keep all the calls as var?
- convert most of the calls to const and use let for the ones that need to be mocked?
- something else?