### PR TITLE
bin: allow testing subsystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Options:
   -j, --parallel <number>     Run tests in parallel
   -J, --autoParallel          Run tests in parallel (automatically detect core count)
   --tmpDir <path>             Directory to test modules in
+  --includeTags tag1 tag2     Only test modules from the lookup that contain a matching tag field
+  --excludeTags tag1 tag2     Specify which tags to skip from the lookup (takes priority over includeTags)
 ```
 
 When using a JSON config file, the properties need to be the same as the
@@ -133,6 +135,7 @@ For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
 "envVar"                     Pass an environment variable before running
 "install": ["--param1", "--param2"] - Array of extra command line parameters passed to 'npm install'
 "maintainers": ["user1", "user2"] - List of module maintainers to be contacted with issues
+"tags": ["tag1", "tag2"]     Specify which tags apply to the module
 ```
 
 If you want to pass options to npm, eg `--registry`, you can usually define an

--- a/lib/check-tags.js
+++ b/lib/check-tags.js
@@ -1,0 +1,44 @@
+'use strict';
+const _ = require('lodash');
+
+function checkTags(options, mod, name, log) {
+  // Returns true if the module should be skipped.
+
+  if ((options.excludeTags.length && !options.includeTags.length && !mod.tags)
+    || (!options.includeTags.length && !options.excludeTags.length)) {
+    return false; // No checks to run.
+  } else if (options.includeTags.length && !mod.tags) {
+    return true; // No tags for this module.
+  }
+
+  if (typeof mod.tags === 'string') {
+    mod.tags = [mod.tags]; // If mod.tags is a single string, convert to array.
+  }
+
+  let excludeTagMatches = _.intersection(options.excludeTags, mod.tags);
+
+  if (excludeTagMatches.length) {
+    log.info(name,
+        `skipped as these excludeTags matched: ${excludeTagMatches}`);
+    return true; // We matched an excludeTag.
+  }
+
+  let includeTagMatches = _.intersection(options.includeTags, mod.tags);
+
+  if (includeTagMatches.length) {
+    log.info(name,
+        `will run as these includeTags matched: ${includeTagMatches}`);
+    return false; // We matched an includeTag.
+  }
+
+  if (options.includeTags.length) {
+    log.info(`${name} skipped as no includeTags matched`);
+    return true; // We did not match an includeTag.
+  } else {
+    log.info(`${name} will run as no excludeTags matched`);
+    return false; // We did not match an excludeTag.
+  }
+
+}
+
+module.exports = checkTags;

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -101,6 +101,9 @@ function resolve(context, next) {
             ' lookup-install', rep.install);
         context.module.install = rep.install;
       }
+      if (rep.tags) {
+        context.module.tags = rep.tags;
+      }
       context.module.flaky = context.options.failFlaky ?
           false : isMatch(rep.flaky);
       context.module.expectFail = context.options.expectFail ?

--- a/man/citgm-all.1
+++ b/man/citgm-all.1
@@ -70,6 +70,12 @@ Run tests in parallel (automatically detect core count)
 .TP
 .BR \-\-tmpDir " " \fI<path>\fR
 Directory to test modules in
+.TP
+.BR \-\-includeTags " " \fI<tag1 tag2>\fR
+Only test modules from the lookup that contain a matching tag field
+.TP
+.BR \-\-excludeTags " " \fI<tag1 tag2>\fR
+Specify which tags to skip from the lookup (takes priority over includeTags)
 
 .SH SEE ALSO
 citgm

--- a/test/bin/test-citgm-all.js
+++ b/test/bin/test-citgm-all.js
@@ -116,6 +116,42 @@ test('citgm-all: flaky-fail ignoring flakyness', function (t) {
   });
 });
 
+test('citgm-all: includeTags', function (t) {
+  t.plan(1);
+  const proc = spawn(citgmAllPath, ['--includeTags', 'tag1', '-l',
+    'test/fixtures/custom-lookup-tags.json']);
+  proc.on('error', function(err) {
+    t.error(err);
+  });
+  proc.on('close', function (code) {
+    t.equals(code, 0, 'citgm-all should only run omg-i-pass');
+  });
+});
+
+test('citgm-all: excludeTags', function (t) {
+  t.plan(1);
+  const proc = spawn(citgmAllPath, ['--excludeTags', 'tag2', '-l',
+    'test/fixtures/custom-lookup-tags.json']);
+  proc.on('error', function(err) {
+    t.error(err);
+  });
+  proc.on('close', function (code) {
+    t.equals(code, 0, 'citgm-all should not run omg-i-fail');
+  });
+});
+
+test('citgm-all: includeTags multiple', function (t) {
+  t.plan(1);
+  const proc = spawn(citgmAllPath, ['--includeTags', 'tag1 noTag1 NoTag2', '-l',
+    'test/fixtures/custom-lookup-tags.json']);
+  proc.on('error', function(err) {
+    t.error(err);
+  });
+  proc.on('close', function (code) {
+    t.equals(code, 0, 'citgm-all should only run omg-i-pass');
+  });
+});
+
 test('citgm-all: skip /w rootcheck /w tap to fs /w junit to fs /w append',
 function (t) {
   t.plan(1);

--- a/test/fixtures/custom-lookup-tags.json
+++ b/test/fixtures/custom-lookup-tags.json
@@ -1,0 +1,13 @@
+{
+  "omg-i-pass": {
+    "npm": true,
+    "tags": "tag1"
+  },
+  "omg-i-fail": {
+    "npm": true,
+    "tags": ["tag2", "tagNotUsed"]
+  },
+  "omg-i-pass-too": {
+    "npm": true
+  }
+}

--- a/test/test-check-tags.js
+++ b/test/test-check-tags.js
@@ -1,0 +1,318 @@
+'use strict';
+
+const test = require('tap').test;
+const rewire = require('rewire');
+
+const checkTags = rewire('../lib/check-tags');
+const log = require('../lib/out')({});
+
+test('test includeTags and matching tag multiple', function (t) {
+  const options = {
+    includeTags: ['a'],
+    excludeTags: []
+  };
+  const mod = {
+    tags: ['a', 'b']
+  };
+  t.plan(1);
+  const result = checkTags(options, mod, 'test', log);
+  t.false(result, 'should return false');
+});
+
+test('test includeTags and matching tag', function (t) {
+  const options = {
+    includeTags: ['a'],
+    excludeTags: []
+  };
+  const mod = {
+    tags: 'a'
+  };
+  t.plan(1);
+  const result = checkTags(options, mod, 'test', log);
+  t.false(result, 'should return false');
+});
+
+test('test includeTags and no matching tag', function (t) {
+  const options = {
+    includeTags: ['a'],
+    excludeTags: []
+  };
+  const mod = {
+    tags: 'b'
+  };
+  t.plan(1);
+  const result = checkTags(options, mod, 'test', log);
+  t.true(result, 'should return true');
+});
+
+test('test includeTags and no tag', function (t) {
+  const options = {
+    includeTags: ['a'],
+    excludeTags: []
+  };
+  const mod = {
+    tags: []
+  };
+  t.plan(1);
+  const result = checkTags(options, mod, 'test', log);
+  t.true(result, 'should return true');
+});
+
+test('test excludeTags and matching tag multiple', function (t) {
+  const options = {
+    excludeTags: ['a'],
+    includeTags: []
+  };
+  const mod = {
+    tags: ['a', 'b']
+  };
+  t.plan(1);
+  const result = checkTags(options, mod, 'test', log);
+  t.true(result, 'should return true');
+});
+
+test('test excludeTags and matching tag', function (t) {
+  const options = {
+    excludeTags: ['a'],
+    includeTags: []
+  };
+  const mod = {
+    tags: 'a'
+  };
+  t.plan(1);
+  const result = checkTags(options, mod, 'test', log);
+  t.true(result, 'should return true');
+});
+
+test('test excludeTags and no matching tag', function (t) {
+  const options = {
+    excludeTags: ['a'],
+    includeTags: []
+  };
+  const mod = {
+    tags: 'b'
+  };
+  t.plan(1);
+  const result = checkTags(options, mod, 'test', log);
+  t.false(result, 'should return false');
+});
+
+test('test excludeTags and no tag', function (t) {
+  const options = {
+    excludeTags: ['a'],
+    includeTags: []
+  };
+  const mod = {
+    tags: []
+  };
+  t.plan(1);
+  const result = checkTags(options, mod, 'test', log);
+  t.false(result, 'should return false');
+});
+
+test('test includeTags and matching tag multiple', function (t) {
+  const options = {
+    includeTags: ['b'],
+    excludeTags: []
+  };
+  const mod = {
+    tags: ['a', 'b']
+  };
+  t.plan(1);
+  const result = checkTags(options, mod, 'test', log);
+  t.false(result, 'should return false');
+});
+
+test('test includeTags and no matching tag', function (t) {
+  const options = {
+    includeTags: ['b'],
+    excludeTags: []
+  };
+  const mod = {
+    tags: 'a'
+  };
+  t.plan(1);
+  const result = checkTags(options, mod, 'test', log);
+  t.true(result, 'should return true');
+});
+
+test('test includeTags and matching tag', function (t) {
+  const options = {
+    includeTags: ['b'],
+    excludeTags: []
+  };
+  const mod = {
+    tags: 'b'
+  };
+  t.plan(1);
+  const result = checkTags(options, mod, 'test', log);
+  t.false(result, 'should return false');
+});
+
+test('test includeTags and no tag', function (t) {
+  const options = {
+    includeTags: ['b'],
+    excludeTags: []
+  };
+  const mod = {
+    tags: []
+  };
+  t.plan(1);
+  const result = checkTags(options, mod, 'test', log);
+  t.true(result, 'should return true');
+});
+
+test('test excludeTags and matching tag multiple', function (t) {
+  const options = {
+    excludeTags: ['b'],
+    includeTags: []
+  };
+  const mod = {
+    tags: ['a', 'b']
+  };
+  t.plan(1);
+  const result = checkTags(options, mod, 'test', log);
+  t.true(result, 'should return true');
+});
+
+test('test excludeTags and no matching tag', function (t) {
+  const options = {
+    excludeTags: ['b'],
+    includeTags: []
+  };
+  const mod = {
+    tags: 'a'
+  };
+  t.plan(1);
+  const result = checkTags(options, mod, 'test', log);
+  t.false(result, 'should return false');
+});
+
+test('test excludeTags and matching tag', function (t) {
+  const options = {
+    excludeTags: ['b'],
+    includeTags: []
+  };
+  const mod = {
+    tags: 'b'
+  };
+  t.plan(1);
+  const result = checkTags(options, mod, 'test', log);
+  t.true(result, 'should return true');
+});
+
+test('test excludeTags and no tag', function (t) {
+  const options = {
+    excludeTags: ['b'],
+    includeTags: []
+  };
+  const mod = {
+    tags: []
+  };
+  t.plan(1);
+  const result = checkTags(options, mod, 'test', log);
+  t.false(result, 'should return false');
+});
+
+test('test excludeTags, includeTags and matching tag', function (t) {
+  const options = {
+    excludeTags: ['a'],
+    includeTags: ['b']
+  };
+  const mod = {
+    tags: ['a', 'b']
+  };
+  t.plan(1);
+  const result = checkTags(options, mod, 'test', log);
+  t.true(result, 'should return true');
+});
+
+test('test excludeTags,includeTags and matching includeTags tag', function (t) {
+  const options = {
+    excludeTags: ['b'],
+    includeTags: ['a']
+  };
+  const mod = {
+    tags: 'a'
+  };
+  t.plan(1);
+  const result = checkTags(options, mod, 'test', log);
+  t.false(result, 'should return false');
+});
+
+test('test excludeTags,includeTags and matching excludeTags tag', function (t) {
+  const options = {
+    excludeTags: ['b'],
+    includeTags: ['a']
+  };
+  const mod = {
+    tags: 'b'
+  };
+  t.plan(1);
+  const result = checkTags(options, mod, 'test', log);
+  t.true(result, 'should return true');
+});
+
+test('test excludeTags, includeTags and no matching tags', function (t) {
+  const options = {
+    excludeTags: ['b'],
+    includeTags: ['a']
+  };
+  const mod = {
+  };
+  t.plan(1);
+  const result = checkTags(options, mod, 'test', log);
+  t.true(result, 'should return true');
+});
+
+test('test excludeTags, includeTags and matching tag', function (t) {
+  const options = {
+    excludeTags: ['b'],
+    includeTags: ['a']
+  };
+  const mod = {
+    tags: ['a', 'b']
+  };
+  t.plan(1);
+  const result = checkTags(options, mod, 'test', log);
+  t.true(result, 'should return true');
+});
+
+test('test excludeTags,includeTags and matching excludeTags tag', function (t) {
+  const options = {
+    excludeTags: ['a'],
+    includeTags: ['b']
+  };
+  const mod = {
+    tags: 'a'
+  };
+  t.plan(1);
+  const result = checkTags(options, mod, 'test', log);
+  t.true(result, 'should return true');
+});
+
+test('test excludeTags,includeTags and matching includeTags tag', function (t) {
+  const options = {
+    excludeTags: ['a'],
+    includeTags: ['b']
+  };
+  const mod = {
+    tags: 'b'
+  };
+  t.plan(1);
+  const result = checkTags(options, mod, 'test', log);
+  t.false(result, 'should return false');
+});
+
+test('test excludeTags, includeTags and no matching tags', function (t) {
+  const options = {
+    excludeTags: ['a'],
+    includeTags: ['b']
+  };
+  const mod = {
+    tags: []
+  };
+  t.plan(1);
+  const result = checkTags(options, mod, 'test', log);
+  t.true(result, 'should return true');
+});


### PR DESCRIPTION
this PR adds the functionality to run `citgm-all` on specific tags in
the lookup by passing in the `includeTags` or `excludeTags` option.
fixes https://github.com/nodejs/citgm/issues/72