### PR TITLE
bin: allow packages to be installed from a tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Options:
   -u, --uid <uid>             Set the uid (posix only)
   -g, --gid <uid>             Set the gid (posix only)
   -a, --append                Turns on append results to file mode rather than replace
+  -T  --tag <tag>             Install module from a specific tag
 ```
 
 When using a JSON config file, the properties need to be the same as the

--- a/bin/citgm.js
+++ b/bin/citgm.js
@@ -16,6 +16,11 @@ yargs = commonArgs(yargs)
     alias: 'c',
     type: 'string',
     description: 'Install module from commit-sha'
+  })
+  .option('tag', {
+    alias: 'T',
+    type: 'string',
+    description: 'Install module from tag'
   });
 
 var app = yargs.argv;
@@ -50,7 +55,8 @@ var options = {
   level: app.verbose,
   npmLevel: app.npmLoglevel,
   timeoutLength: app.timeout,
-  sha: app.sha
+  sha: app.sha,
+  tag: app.tag
 };
 
 if (!citgm.windows) {

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -68,7 +68,15 @@ function resolve(context, next) {
   var meta = context.meta;
   if (meta) {
     var rep = lookup[detail.name];
-    context.module.version = meta.version;
+    if (context.options.tag && meta.versions.includes(context.options.tag)) {
+      meta['dist-tags']['latest'] = context.options.tag;
+      context.module.version = context.options.tag;
+    } else if (!context.options.tag) {
+      context.module.version = meta.version;
+    } else {
+      next(new Error('version not found'));
+      return;
+    }
     if (rep) {
       if (rep.envVar){
         context.module.envVar = rep.envVar;


### PR DESCRIPTION
this PR allows packages to be installed from a tag using `citgm <module> -T <version>`. 
Fixes: https://github.com/nodejs/citgm/issues/171