### PR TITLE
docs: add issue template and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!--
+Thank you for reporting an issue.
+
+Please fill in as much of the template below as you're able.
+
+Node Version: output of `node -v`
+Citgm Version: output of `citgm -v`
+Platform: output of `uname -a` (UNIX), or version and 32 or 64-bit (Windows)
+
+If possible, please provide code that demonstrates the problem, keeping it as
+simple and free of external dependencies as you are able.
+-->
+* **Node Version**:
+* **CitGM Version**:
+* **Platform**:
+
+<!-- Enter your issue details below this comment. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+<!--
+Thank you for your pull request. Please provide a description above and review
+the requirements below.
+-->
+
+##### Checklist
+<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
+
+- [ ] `npm test` passes
+- [ ] tests are included
+- [ ] documentation is changed or added
+- [ ] contribution guidelines followed [here](CONTRIBUTING.md)
+- [ ] commit message follows commit guidelines


### PR DESCRIPTION
We should have a default issue template and a default PR template. I have briefly drafted one up from the node repository but I am happy to tweak it if people have suggestions