### PR TITLE
lookup: add support for multiple test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,52 @@ For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
 If you want to pass options to npm, eg `--registry`, you can usually define an
 environment variable, eg `"npm_config_registry": "https://www.xyz.com"`.
 
+## Multiple tests for single module
+
+You can provide more than one configuration option for a module by using
+`tests` attribute in [lookup.json](./lib/lookup.json). Entire entry without the
+`test` attribute will be the default test. Each key of the `test` attribute is
+an object that defines separate test. Keys of each test will be used to
+overwrite values of the default test.
+
+Special key `default-name` can be used to rename default test.
+
+For example, this can be used to test both prebuilt and locally built addons:
+```
+"sample_module": {
+  "prefix": "v",
+  "flaky": true,
+  "tests": {
+    "default-name": "prebuilt",
+    "built-locally": {
+      "flaky": false,
+      "install": ["--build-from-source"]
+    }
+  }
+}
+```
+
+This defines two test for `sample_module`. Default one called "prebuilt" with:
+```
+{
+  "prefix:": "v",
+  "flaky": true
+}
+```
+And "built-locally" with:
+```
+{
+  "prefix": "v",
+  "flaky": false,
+  "install": ["--build-from-source"]
+}
+```
+
+`citgm-all` will use both tests when running. Running `citgm sample_module` will
+call the default test. You can select the test by adding `#test name` to module
+name - `citgm sample_module#prebuilt` will run default test and
+`citgm sample_module#build-locally` will use the "built-locally" test.
+
 ## Testing
 
 You can run the test suite using npm

--- a/bin/citgm.js
+++ b/bin/citgm.js
@@ -75,8 +75,11 @@ function launch(mod, options) {
   process.on('SIGHUP', cleanup);
   process.on('SIGBREAK', cleanup);
 
-  runner.on('start', function(name) {
+  runner.on('start', function(name, test) {
     log.info('starting', name);
+    if (test) {
+      log.info('test', test);
+    }
   }).on('fail', function(err) {
     log.error('failure', err.message);
   }).on('data', function(type, key, message) {

--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -83,7 +83,13 @@ function Tester(mod, options) {
   if (!(this instanceof Tester))
     return new Tester(mod, options);
   EventEmitter.call(this);
-  this.module = extractDetail(mod);
+  const colonPosition = mod.indexOf('#');
+  if (colonPosition === -1) {
+    this.module = extractDetail(mod);
+  } else {
+    this.module = extractDetail(mod.substr(0, colonPosition));
+    this.module.test = mod.substr(colonPosition + 1);
+  }
   this.options = options;
   this.testOutput = '';
   this.testError = '';
@@ -93,7 +99,7 @@ function Tester(mod, options) {
 util.inherits(Tester, EventEmitter);
 
 Tester.prototype.run = function() {
-  this.emit('start', this.module.raw, this.options);
+  this.emit('start', this.module.raw, this.module.test, this.options);
 
   async.waterfall([
     init.bind(null, this),
@@ -110,6 +116,7 @@ Tester.prototype.run = function() {
     if (!this.cleanexit) {
       const payload = {
         name: this.module.name || this.module.raw,
+        test: this.module.test,
         version: this.module.version,
         flaky: this.module.flaky,
         expectFail: this.module.expectFail

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -1,6 +1,7 @@
 'use strict';
 const path = require('path');
 const util = require('util');
+const _ = require('lodash');
 
 const normgit = require('normalize-git-url');
 
@@ -68,9 +69,23 @@ function resolve(context, next) {
   context.emit('data', 'info', 'lookup', detail.name);
   const meta = context.meta;
   if (meta) {
-    const rep = lookup[detail.name];
+    let rep = lookup[detail.name];
     context.module.version = meta.version;
     if (rep) {
+      if (detail.test) {
+        if (!rep.tests) {
+          return next(Error('No tests specified for module'));
+        }
+        const testDetails = rep.tests[detail.test];
+        if (!testDetails && rep.tests['default-name'] !== detail.test) {
+          return next(Error('This module does not have such test'));
+        }
+        rep = _.assign({}, rep, testDetails);
+      } else {
+        if (rep.tests && rep.tests['default-name'])
+          detail.test = rep.tests['default-name'] + ' (default)';
+      }
+
       if (rep.envVar){
         context.module.envVar = rep.envVar;
       }
@@ -109,6 +124,9 @@ function resolve(context, next) {
       context.module.expectFail = context.options.expectFail ?
           false : isMatch(rep.expectFail);
     } else {
+      if (detail.test) {
+        return next(Error('Test specified for module not in lookup'));
+      }
       context.emit('data', 'info', 'lookup-notfound', detail.name);
     }
   }

--- a/lib/reporter/logger.js
+++ b/lib/reporter/logger.js
@@ -6,6 +6,9 @@ const util = require('./util');
 
 function logModule(log, logType, module) {
   log[logType](chalk.yellow('module name:'), module.name);
+  if (module.test) {
+    log[logType](chalk.yellow('module test:'), module.test);
+  }
   log[logType](chalk.yellow('version:'), module.version);
   if (module.error) {
     log[logType]('error:', module.error.message);

--- a/test/bin/test-citgm-all.js
+++ b/test/bin/test-citgm-all.js
@@ -166,6 +166,19 @@ function (t) {
   });
 });
 
+test('citgm-all: /w multiple tests', function (t) {
+  t.plan(1);
+  const proc = spawn(citgmAllPath,
+    ['-l', 'test/fixtures/custom-lookup-multiple-tests.json', '-m']);
+  proc.on('error', function(err) {
+    t.error(err);
+    t.fail('we should not get an error');
+  });
+  proc.on('close', function (code) {
+    t.equals(code, 0, 'citgm-all should run all the tests in the lookup');
+  });
+});
+
 test('bin: sigterm', function (t) {
   t.plan(1);
 

--- a/test/bin/test-citgm.js
+++ b/test/bin/test-citgm.js
@@ -85,3 +85,37 @@ test('bin: install from sha', function (t) {
     t.ok(code === 0, 'omg-i-pass should pass and exit with a code of zero');
   });
 });
+
+test('bin: omg-i-pass-with-install-param /w multiple tests /w custom lookup',
+  function (t) {
+    t.plan(1);
+    const proc = spawn(citgmPath,
+      ['-l', './test/fixtures/custom-lookup-multiple-tests.json',
+        'omg-i-pass-with-install-param#works']);
+    proc.on('error', function(err) {
+      t.error(err);
+      t.fail('we should not get an error testing ' +
+             'omg-i-pass-with-install-param');
+    });
+    proc.on('close', function (code) {
+      t.ok(code === 0, 'omg-i-pass-with-install-param should pass and exit ' +
+        'with a code of zero');
+    });
+  }
+);
+
+test('bin: omg-i-pass-with-install-param should fail /w multiple tests /w ' +
+  'custom lookup', function (t) {
+  t.plan(1);
+  const proc = spawn(citgmPath,
+    ['-l', './test/fixtures/custom-lookup-multiple-tests.json',
+      'omg-i-pass-with-install-param']);
+  proc.on('error', function(err) {
+    t.error(err);
+    t.fail('we should not get an error testing omg-i-pass-with-install-param');
+  });
+  proc.on('close', function (code) {
+    t.ok(code === 1, 'omg-i-pass-with-install-param should fail and exit ' +
+      'with a code of 1');
+  });
+});

--- a/test/fixtures/custom-lookup-multiple-tests.json
+++ b/test/fixtures/custom-lookup-multiple-tests.json
@@ -1,0 +1,27 @@
+{
+  "omg-i-pass": {
+    "npm": true,
+    "install": ["--default-install-param"],
+    "tests": {
+      "default-name": "default test name",
+      "second": {
+        "install": ["--second-test-install-param"]
+      }
+    }
+  },
+  "omg-i-pass-with-install-param": {
+    "npm": true,
+    "skip": true,
+    "install": ["--some-param"],
+    "tests": {
+      "works": {
+        "skip": false,
+        "install": ["--extra-param"]
+      }
+    }
+  },
+  "omg-i-fail": {
+    "npm": true,
+    "skip": true
+  }
+}

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -274,3 +274,155 @@ test('lookup: logging', function (t) {
     t.end();
   });
 });
+
+test('lookup: fail if test requested for module without tests', function(t) {
+  const context = {
+    module: {
+      name: 'omg-i-fail',
+      test: 'test',
+      raw: null
+    },
+    meta: {
+      repository: '/dev/null',
+      version: '0.1.1'
+    },
+    options: {
+      lookup: 'test/fixtures/custom-lookup-multiple-tests.json'
+    },
+    emit: function () {}
+  };
+
+  lookup(context, function (err) {
+    t.match(err && err.message, 'No tests specified for module');
+    t.end();
+  });
+});
+
+test('lookup: fail if test requested for module not in lookup', function(t) {
+  const context = {
+    module: {
+      name: 'omg-i-do-not-support-testing',
+      test: 'test',
+      raw: null
+    },
+    meta: {
+      repository: '/dev/null',
+      version: '0.1.1'
+    },
+    options: {
+      lookup: 'test/fixtures/custom-lookup-multiple-tests.json'
+    },
+    emit: function () {}
+  };
+
+  lookup(context, function (err) {
+    t.match(err && err.message, 'Test specified for module not in lookup');
+    t.end();
+  });
+});
+
+test('lookup: fail if test requested for module with wrong name', function(t) {
+  const context = {
+    module: {
+      name: 'omg-i-pass',
+      test: 'wrong name',
+      raw: null
+    },
+    meta: {
+      repository: '/dev/null',
+      version: '0.1.1'
+    },
+    options: {
+      lookup: 'test/fixtures/custom-lookup-multiple-tests.json'
+    },
+    emit: function () {}
+  };
+
+  lookup(context, function (err) {
+    t.match(err && err.message, 'This module does not have such test');
+    t.end();
+  });
+});
+
+test('lookup: default test name is set', function(t) {
+  const context = {
+    module: {
+      name: 'omg-i-pass',
+      raw: null
+    },
+    meta: {
+      repository: '/dev/null',
+      version: '0.1.1'
+    },
+    options: {
+      lookup: 'test/fixtures/custom-lookup-multiple-tests.json'
+    },
+    emit: function () {}
+  };
+  const expected = {
+    test: /default test name/,
+    install: [/--default-install-param/]
+  };
+
+  lookup(context, function(err) {
+    t.error(err);
+    t.match(context.module, expected, 'Read proper test data');
+    t.end();
+  });
+});
+
+test('lookup: read default test by its name', function(t) {
+  const context = {
+    module: {
+      name: 'omg-i-pass',
+      test: 'default test name',
+      raw: null
+    },
+    meta: {
+      repository: '/dev/null',
+      version: '0.1.1'
+    },
+    options: {
+      lookup: 'test/fixtures/custom-lookup-multiple-tests.json'
+    },
+    emit: function () {}
+  };
+  const expected = {
+    test: /default test name/,
+    install: [/--default-install-param/]
+  };
+
+  lookup(context, function(err) {
+    t.error(err);
+    t.match(context.module, expected, 'Read proper test data');
+    t.end();
+  });
+});
+
+test('lookup: read required test', function(t) {
+  const context = {
+    module: {
+      name: 'omg-i-pass',
+      test: 'second',
+      raw: null
+    },
+    meta: {
+      repository: '/dev/null',
+      version: '0.1.1'
+    },
+    options: {
+      lookup: 'test/fixtures/custom-lookup-multiple-tests.json'
+    },
+    emit: function () {}
+  };
+  const expected = {
+    test: /second/,
+    install: [/--second-test-install-param/]
+  };
+
+  lookup(context, function(err) {
+    t.error(err);
+    t.match(context.module, expected, 'Read proper test data');
+    t.end();
+  });
+});


### PR DESCRIPTION
This adds support for multiple test cases for single module. It allows to test single module with various configurations, e. g. `node-gyp` and `node-pre-gyp`.

Testing both downloaded and built addons is will be very useful for Windows platform, with various VS versions being used to build node and modules.

