### PR TITLE
npm: allow npm tmpdir to be set as an env var

### DIFF
--- a/lib/create-options.js
+++ b/lib/create-options.js
@@ -9,7 +9,10 @@ function createOptions(cwd, context) {
   }
   options.env = Object.create(process.env);
   options.env['npm_loglevel'] = 'error';
-  options.env['npm_config_tmp'] = context.npmConfigTmp;
+  // Use a local temp directory for npm if not already set via the env variable
+  if (!options.env['npm_config_tmp']) {
+    options.env['npm_config_tmp'] = context.npmConfigTmp;
+  }
 
   if (context.module && context.module.envVar) {
     _.forEach(context.module.envVar, function (val, key) {

--- a/lib/npm/install.js
+++ b/lib/npm/install.js
@@ -18,6 +18,8 @@ function install(context, next) {
   var bailed = false;
   context.emit('data', 'info', context.module.name + ' npm:', 'npm install started');
 
+  context.emit('data', 'verbose', context.module.name + ' npm:', 'Using temp directory: "' + options.env['npm_config_tmp'] + '"');
+
   if (context.module.install) {
     args = args.concat(context.module.install);
   }


### PR DESCRIPTION
currently if you `export npm_config_tmp="whatever/you/want"`, citgm
ignores this and will default to the machine tmp directory. This PR
forces citgm to use the env var if it has been exported