### PR TITLE
logger: display 'flaky but passed' modules

### DIFF
--- a/lib/reporter/logger.js
+++ b/lib/reporter/logger.js
@@ -28,6 +28,7 @@ function logger(log, modules) {
   var flaky = util.getFlakyFails(modules);
   var failed = util.getFails(modules);
   var expectFail = util.getExpectedFails(modules);
+  var passedFlaky = util.getpassedFlaky(modules);
 
   if (passed.length > 0) {
     log.info('passing module(s)');
@@ -36,6 +37,10 @@ function logger(log, modules) {
   if (expectFail.length > 0) {
     log.info('expected to fail:');
     logModules(log, 'error', expectFail);
+  }
+  if (passedFlaky.length > 0) {
+    log.info('flaky but passed:');
+    logModules(log, 'info', passedFlaky);
   }
   if (flaky.length > 0) {
     log.warn('flaky module(s)');

--- a/lib/reporter/tap.js
+++ b/lib/reporter/tap.js
@@ -7,14 +7,20 @@ var util = require('./util');
 
 function generateTest(mod, count) {
   var result = (!mod.error || mod.flaky) ? 'ok' : 'not ok';
-  var directive = (mod.flaky && mod.error) ? ' # SKIP' : '';
+  var directive = '';
+  if (mod.flaky && mod.error) {
+    directive = ' # SKIP';
+  } else if (mod.flaky && !mod.error) {
+    directive = ' # TODO';
+  }
   if (mod.error && mod.error.message) {
     mod.error = mod.error.message;
   }
   var error = mod.error ? [directive, mod.error].join(' ') : '';
+  var passedFlaky = (mod.flaky && !mod.error) ? [directive, 'passed but flaky'].join(' ') : '';
   var duration = '\n  duration_ms: ' + mod.duration;
   var output = mod.testOutput ? '\n' + util.sanitizeOutput(mod.testOutput, '  #') : '';
-  return [result, count + 1, '-', mod.name, 'v' + mod.version + error + '\n  ---' + output + duration + '\n  ...'].join(' ');
+  return [result, count + 1, '-', mod.name, 'v' + mod.version + error + passedFlaky +'\n  ---' + output + duration + '\n  ...'].join(' ');
 }
 
 function generateTap(modules) {

--- a/lib/reporter/util.js
+++ b/lib/reporter/util.js
@@ -20,6 +20,12 @@ function getExpectedFails(modules) {
   });
 }
 
+function getpassedFlaky(modules) {
+  return _.filter(modules, function (mod) {
+    return (mod.flaky && !mod.error);
+  });
+}
+
 function getFails(modules) {
   return _.filter(modules, function (mod) {
     return (mod.error && !mod.flaky && !mod.expectFail);
@@ -48,5 +54,6 @@ module.exports = {
   getFlakyFails: getFlakyFails,
   getExpectedFails: getExpectedFails,
   hasFailures: hasFailures,
-  sanitizeOutput: sanitizeOutput
+  sanitizeOutput: sanitizeOutput,
+  getpassedFlaky: getpassedFlaky
 };

--- a/test/reporter/test-reporter-logger.js
+++ b/test/reporter/test-reporter-logger.js
@@ -50,6 +50,9 @@ test('multiple modules passing, with a flaky module that fails:', function (t) {
   expected += 'version:' + '4.2.2';
   expected += 'module name:' + 'iFlakyPass';
   expected += 'version:' + '3.0.1';
+  expected += 'flaky but passed:';
+  expected += 'module name:' + 'iFlakyPass';
+  expected += 'version:' + '3.0.1';
   expected += 'flaky module(s)';
   expected += 'module name:' + 'iFlakyFail';
   expected += 'version:' + '3.3.3';


### PR DESCRIPTION
This PR will display all modules that passed despite being marked as
flaky in the logger at the end of the citgm run.
Fixes: https://github.com/nodejs/citgm/issues/316