### PR TITLE
lookup: mark libxmljs flaky on sles and rhel

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -286,7 +286,7 @@
   },
   "libxmljs": {
     "prefix": "v",
-    "flaky": "aix",
+    "flaky": ["aix", "sles", "rhel"],
     "skip": "win32"
   },
   "radium": {


### PR DESCRIPTION
libxmljs has been failing on sles and rhel
