### PR TITLE
chore update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "async": "^2.1.2",
     "chalk": "^1.1.3",
     "columnify": "^1.5.1",
-    "dotenv": "^2.0.0",
+    "dotenv": "^4.0.0",
     "lodash": "^4.12.0",
     "mkdirp": "^0.5.1",
     "normalize-git-url": "^3.0.2",
@@ -58,12 +58,12 @@
     "yargs": "^6.3.0"
   },
   "devDependencies": {
-    "eslint": "^2.13.1",
+    "eslint": "^3.13.1",
     "ncp": "^2.0.0",
     "rewire": "^2.4.0",
     "string-to-stream": "^1.1.0",
-    "tap": "^8.0.0",
-    "tap-parser": "^3.0.3",
+    "tap": "^9.0.3",
+    "tap-parser": "^5.1.0",
     "xml2js": "^0.4.17"
   }
 }


### PR DESCRIPTION
some of our dependencies are out of date as shown below:
```
dotenv       ^2.0.0  →   ^4.0.0
eslint      ^2.13.1  →  ^3.13.1
tap          ^8.0.0  →   ^9.0.3
tap-parser   ^3.0.3  →   ^5.1.0
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines
