### PR TITLE
lookup: skip pug

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -42,7 +42,8 @@
   "pug": {
     "flaky": {
       "ppc": ["v6", "v7"]
-    }
+    },
+    "skip": true
   },
   "socket.io": {
     "flaky": true


### PR DESCRIPTION
pug is currently failing to install from npm because the tags now contain `pug@` in the prefix. Issue raised: https://github.com/pugjs/pug/issues/2683

