### PR TITLE
lookup: add prefix to browserify

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -82,6 +82,7 @@
   },
   "browserify": {
     "flaky": ["v7", "win32"],
+    "prefix": "v",
     "expectFail": "fips"
   },
   "watchify": {


### PR DESCRIPTION
browserify as of v14.0.0 now contains a prefix.
https://github.com/substack/node-browserify/releases
