### PR TITLE
linter: add new linter rules

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -10,5 +10,13 @@
     linebreak-style: [2, unix]
     semi: [2, always]
     max-len: [2, 80]
+    no-multi-spaces: 2
+    no-useless-escape: 2
+    array-bracket-spacing: [2, never]
+    brace-style: 2
+    capitalized-comments: 2
+    eol-last: [2, always]
+    func-call-spacing: [2, never]
+    semi-spacing: 2
 
   extends: eslint:recommended

--- a/bin/citgm-all.js
+++ b/bin/citgm-all.js
@@ -42,8 +42,8 @@ var log = logger({
 update(log);
 
 if (!app.su) {
-  require('root-check')(); // silently downgrade if running as root...
-                           // unless --su is passed
+  require('root-check')(); // Silently downgrade if running as root...
+                           // Unless --su is passed
 } else {
   log.warn('root', 'Running as root! Use caution!');
 }
@@ -122,8 +122,7 @@ function runCitgm (mod, name, next) {
     if (result.error) {
       log.error(result.name + ' done', 'done - the test suite for ' +
           result.name + ' version ' + result.version + ' failed');
-    }
-    else {
+    } else {
       log.info(result.name + ' done', 'done - the test suite for ' + result.name
           + ' version ' + result.version + ' passed.');
     }
@@ -163,10 +162,10 @@ function launch() {
     }
 
     if (app.tap) {
-      // if tap is a string it should be a path to write output to
-      // if not use `log.bypass` which is currently process.stdout.write
+      // If tap is a string it should be a path to write output to
+      // If not use `log.bypass` which is currently process.stdout.write
       // TODO check that we can write to that path, perhaps require a flag to
-      // overwrite
+      // Overwrite
       var tap = (typeof app.tap === 'string') ? app.tap : log.bypass;
       reporter.tap(tap, modules, app.append);
     }

--- a/bin/citgm.js
+++ b/bin/citgm.js
@@ -31,8 +31,8 @@ var log = logger({
 update(log);
 
 if (!app.su) {
-  require('root-check')(); // silently downgrade if running as root...
-                           // unless --su is passed
+  require('root-check')(); // Silently downgrade if running as root...
+                           // Unless --su is passed
 } else {
   log.warn('root', 'Running as root! Use caution!');
 }

--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -1,15 +1,15 @@
 'use strict';
 
-// node modules
+// Node modules
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 
-// npm modules
+// Npm modules
 var async = require('async');
 var npa = require('npm-package-arg');
 var which = require('which');
 
-// local modules
+// Local modules
 var lookup = require('./lookup');
 var grabProject = require('./grab-project');
 var unpack = require('./unpack');
@@ -47,7 +47,7 @@ function find(app, context, next) {
 
 function init(context, next) {
   // Script is passed as an option to citgm, but it needs to also apply to the
-  // single module that citgm is testing.
+  // Single module that citgm is testing.
   if (context.options.script) {
     context.module.script = context.options.script;
   }
@@ -61,7 +61,7 @@ function init(context, next) {
   }
   context.emit('data', 'silly', context.module.name + ' init-detail',
       context.module);
-  next(null, context); // inject the context
+  next(null, context); // Inject the context
 }
 
 function sha1(mod) {
@@ -72,7 +72,7 @@ function sha1(mod) {
 }
 
 function extractDetail(mod) {
-  var detail = npa(mod); // will throw on failure
+  var detail = npa(mod); // Will throw on failure
   detail.name = detail.name || sha1(mod);
   return detail;
 }

--- a/lib/grab-module-data.js
+++ b/lib/grab-module-data.js
@@ -2,8 +2,8 @@ var spawn = require('./spawn');
 var createOptions = require('./create-options');
 
 function grabModuleData(context, next) {
-  // launch npm info as a child process, using the tmp directory
-  // as the working directory.
+  // Launch npm info as a child process, using the tmp directory
+  // As the working directory.
   var proc =
     spawn(
       'npm',

--- a/lib/grab-project.js
+++ b/lib/grab-project.js
@@ -1,7 +1,7 @@
-// node modules
+// Node modules
 var path = require('path');
 
-// local modules
+// Local modules
 var spawn = require('./spawn');
 var createOptions = require('./create-options');
 
@@ -27,7 +27,7 @@ function grabProject(context, next) {
 
   var filename = '';
 
-  // default timeout to 10 minutes if not provided
+  // Default timeout to 10 minutes if not provided
   var timeout = setTimeout(cleanup, context.options.timeoutLength
         || 1000 * 60 * 10);
 

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -5,7 +5,7 @@ var path = require('path');
 
 var isMatch = require('./match-conditions');
 
-// construct the tarball url using the repo, spec and prefix config
+// Construct the tarball url using the repo, spec and prefix config
 function makeUrl(repo, spec, tags, prefix, sha) {
   var version = (!spec || spec === '') ? 'master' : tags[spec];
   prefix = prefix || '';
@@ -18,10 +18,10 @@ function makeUrl(repo, spec, tags, prefix, sha) {
   return util.format('%s/archive/%s%s.tar.gz', repo, prefix, version);
 }
 
-// pull the repository url either from the lookup table
-// or the npm metadata. remove the .git suffix from the url
-// if necessary, and replace the git:// prefx with https://
-// if necessary
+// Pull the repository url either from the lookup table
+// Or the npm metadata. remove the .git suffix from the url
+// If necessary, and replace the git:// prefx with https://
+// If necessary
 function getRepo(repo, meta) {
   var ret = normgit(repo || meta.repository.url).url;
   ret = ret.replace(/\.git$/, '');

--- a/lib/match-conditions.js
+++ b/lib/match-conditions.js
@@ -16,7 +16,7 @@ var release = '';
 var fips = '';
 
 if (process.versions.openssl.indexOf('fips') !== -1) {
-  //when in fips mode include `fips` as a match condition
+  // When in fips mode include `fips` as a match condition
   fips = 'fips';
 }
 

--- a/lib/npm/index.js
+++ b/lib/npm/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// local modules
+// Local modules
 var test = require('./test');
 var install = require('./install');
 

--- a/lib/npm/install.js
+++ b/lib/npm/install.js
@@ -1,12 +1,12 @@
 'use strict';
 
-// node modules
+// Node modules
 var path = require('path');
 
-// npm modules
+// Npm modules
 var stripAnsi = require('strip-ansi');
 
-// local modules
+// Local modules
 var spawn = require('../spawn');
 var createOptions = require('../create-options');
 
@@ -39,7 +39,7 @@ function install(context, next) {
 
   var proc = spawn('npm', args, options);
 
-  // default timeout to 10 minutes if not provided
+  // Default timeout to 10 minutes if not provided
   var timeout = setTimeout(cleanup, context.options.timeoutLength
         || 1000 * 60 * 10);
 

--- a/lib/npm/script/fetch.js
+++ b/lib/npm/script/fetch.js
@@ -1,9 +1,9 @@
-// node modules
+// Node modules
 var path = require('path');
 var fs = require('fs');
 var url = require('url');
 
-// npm modules
+// Npm modules
 var uuid = require('uuid');
 var request = require('request');
 
@@ -16,13 +16,11 @@ function fetchScript(context, script, next) {
     var _path;
     if (context.options && context.options.lookup && script[0] !== '/') {
       _path = path.resolve(path.dirname(context.options.lookup), script);
-    }
-    else {
+    } else {
       _path = path.resolve(process.cwd(), script);
     }
     readStream = fs.createReadStream(_path);
-  }
-  else {
+  } else {
     context.emit('data', 'silly', context.module.name + ' fetch-script-start',
         script);
     readStream = request(res.href);
@@ -38,7 +36,7 @@ function fetchScript(context, script, next) {
     next(null, dest);
   });
 
-  readStream.pipe(fs.createWriteStream(dest)); // todo add verification
+  readStream.pipe(fs.createWriteStream(dest)); // Todo add verification
 }
 
 module.exports = fetchScript;

--- a/lib/npm/script/run.js
+++ b/lib/npm/script/run.js
@@ -1,12 +1,12 @@
-// node modules
+// Node modules
 var path = require('path');
 var fs = require('fs');
 var util = require('util');
 
-// npm modules
+// Npm modules
 var stripAnsi = require('strip-ansi');
 
-// local modules
+// Local modules
 var createOptions = require('../../create-options');
 var spawn = require('../../spawn');
 

--- a/lib/npm/test.js
+++ b/lib/npm/test.js
@@ -1,15 +1,15 @@
 'use strict';
 
-// node modules
+// Node modules
 var path = require('path');
 var fs = require('fs');
 
-// npm modules
+// Npm modules
 var readPackage = require('read-package-json');
 var stripAnsi = require('strip-ansi');
 var which = require('which').sync;
 
-// local modules
+// Local modules
 var spawn = require('../spawn');
 var createOptions = require('../create-options');
 var script = require('./script');
@@ -67,7 +67,7 @@ function test(context, next) {
       nodeBin = which(nodeBinName, {path: options.env.PATH
             || process.env.PATH});
     }
-    var npmBin = which(npmBinName,  {path: options.env.PATH
+    var npmBin = which(npmBinName, {path: options.env.PATH
           || process.env.PATH});
     if (windows) {
       npmBin = path.join(path.dirname(npmBin), 'node_modules', 'npm', 'bin',

--- a/lib/out.js
+++ b/lib/out.js
@@ -55,7 +55,7 @@ module.exports = function(options) {
       output(tag, message, logger.verbose);
     },
     info: function(tag, message) {
-      // if (colorize) tag = chalk.cyan(tag);
+      // If (colorize) tag = chalk.cyan(tag);
       output(tag, message, logger.info);
     },
     warn: function(tag, message) {

--- a/lib/reporter/index.js
+++ b/lib/reporter/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// local modules
+// Local modules
 var markdown = require('./markdown');
 var junit = require('./junit');
 var logger = require('./logger');

--- a/lib/reporter/junit.js
+++ b/lib/reporter/junit.js
@@ -39,12 +39,10 @@ function junit(logger, modules, append) {
   if (typeof logger === 'string') {
     if (append){
       fs.appendFileSync(logger, payload + '\n');
-    }
-    else {
+    } else {
       fs.writeFileSync(logger, payload + '\n');
     }
-  }
-  else {
+  } else {
     logger(payload);
   }
 }

--- a/lib/reporter/logger.js
+++ b/lib/reporter/logger.js
@@ -45,8 +45,7 @@ function logger(log, modules) {
     log.error('failing module(s)');
     logModules(log, 'error', failed);
     log.error('done', 'The smoke test has failed.');
-  }
-  else {
+  } else {
     log.info('done', 'The smoke test has passed.');
   }
 }

--- a/lib/reporter/markdown.js
+++ b/lib/reporter/markdown.js
@@ -35,8 +35,7 @@ function markdown(logger, modules) {
     if (flaky.length > 0) {
       logger('## 📛 But with Flaky Failures 📛');
     }
-  }
-  else {
+  } else {
     logger('## 🔥⚠️🔥 CITGM FAILED 🔥⚠️🔥');
   }
 

--- a/lib/reporter/tap.js
+++ b/lib/reporter/tap.js
@@ -32,12 +32,10 @@ function tap(logger, modules, append) {
   if (typeof logger === 'string') {
     if (append){
       fs.appendFileSync(logger, payload + '\n');
-    }
-    else {
+    } else {
       fs.writeFileSync(logger, payload + '\n');
     }
-  }
-  else {
+  } else {
     logger(payload);
   }
 }

--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -1,4 +1,4 @@
-// node modules
+// Node modules
 var child = require('child_process');
 
 function spawn(cmd, args, options) {

--- a/lib/temp-directory.js
+++ b/lib/temp-directory.js
@@ -1,7 +1,7 @@
-// node modules
+// Node modules
 var path = require('path');
 
-// npm modules
+// Npm modules
 var mkdirp = require('mkdirp');
 var rimraf = require('rimraf');
 var uuid = require('uuid');

--- a/lib/unpack.js
+++ b/lib/unpack.js
@@ -1,9 +1,9 @@
-// node modules
+// Node modules
 var fs = require('fs');
 var zlib = require('zlib');
 var path = require('path');
 
-// npm modules
+// Npm modules
 var tar = require('tar');
 
 function unpack(context, next) {

--- a/test/npm/test-npm-script-fetch.js
+++ b/test/npm/test-npm-script-fetch.js
@@ -38,7 +38,7 @@ test('fetch: given a file path', function (t) {
       name: 'test-module'
     }
   };
-  fetch(context, passing, function (err, _path)  {
+  fetch(context, passing, function (err, _path) {
     t.error(err);
     t.match(_path, context.path, 'the resolved path should be in the context'
     + ' path');
@@ -62,7 +62,7 @@ test('fetch: given a custom lookup table and relative path', function (t) {
       lookup: path.join(fixtures, 'custom-lookup-script.json')
     }
   };
-  fetch(context, './example-test-script-passing.sh', function (err, _path)  {
+  fetch(context, './example-test-script-passing.sh', function (err, _path) {
     t.error(err);
     t.match(_path, context.path, 'the resolved path should be in the context'
     + ' path');

--- a/test/reporter/test-reporter-util.js
+++ b/test/reporter/test-reporter-util.js
@@ -91,7 +91,7 @@ test('hasFailures:', function (t) {
 });
 
 test('util.sanitizeOutput', function (t) {
-  // var result = util.sanitizeOutput();
+  // Var result = util.sanitizeOutput();
   var raw = fs.readFileSync(carriageReturnPath, 'utf-8');
   var expected = fs.readFileSync(carriageReturnExpectedPath, 'utf-8');
   var result = util.sanitizeOutput(raw, '#');

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -46,8 +46,7 @@ test('lookup[getLookupTable]:', function (t) {
     var table = getLookupTable({
       lookup: null
     });
-  }
-  catch (e) {
+  } catch (e) {
     t.error(e);
   }
   t.ok(table, 'table should exist');
@@ -62,8 +61,7 @@ test('lookup[getLookupTable]: custom table', function (t) {
     var table = getLookupTable({
       lookup: 'test/fixtures/custom-lookup.json'
     });
-  }
-  catch (e) {
+  } catch (e) {
     t.error(e);
   }
 
@@ -84,8 +82,7 @@ test('lookup[getLookupTable]: custom table that does not exist', function (t) {
     var table = getLookupTable({
       lookup: 'test/fixtures/i-am-not-a.json'
     });
-  }
-  catch (e) {
+  } catch (e) {
     t.error(e);
   }
 
@@ -230,8 +227,7 @@ test('lookup: --fail-flaky', function (t) {
 test('lookup: ensure lookup works', function (t) {
   try {
     var lookup = require('../lib/lookup.json');
-  }
-  catch (err) {
+  } catch (err) {
     t.error(err);
   }
   t.ok(lookup, 'the lookup table should exist');
@@ -273,7 +269,7 @@ test('lookup: logging', function (t) {
       msg: 'https://github.com/nodejs/citgm/archive/master.tar.gz' },
     { type: 'verbose',
       key: 'omg-i-pass lookup-install',
-      msg: [ '--extra-param' ] },
+      msg: ['--extra-param'] },
     { type: 'info',
       key: 'omg-i-pass lookup-script',
       msg: './example-test-script-passing.sh' }

--- a/test/test-spawn.js
+++ b/test/test-spawn.js
@@ -34,7 +34,7 @@ test('spawn: windows mock', function (t) {
   });
 
   child.spawn = function (cmd, args, options) {
-    return  {
+    return {
       cmd: cmd,
       args: args,
       options: options


### PR DESCRIPTION
this PR adds some new linter rules that I feel that we should be using
in CitGM:

```
"no-multi-spaces": 2,
"no-useless-escape": 2,
"array-bracket-spacing": [2, "never"],
"brace-style": 2,
"capitalized-comments": 2,
"eol-last": [2, "always"],
"func-call-spacing": [2, "never"],
"semi-spacing": 2,
```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](CONTRIBUTING.md)
- [x] commit message follows commit guidelines
