### PR TITLE
match conditions: fix for rhel and sles x64/x86

### DIFF
--- a/lib/match-conditions.js
+++ b/lib/match-conditions.js
@@ -21,10 +21,9 @@ if (process.versions.openssl.indexOf('fips') !== -1) {
 }
 
 if (fs.existsSync('/etc/os-release')) {
-  var osRelease = require('dotenv').config({path: '/etc/os-release',
-    silent: true});
-  distro = osRelease['ID'] || '';
-  release = osRelease['VERSION_ID'] || '';
+  var osRelease = fs.readFileSync('/etc/os-release', 'utf8');
+  distro = osRelease.match(/\n\s*ID="?(.*)"?/)[1] || '';
+  release = osRelease.match(/\n\s*VERSION_ID="?(.*)"?/)[1] || '';
 } else if (platform === 'darwin') {
   distro = 'macos';
   release = execSync('sw_vers -productVersion').toString() || '';

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "async": "^2.1.2",
     "chalk": "^1.1.3",
     "columnify": "^1.5.1",
-    "dotenv": "^4.0.0",
     "lodash": "^4.12.0",
     "mkdirp": "^0.5.1",
     "normalize-git-url": "^3.0.2",

--- a/test/test-match-conditions.js
+++ b/test/test-match-conditions.js
@@ -7,7 +7,10 @@ var isMatch = rewire('../lib/match-conditions');
 
 var platformCache = isMatch.__get__('platform');
 var versionCache = isMatch.__get__('version');
+var archCache = isMatch.__get__('arch');
 var semVersionCache = isMatch.__get__('semVersion');
+var distroCache = isMatch.__get__('distro');
+var releaseCache = isMatch.__get__('release');
 
 var match = {
   v5: ['darwin', 'hurd', 'x86']
@@ -28,12 +31,17 @@ function shim() {
   isMatch.__set__('platform', 'darwin');
   isMatch.__set__('arch', 'x64');
   isMatch.__set__('semVersion', 'v5.3.1');
+  isMatch.__set__('distro', 'macos');
+  isMatch.__set__('release', '10.12.2');
 }
 
 function revertShim() {
   isMatch.__set__('version', versionCache);
   isMatch.__set__('platform', platformCache);
+  isMatch.__set__('arch', archCache);
   isMatch.__set__('semVersion', semVersionCache);
+  isMatch.__set__('distro', distroCache);
+  isMatch.__set__('release', releaseCache);
 }
 
 function testVersions(t, testFunction) {
@@ -43,6 +51,7 @@ function testVersions(t, testFunction) {
   t.ok(testFunction('v5'), 'the module is matched on the current platform');
   t.ok(testFunction('> 5.0.0'),
       'the module is matched on the current platform');
+  t.ok(testFunction('macos'), 'the distro is correct');
   t.notok(testFunction('v2'),
       'the module is not matched on the current platform');
   t.notok(testFunction('<=v2.0.0'),


### PR DESCRIPTION
This PR fixes and issue where dotenv was sometimes returning osRelease
with a parsed key and sometimes without. This meant that pulling the
distro and release version from the object was much harder. I have
swapped dotenv out with a simple regex that only grabs the information
that we need.

Example of the issue:
on rhel and sles x86/x64:
```
{ parsed: 
   { NAME: 'Red Hat Enterprise Linux Server',
     VERSION: '7.1 (Maipo)',
     ID: 'rhel',
     ID_LIKE: 'fedora',
     VERSION_ID: '7.1',
     PRETTY_NAME: 'Red Hat Enterprise Linux Server 7.1 (Maipo)',
     ANSI_COLOR: '0;31',
     CPE_NAME: 'cpe:/o:redhat:enterprise_linux:7.1:GA:server',
     HOME_URL: 'https://www.redhat.com/',
     BUG_REPORT_URL: 'https://bugzilla.redhat.com/',
     REDHAT_BUGZILLA_PRODUCT: 'Red Hat Enterprise Linux 7',
     REDHAT_BUGZILLA_PRODUCT_VERSION: '7.1',
     REDHAT_SUPPORT_PRODUCT: 'Red Hat Enterprise Linux',
     REDHAT_SUPPORT_PRODUCT_VERSION: '7.1' } }
```
on all other linux platforms
```
   { NAME: 'Red Hat Enterprise Linux Server',
     VERSION: '7.1 (Maipo)',
     ID: 'rhel',
     ID_LIKE: 'fedora',
     VERSION_ID: '7.1',
     PRETTY_NAME: 'Red Hat Enterprise Linux Server 7.1 (Maipo)',
     ANSI_COLOR: '0;31',
     CPE_NAME: 'cpe:/o:redhat:enterprise_linux:7.1:GA:server',
     HOME_URL: 'https://www.redhat.com/',
     BUG_REPORT_URL: 'https://bugzilla.redhat.com/',
     REDHAT_BUGZILLA_PRODUCT: 'Red Hat Enterprise Linux 7',
     REDHAT_BUGZILLA_PRODUCT_VERSION: '7.1',
     REDHAT_SUPPORT_PRODUCT: 'Red Hat Enterprise Linux',
     REDHAT_SUPPORT_PRODUCT_VERSION: '7.1' } 
```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](CONTRIBUTING.md)
- [x] commit message follows commit guidelines
