### PR TITLE
doc: fix the PR template CONTRIBUTING.md link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,5 +9,5 @@ the requirements below.
 - [ ] `npm test` passes
 - [ ] tests are included
 - [ ] documentation is changed or added
-- [ ] contribution guidelines followed [here](CONTRIBUTING.md)
+- [ ] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
 - [ ] commit message follows commit guidelines


### PR DESCRIPTION
Using ./CONTRIBUTING.md in the PR template resolves to
https://github.com/nodejs/citgm/compare/CONTRIBUTING.md. Use the full path
instead (as is done in Node.js core).

Note that the CONTRIBUTING.md file hasn't yet been added (the PR to add it is
https://github.com/nodejs/citgm/pull/314).

Link to core PR template: https://raw.githubusercontent.com/nodejs/node/master/.github/PULL_REQUEST_TEMPLATE.md

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] contribution guidelines followed [here](CONTRIBUTING.md)
- [x] commit message follows commit guidelines
