### PR TITLE
deps: update update-notifier to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "supports-color": "^3.1.0",
     "tar": "^2.1.1",
     "uid-number": "0.0.6",
-    "update-notifier": "^1.0.2",
+    "update-notifier": "^2.1.0",
     "uuid": "^3.0.0",
     "which": "^1.2.8",
     "winston": "^2.2.0",


### PR DESCRIPTION
There is a major version bump because the module removed support for Node.js 0.10 and 0.12

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](CONTRIBUTING.md)
- [x] commit message follows commit guidelines
