### PR TITLE
lookup: flaky modules

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -326,13 +326,13 @@
   },
   "ember-cli": {
     "prefix": "v",
-    "flaky": ["win32", "rhel", "sles"],
+    "flaky": ["win32", "rhel", "sles", {"ubuntu": "big"}],
     "expectFail": "fips",
     "maintainers": ["stefanpenner", "rwjblue", "Turbo87", "kellyselden"]
   },
   "node-sass": {
     "prefix": "v",
-    "flaky": ["ppc", "s390"],
+    "flaky": ["ppc", "s390", "win32"],
     "maintainers": "xzyfer"
   },
   "full-icu-test": {


### PR DESCRIPTION
mark node-sass flaky on windows and ember-cli flaky on ppcbe

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
- [x] commit message follows commit guidelines
