### PR TITLE
lookup: stop using master branch for underscore

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -4,7 +4,6 @@
     "maintainers": "jdalton"
   },
   "underscore": {
-    "master": true,
     "flaky": ["aix", "s390"],
     "skip": "win32",
     "maintainers": "jashkenas"

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -52,8 +52,8 @@ test('lookup[getLookupTable]:', function (t) {
   }
   t.ok(table, 'table should exist');
   t.ok(table.lodash, 'lodash should be in the table');
-  t.ok(table.underscore.master, 'underscore should contain a master paramter');
-
+  t.ok(table.underscore.maintainers,
+      'underscore should contain a maintainers parameter');
   t.end();
 });
 


### PR DESCRIPTION
Underscore was marked to use the master branch a while ago but this is no longer required

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
- [x] commit message follows commit guidelines
