### PR TITLE
lookup: unskip uglify-js

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -67,8 +67,7 @@
   },
   "uglify-js": {
     "prefix": "v",
-    "flaky": ["darwin", "aix", "win32"],
-    "skip": true,
+    "flaky": ["aix", "win32", "v7"],
     "maintainers": "mishoo"
   },
   "jquery": {


### PR DESCRIPTION
uglify-js seems to be passing now and I have also removed the flaky tag
for darwin


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
- [x] commit message follows commit guidelines
