### PR TITLE
lookup: mark david as flaky on win32

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -66,7 +66,8 @@
     "flaky": "win32"
   },
   "david": {
-    "prefix": "v"
+    "prefix": "v",
+    "flaky": "win32"
   },
   "eslint": {
     "prefix": "v",


### PR DESCRIPTION
David is failing on windows:
```
C:\Users\jenkins\workspace\SVT-V6-COMMUNITY-CITGM\ARCH\x64\GCC\gcc48\OS\win7\TAG\svt\tmp\3e38cc3b-ceb3-46ea-a311-0b9b1a189dc2\david\node_modules\.bin\tape.CMD:1
 (function (exports, require, module, __filename, __dirname) { @IF EXIST "%~dp0\node.exe" (
                                                               ^
 SyntaxError: Invalid or unexpected token
     at Object.exports.runInThisContext (vm.js:76:16)
     at Module._compile (module.js:542:28)
     at Object.Module._extensions..js (module.js:579:10)
     at Object.Module._extensions.(anonymous function) [as .js] (C:\Users\jenkins\workspace\SVT-V6-COMMUNITY-CITGM\ARCH\x64\GCC\gcc48\OS\win7\TAG\svt\tmp\3e38cc3b-ceb3-46ea-a311-0b9b1a189dc2\david\node_modules\istanbul\lib\hook.js:109:37)
     at Module.load (module.js:487:32)
     at tryModuleLoad (module.js:446:12)
     at Function.Module._load (module.js:438:3)
     at Function.Module.runMain (module.js:604:10)
     at runFn (C:\Users\jenkins\workspace\SVT-V6-COMMUNITY-CITGM\ARCH\x64\GCC\gcc48\OS\win7\TAG\svt\tmp\3e38cc3b-ceb3-46ea-a311-0b9b1a189dc2\david\node_modules\istanbul\lib\command\common\run-with-cover.js:122:16)
     at C:\Users\jenkins\workspace\SVT-V6-COMMUNITY-CITGM\ARCH\x64\GCC\gcc48\OS\win7\TAG\svt\tmp\3e38cc3b-ceb3-46ea-a311-0b9b1a189dc2\david\node_modules\istanbul\lib\command\common\run-with-cover.js:251:17
```
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
- [x] commit message follows commit guidelines
