### PR TITLE
test: remove `thisisatest` folder

### DIFF
--- a/test/test-temp-directory.js
+++ b/test/test-temp-directory.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 
 const test = require('tap').test;
 const rewire = require('rewire');
+const rimraf = require('rimraf');
 
 const tempDirectory = rewire('../lib/temp-directory');
 
@@ -17,7 +18,7 @@ const context = {
 
 const contextTmpDir = {
   options: {
-    tmpDir: 'thisisatest'
+    tmpDir: '.thisisatest'
   },
   path: null,
   emit: function () {},
@@ -55,6 +56,8 @@ test('tempDirectory.create --tmpDir:', function (t) {
     fs.stat(ctx.path, function (err, stats) {
       t.error(err);
       t.ok(stats.isDirectory(), 'the path should exist and be a folder');
+      rimraf('./.thisisatest', function() {
+      });
       t.end();
     });
   });


### PR DESCRIPTION
one of the tests in test/test-temp-directory creates a temporary
directory called `thisisatest` but this was not getting cleaned up at
the end of the run

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
- [x] commit message follows commit guidelines
