### PR TITLE
revert #350

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "supports-color": "^3.1.0",
     "tar": "^2.1.1",
     "uid-number": "0.0.6",
-    "update-notifier": "^2.1.0",
+    "update-notifier": "^1.0.2",
     "uuid": "^3.0.0",
     "which": "^1.2.8",
     "winston": "^2.2.0",


### PR DESCRIPTION
this commit reverts #350 which dropped support for 0.10 and 0.12 for
update-notifier