### PR TITLE
doc: remove bin/ prefix from usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install -g citgm
 
 ## Usage
 ```
-bin/citgm --help
+citgm --help
 ```
 
 (If citgm is installed globally, you can also `man citgm`)


### PR DESCRIPTION
The instructions say to install with "npm install -g citgm"
but then it tells you to run "bin/citgm" - the bin prefix
won't work after doing a global install so is confusing

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] documentation is changed or added
- [ ] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md) <<< That link doesn't work
- [x] commit message follows commit guidelines
