### PR TITLE
ci: remove travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: node_js
-os:
-  - linux
-  - osx
-node_js:
-  - "7"
-  - "6"
-  - "4"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ citgm is a simple tool for pulling down an arbitrary module
 from npm and testing it using a specific version of the
 node runtime.
 
-[![Build Status](https://travis-ci.org/nodejs/citgm.svg?branch=master)](https://travis-ci.org/nodejs/citgm) [![dependencies Status](https://david-dm.org/nodejs/citgm/status.svg)](https://david-dm.org/nodejs/citgm) [![devDependencies Status](https://david-dm.org/nodejs/citgm/dev-status.svg)](https://david-dm.org/nodejs/citgm?type=dev)
+[![dependencies Status](https://david-dm.org/nodejs/citgm/status.svg)](https://david-dm.org/nodejs/citgm) [![devDependencies Status](https://david-dm.org/nodejs/citgm/dev-status.svg)](https://david-dm.org/nodejs/citgm?type=dev)
 
 The Node.js project uses citgm to smoketest our releases and controversial changes. The Jenkins job that utilizes citgm can be found [on our CI](https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/).
 


### PR DESCRIPTION
we no longer need travis as we are now using Jenkins CI build statuses
inline in PRs #358. We will also need to remove citgm from the travis configuration

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
- [x] commit message follows commit guidelines
