### PR TITLE
citgm-stress: add a citgm stress test

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Options:
   -d, --nodedir <path>        Path to the node source to use when compiling native addons
   -p, --test-path <path>      Path to prepend to $PATH when running tests
   -n, --no-color              Turns off colorized output
-  -s, --su                    Allow running the tool as root.
+  -s, --su                    Allow running the tool as root
   -m, --markdown              Output results in markdown
   -t, --tap [path]            Output results in tap with optional file path
   -x, --junit [path]          Output results in junit xml with optional file path
@@ -125,7 +125,7 @@ For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
 ```
 "npm": true                  Download the module from npm instead of github
 "master": true               Use the master branch
-"prefix": "v"                Specify the prefix used in the module version.
+"prefix": "v"                Specify the prefix used in the module version
 "flaky": true                Ignore failures
 "skip": true                 Completely skip the module
 "expectFail"                 Expect the module to fail, error if it passes
@@ -140,6 +140,38 @@ For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
 
 If you want to pass options to npm, eg `--registry`, you can usually define an
 environment variable, eg `"npm_config_registry": "https://www.xyz.com"`.
+
+## citgm-stress
+
+//Need to write a description here//
+
+```
+Usage: citgm-stress [options] <module> <repeat>
+
+Options:
+
+  -h, --help                  output usage information
+  -V, --version               output the version number
+  --config                    Path to a JSON config file
+  -v, --verbose [level]       Verbose output (silly, verbose, info, warn, error)
+  -q, --npm-loglevel [level]  Verbose output (silent, error, warn, http, info, verbose, silly)
+  -l, --lookup <path>         Use the lookup table provided at <path>
+  -d, --nodedir <path>        Path to the node source to use when compiling native addons
+  -p, --test-path <path>      Path to prepend to $PATH when running tests
+  -n, --no-color              Turns off colorized output
+  -s, --su                    Allow running the tool as root
+  -m, --markdown              Output results in markdown
+  -t, --tap [path]            Output results in tap with optional file path
+  -x, --junit [path]          Output results in junit xml with optional file path
+  -o, --timeout <length>      Set timeout for npm install
+  -c, --sha <commit-sha>      Install module from commit-sha
+  -u, --uid <uid>             Set the uid (posix only)
+  -g, --gid <uid>             Set the gid (posix only)
+  -a, --append                Turns on append results to file mode rather than replace
+  -j, --parallel <number>     Run tests in parallel
+  -J, --autoParallel          Run tests in parallel (automatically detect core count)
+  --tmpDir <path>             Directory to test modules in
+```
 
 ## Testing
 

--- a/bin/citgm-stress.js
+++ b/bin/citgm-stress.js
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+'use strict';
+const os = require('os');
+
+const async = require('async');
+
+const citgm = require('../lib/citgm');
+const commonArgs = require('../lib/common-args');
+const logger = require('../lib/out');
+const reporter = require('../lib/reporter');
+const update = require('../lib/update');
+
+const yargs = commonArgs(require('yargs'))
+  .usage('citgm-stress [options] <module> <repeat>')
+  .option('parallel', {
+    alias: 'j',
+    type: 'number',
+    description: 'Number of tests to run in parallel'
+  })
+  .option('autoParallel', {
+    alias: 'J',
+    type: 'boolean',
+    description: 'Auto detect number of cores to use to run tests in parallel'
+  });
+
+const app = yargs.argv;
+
+const repeatNumber = app._[1];
+
+const log = logger({
+  level: app.verbose,
+  nocolor: app.color
+});
+
+update(log);
+
+if (!app.su) {
+  require('root-check')(); // Silently downgrade if running as root...
+                           // Unless --su is passed
+} else {
+  log.warn('root', 'Running as root! Use caution!');
+}
+
+const options = {
+  lookup: app.lookup,
+  nodedir: app.nodedir,
+  testPath: app.testPath,
+  level: app.verbose,
+  npmLevel: app.npmLoglevel,
+  timeoutLength: app.timeout,
+  sha: app.sha,
+  tmpDir: app.tmpDir,
+  repeat: app.repeat
+};
+
+if (!repeatNumber) {
+  log.error('repeat', 'please specify a number to repeat');
+  process.exit(1);
+}
+
+const cpus = os.cpus().length;
+if (app.autoParallel || (app.parallel && app.parallel > cpus)) {
+  app.parallel = cpus;
+  log.info('cores', 'running tests using ' + app.parallel + ' cores');
+}
+if (app.parallel && ((app.parallel + 1) > process.getMaxListeners())) {
+  process.setMaxListeners(app.parallel + 1);
+}
+
+if (!citgm.windows) {
+  const uidnumber = require('uid-number');
+  const uid = app.uid || process.getuid();
+  const gid = app.gid || process.getgid();
+  uidnumber(uid, gid, function(err, uid, gid) {
+    options.uid = uid;
+    options.gid = gid;
+    launch(options);
+  });
+} else {
+  launch(options);
+}
+
+const modules = [];
+
+function runCitgm (mod, name, next) {
+
+  const start = new Date();
+  const runner = citgm.Tester(name, options);
+
+  let bailed = false;
+
+  function cleanup() {
+    bailed = true;
+    runner.cleanup();
+    process.removeListener('SIGINT', cleanup);
+    process.removeListener('SIGHUP', cleanup);
+    process.removeListener('SIGBREAK', cleanup);
+  }
+
+  process.on('SIGINT', cleanup);
+  process.on('SIGHUP', cleanup);
+  process.on('SIGBREAK', cleanup);
+
+  runner.on('start', function(name) {
+    log.info('starting', name);
+  }).on('fail', function(err) {
+    log.error('failure', err.message);
+  }).on('data', function(type, key, message) {
+    log[type](key, message);
+  }).on('end', function(result) {
+    result.duration = new Date() - start;
+    log.info('duration', 'test duration: ' + result.duration + 'ms');
+    if (result.error) {
+      log.error(result.name + ' done', 'done - the test suite for ' +
+          result.name + ' version ' + result.version + ' failed');
+    } else {
+      log.info(result.name + ' done', 'done - the test suite for ' + result.name
+          + ' version ' + result.version + ' passed.');
+    }
+    modules.push(result);
+    if (!bailed) {
+      process.removeListener('SIGINT', cleanup);
+      process.removeListener('SIGHUP', cleanup);
+      process.removeListener('SIGBREAK', cleanup);
+    }
+    return next(bailed);
+  }).run();
+}
+
+function runTask(task, next) {
+  runCitgm(task.mod, task.name, next);
+}
+
+function launch() {
+  let i = 0;
+  const collection = [];
+  while (i < app._[1]) {
+    collection.push({ name: app._[0] });
+    i++;
+  }
+
+  const q = async.queue(runTask, app.parallel || 1);
+  q.push(collection);
+  function done () {
+    q.drain = null;
+    reporter.logger(log, modules);
+
+    if (app.markdown) {
+      reporter.markdown(log.bypass, modules);
+    }
+
+    if (app.tap) {
+      // If tap is a string it should be a path to write output to
+      // If not use `log.bypass` which is currently process.stdout.write
+      // TODO check that we can write to that path, perhaps require a flag to
+      // Overwrite
+      const tap = (typeof app.tap === 'string') ? app.tap : log.bypass;
+      reporter.tap(tap, modules, app.append);
+    }
+
+    if (app.junit) {
+      const junit = (typeof app.junit === 'string') ? app.junit : log.bypass;
+      reporter.junit(junit, modules, app.append);
+    }
+
+    process.exit(reporter.util.hasFailures(modules));
+  }
+
+  function abort() {
+    q.pause();
+    q.kill();
+    process.exitCode = 1;
+    process.removeListener('SIGINT', abort);
+    process.removeListener('SIGHUP', abort);
+    process.removeListener('SIGBREAK', abort);
+    done();
+  }
+
+  q.drain = done;
+
+  process.on('SIGINT', abort);
+  process.on('SIGHUP', abort);
+  process.on('SIGBREAK', abort);
+}

--- a/man/citgm-all.1
+++ b/man/citgm-all.1
@@ -79,6 +79,7 @@ Specify which tags to skip from the lookup (takes priority over includeTags)
 
 .SH SEE ALSO
 citgm
+citgm-stress
 .SH AUTHOR
 Myles Borins <mborins@us.ibm.com>
 .SH COPYRIGHT

--- a/man/citgm-stress.1
+++ b/man/citgm-stress.1
@@ -1,14 +1,15 @@
 .\" Manpage for citgm
-.\" Contact jasnell@gmail.com to correct errors or typos
+.\" Contact george.adams@uk.ibm.com to correct errors or typos
 .TH "0.1.0" "MIT"
 .SH NAME
-citgm \- Canary in the Goldmine
+citgm-stress \- Canary in the Goldmine
 .SH SYNOPSIS
-citgm [options] <module>
+citgm-stress [options] <module> <repeat>
 .SH DESCRIPTION
 citgm is a tool for testing Node.js modules against different Node.js builds.
 Specifically, it automates the 'npm install' and 'npm test' steps and reports
-back the status.
+back the status. citgm-stress will run the same module multiple times to check
+flakiness
 .SH OPTIONS
 .TP
 .BR \-h ", " \-\-help
@@ -17,7 +18,7 @@ output usage information
 .BR \-V ", " \-\-version
 output the version number
 .TP
-.BR \-v ", " \-\-verbose ", " \-\-loglevel " " \fI[level]\fR
+.BR \-v ", " \-\-verbose " " \fI[level]\fR
 Verbose output (silly,verbose,info,warn,error)
 .TP
 .BR \-q ", " \-\-npm-loglevel " " \fI[level]\fR
@@ -64,24 +65,12 @@ Turns on append results to file mode rather than replace
 .TP
 .BR \-\-tmpDir " " \fI<path>\fR
 Directory to test modules in
-.SH EXAMPLES
-Test the latest underscore module:
-
-  citgm underscore@latest
-
-Test a local module:
-
-  citgm ./my-module
-
-Test using a tar.gz from Github:
-
-  citgm http://github.com/jasnell/activitystrea.ms/archive/master.tar.gz
 
 .SH SEE ALSO
 citgm-all
-citgm-stress
+citgm
 .SH AUTHOR
-James M Snell <jasnell@gmail.com>
+George Adams <george.adams@uk.ibm.com>
 .SH COPYRIGHT
 Copyright (c) 2015 citgm contributors
 .SH LICENSE

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "preferGlobal": true,
   "bin": {
     "citgm": "./bin/citgm.js",
-    "citgm-all": "./bin/citgm-all.js"
+    "citgm-all": "./bin/citgm-all.js",
+    "citgm-stress": "./bin/citgm-stress.js"
   },
   "scripts": {
     "test": "npm run lint && npm run tap",

--- a/test/bin/test-citgm-stress.js
+++ b/test/bin/test-citgm-stress.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const test = require('tap').test;
+
+const spawn = require('../../lib/spawn');
+
+const citgmPath = require.resolve('../../bin/citgm-stress.js');
+
+test('bin: omg-i-pass /w repeat x2 /w tap to file /w junit to file /w append',
+function (t) {
+  t.plan(1);
+  const proc = spawn(citgmPath, ['omg-i-pass', '2', '--tap', '/dev/null',
+    '--junit', '/dev/null', '--append']);
+  proc.on('error', function(err) {
+    t.error(err);
+    t.fail('we should not get an error testing omg-i-pass');
+  });
+  proc.on('close', function (code) {
+    t.ok(code === 0, 'omg-i-pass should pass and exit with a code of zero');
+  });
+});
+
+test('bin: omg-i-fail /w repeat x2 /w tap /w junit /w markdown output'
++ ' /w nodedir /w parallel', function (t) {
+  t.plan(1);
+  const proc = spawn(citgmPath, ['omg-i-fail', '2', '-m', '-t', '-x', '-d',
+    '/dev/null', '-J']);
+  proc.on('error', function(err) {
+    t.error(err);
+    t.fail('we should not get an error testing omg-i-pass');
+  });
+  proc.on('close', function (code) {
+    t.equal(code, 1, 'omg-i-fail should fail and exit with a code of one');
+  });
+});
+
+test('bin: omg-i-pass /w repeat no repeat', function (t) {
+  t.plan(1);
+  const proc = spawn(citgmPath, ['omg-i-pass']);
+  proc.on('error', function(err) {
+    t.error(err);
+    t.fail('we should not get an error testing omg-i-pass');
+  });
+  proc.on('close', function (code) {
+    t.equal(code, 1, 'omg-i-pass should fail because no repeat was specified');
+  });
+});
+
+test('bin: omg-i-pass /w repeat x1 /w local module', function (t) {
+  t.plan(1);
+  const proc = spawn(citgmPath, ['./test/fixtures/omg-i-pass', '1']);
+  proc.on('error', function(err) {
+    t.error(err);
+    t.fail('we should not get an error testing omg-i-pass');
+  });
+  proc.on('close', function (code) {
+    t.ok(code === 0, 'omg-i-pass should pass and exit with a code of zero');
+  });
+});
+
+test('bin: sigterm /w repeat x1', function (t) {
+  t.plan(1);
+
+  const proc = spawn(citgmPath, ['omg-i-pass', '1', '-v', 'verbose']);
+  proc.on('error', function(err) {
+    t.error(err);
+    t.fail('we should not get an error testing omg-i-pass');
+  });
+  proc.stdout.once('data', function () {
+    proc.kill('SIGINT');
+  });
+  proc.on('exit', function (code) {
+    t.equal(code, 1, 'omg-i-pass should fail from a sigint');
+  });
+});
+
+test('bin: install from sha /w repeat x1', function (t) {
+  t.plan(1);
+  const proc = spawn(citgmPath, ['omg-i-pass', '1', '-t', '-c',
+    '37c34bad563599782c622baf3aaf55776fbc38a8']);
+  proc.on('error', function(err) {
+    t.error(err);
+    t.fail('we should not get an error testing omg-i-pass');
+  });
+  proc.on('close', function (code) {
+    t.ok(code === 0, 'omg-i-pass should pass and exit with a code of zero');
+  });
+});


### PR DESCRIPTION
Closes: #122
The idea behind citgm stress is that we can repeat a single module test
multiple times to test for flakiness. You can run citgm-stress using
`./bin/citgm-stress.js <module> <repeat>`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)

#### TODO
- [ ] write description for README.md
