### PR TITLE
lookup: skip koa <7

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -376,7 +376,7 @@
     "maintainers": "wadey"
   },
   "koa": {
-    "skip": ["<4", "win32", "rhel"],
+    "skip": ["<7", "win32", "rhel"],
     "flaky": "ubuntu",
     "maintainers": "tj"
   },


### PR DESCRIPTION
Koa now ships with some async / await code. Fails on anything < 7
