### PR TITLE
lookup: fs-extra now has a prefix

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -57,6 +57,7 @@
     "maintainers": "rauchg"
   },
   "fs-extra": {
+    "prefix": "v",
     "flaky": ["linux-ia32", "aix", "s390", "win32"],
     "expectFail": "fips",
     "maintainers": "jprichardson"


### PR DESCRIPTION
TLDR; 'v'