### PR TITLE
lookup: remove expectFail: fips on express

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -21,7 +21,6 @@
   },
   "express": {
     "flaky": "ppc",
-    "expectFail": "fips",
     "maintainers": "tj"
   },
   "q": {


### PR DESCRIPTION
With the latest minor release of Express.js, the default out-of-the-box configuration should no longer fail on a FIPS-built Node.js since the removed hashing function is no longer used.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
