### PR TITLE
lib: support citgm module@version

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Options:
 ```
 
 ### Examples:
-  Test the latest underscore module:
-    `citgm underscore@latest`
+  Test the latest underscore module or a specific version:
+    `citgm underscore@latest` or `citgm underscore@1.3.0`
 
   Test a local module:
     `citgm ./my-module`

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -8,7 +8,15 @@ const isMatch = require('./match-conditions');
 
 // Construct the tarball url using the repo, spec and prefix config
 function makeUrl(repo, spec, tags, prefix, sha) {
-  let version = (!spec || spec === '') ? 'master' : tags[spec];
+  let version;
+  if (!spec) // Spec should already have defaulted to latest.
+    version = 'master';
+  else if (tags[spec])
+    version = tags[spec]; // Matches npm tags like 'latest' or 'next'.
+  else
+    // `spec` must match one of `meta.versions` as npm info call passed.
+    version = spec; // Matches npm versions like '1.0.0'
+
   prefix = prefix || '';
 
   if (sha) {

--- a/man/citgm.1
+++ b/man/citgm.1
@@ -65,9 +65,10 @@ Turns on append results to file mode rather than replace
 .BR \-\-tmpDir " " \fI<path>\fR
 Directory to test modules in
 .SH EXAMPLES
-Test the latest underscore module:
+Test the latest underscore module or a specific version:
 
   citgm underscore@latest
+  citgm underscore@1.3.0
 
 Test a local module:
 

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -28,6 +28,11 @@ test('lookup: makeUrl', function (t) {
   t.equal(url, expected,
         'if given a spec and tags it should give a link to associated version');
 
+  expected = repo + '/archive/' + '1.0.0' + '.tar.gz';
+  url = makeUrl(repo, '1.0.0', tags);
+  t.equal(url, expected,
+        'given a spec which is not an npm tag we should assume a Github tag');
+
   expected = repo + '/archive/' + prefix + tags.latest + '.tar.gz';
   url = makeUrl(repo, 'latest', tags, prefix);
   t.equal(url, expected,


### PR DESCRIPTION
Currently we support resolving an npm tag, but not an npm version. Update to
handle both.

Could probably do with a test.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)