### PR TITLE
lookup: mark node-sass and tape as flaky on windows

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -94,7 +94,7 @@
   },
   "tape": {
     "prefix": "v",
-    "flaky": "linux",
+    "flaky": ["linux", "win32"],
     "maintainers": "substack"
   },
   "browserify": {
@@ -332,7 +332,7 @@
   },
   "node-sass": {
     "prefix": "v",
-    "flaky": ["ppc", "s390"],
+    "flaky": ["ppc", "s390", "win32"],
     "maintainers": "xzyfer"
   },
   "full-icu-test": {


### PR DESCRIPTION
node-sass and tape are failing on windows
