### PR TITLE
lib: fix module linter issues by setting root

### DIFF
--- a/lib/temp-directory.js
+++ b/lib/temp-directory.js
@@ -1,4 +1,5 @@
 'use strict';
+const fs = require('fs');
 let path = require('path'); // Mocked in tests
 
 const mkdirp = require('mkdirp');
@@ -21,7 +22,17 @@ function create(context, next) {
     if (err) {
       return next(err);
     }
-    return next(null, context);
+    /* Tells eslint running in module tests not to look for config files above
+       this temp directory. */
+    const eslintrcPath = path.join(context.path, '.eslintrc.yml');
+    context.emit('data', 'verbose', context.module.name + ' mk.eslintrc',
+        eslintrcPath);
+    fs.writeFile(eslintrcPath, 'root: true', function (err) {
+      if (err) {
+        return next(err);
+      }
+      return next(null, context);
+    });
   });
 }
 

--- a/test/test-temp-directory.js
+++ b/test/test-temp-directory.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
 
 const test = require('tap').test;
 const rewire = require('rewire');
@@ -43,7 +44,12 @@ test('tempDirectory.create:', function (t) {
     fs.stat(ctx.path, function (err, stats) {
       t.error(err);
       t.ok(stats.isDirectory(), 'the path should exist and be a folder');
-      t.end();
+      const eslintrcPath = path.join(ctx.path, '.eslintrc.yml');
+      fs.readFile(eslintrcPath, 'utf-8', function (err, data) {
+        t.error(err);
+        t.equal(data, 'root: true', 'tmpDir should have a .eslintrc.yml file');
+        t.end();
+      });
     });
   });
 });


### PR DESCRIPTION
Eslint searches parent directories looking for config files until it
finds one with "root: true" in it. This sets "root: true" in CitGM's
tmpDir to avoid that.

Fixes: https://github.com/nodejs/citgm/issues/399

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)


To test:

```bash
mkdir /path/to/node/citgm_tmp
node /path/to/citgm.js --tmpDir /path/to/node/citgm_tmp --v silly gulp
```