### PR TITLE
Set nodedir and loglevel env vars

### DIFF
--- a/lib/create-options.js
+++ b/lib/create-options.js
@@ -11,7 +11,7 @@ function createOptions(cwd, context) {
     if (context.options.gid) options.gid = context.options.gid;
   }
   options.env = Object.create(process.env);
-  options.env['npm_loglevel'] = 'error';
+  options.env['npm_loglevel'] = context.options.npmLevel;
   options.env['npm_config_tmp'] = context.npmConfigTmp;
 
   if (context.options.nodedir) {

--- a/lib/create-options.js
+++ b/lib/create-options.js
@@ -1,5 +1,6 @@
 'use strict';
 const _ = require('lodash');
+const path = require('path');
 
 function createOptions(cwd, context) {
   const options = {
@@ -12,6 +13,13 @@ function createOptions(cwd, context) {
   options.env = Object.create(process.env);
   options.env['npm_loglevel'] = 'error';
   options.env['npm_config_tmp'] = context.npmConfigTmp;
+
+  if (context.options.nodedir) {
+    const nodedir = path.resolve(process.cwd(), context.options.nodedir);
+    options.env['npm_config_nodedir'] = nodedir;
+    context.emit('data', 'verbose', `${context.module.name} nodedir`,
+        `Using nodedir "${nodedir}"`);
+  }
 
   if (context.module && context.module.envVar) {
     _.forEach(context.module.envVar, function (val, key) {

--- a/lib/npm/install.js
+++ b/lib/npm/install.js
@@ -22,17 +22,6 @@ function install(context, next) {
     args = args.concat(context.module.install);
   }
 
-  if (context.options.nodedir) {
-    let nodedir = path.resolve(process.cwd(), context.options.nodedir);
-    options.env.npm_config_nodedir = nodedir;
-    if (process.platform === 'win32') {
-      nodedir = nodedir.replace(/\\/g, '\\\\');
-    }
-    args.push('--nodedir="' + nodedir + '"');
-    context.emit('data', 'verbose', context.module.name + ' nodedir',
-        'Using --nodedir="' + nodedir + '"');
-  }
-
   const proc = spawn('npm', args, options);
   const finish = timeout(context, proc, next, 'Install');
 

--- a/lib/npm/install.js
+++ b/lib/npm/install.js
@@ -11,7 +11,7 @@ function install(context, next) {
   const options =
     createOptions(
       path.join(context.path, context.module.name), context);
-  let args = ['install', '--loglevel', context.options.npmLevel];
+  let args = ['install'];
   context.emit('data', 'info', context.module.name + ' npm:',
       'npm install started');
 

--- a/lib/npm/test.js
+++ b/lib/npm/test.js
@@ -55,8 +55,7 @@ function test(context, next) {
       npmBin = path.join(path.dirname(npmBin), 'node_modules', 'npm', 'bin',
           'npm-cli.js');
     }
-    const proc = spawn(nodeBin, [npmBin, 'test', '--loglevel=' +
-        context.options.npmLevel], options);
+    const proc = spawn(nodeBin, [npmBin, 'test'], options);
     const finish = timeout(context, proc, next, 'Test');
 
     proc.stdout.on('data', function (data) {

--- a/test/test-create-options.js
+++ b/test/test-create-options.js
@@ -10,6 +10,7 @@ test('create-options:', function (t) {
   const context = {
     options: {
       nodedir: nodePath,
+      npmLevel: 'warning',
     },
     emit: function() {},
     npmConfigTmp: 'npm_config_tmp',
@@ -17,7 +18,7 @@ test('create-options:', function (t) {
   };
 
   const env = Object.create(process.env);
-  env['npm_loglevel'] = 'error';
+  env['npm_loglevel'] = 'warning';
   env['npm_config_tmp'] = 'npm_config_tmp';
   env['testenvVar'] = 'thisisatest';
   env['npm_config_nodedir'] = nodePath;

--- a/test/test-create-options.js
+++ b/test/test-create-options.js
@@ -5,9 +5,13 @@ const createOptions = require('../lib/create-options');
 
 test('create-options:', function (t) {
   const cwd = __dirname;
+  const nodePath = '/path/to/node';
 
   const context = {
-    options: {},
+    options: {
+      nodedir: nodePath,
+    },
+    emit: function() {},
     npmConfigTmp: 'npm_config_tmp',
     module: {envVar: {testenvVar: 'thisisatest'}}
   };
@@ -16,6 +20,7 @@ test('create-options:', function (t) {
   env['npm_loglevel'] = 'error';
   env['npm_config_tmp'] = 'npm_config_tmp';
   env['testenvVar'] = 'thisisatest';
+  env['npm_config_nodedir'] = nodePath;
 
   const options = createOptions(cwd, context);
 
@@ -23,7 +28,7 @@ test('create-options:', function (t) {
   t.notOk(options.uid, 'There should not be a uid in the options');
   t.notOk(options.gid, 'There should not be a gid in the options');
   t.deepequal(options.env, env, 'The created env should be a clone of'
-  + ' process.env with the added npm_loglevel');
+  + ' process.env with the added npm_loglevel and nodedir');
   t.end();
 });
 


### PR DESCRIPTION
```
lib: pass npm_config_nodedir as an env var

We currently pass --nodedir as an argument to `npm install`. However
this doesn't work for modules like bcrypt whose `npm test` script starts
with an `npm install`. Set the environment variable instead.
```
Fixes: #401


```
lib: set npm_config_loglevel to the passed arg

Set the env var to the argument passed in, and rely on that rather than
passing parameters to npm (as env vars are passed down to spawned shells).
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
