### PR TITLE
lookup: add zeromq

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -306,6 +306,11 @@
     "tags": "native",
     "maintainers": "rvagg"
   },
+  "zeromq": {
+    "prefix": "v",
+    "tags": "native",
+    "maintainers": ["lgeiger", "rgbkrk"]
+  },
   "bcrypt": {
     "prefix": "v",
     "skip": "win32",


### PR DESCRIPTION
This adds the native module `zeromq` to the citgm suite.

##### Checklist

I'm not sure how much of the checklist I need to handle when adding a new lib to lookup. 
¯\\\_(ツ)\_/¯

- [ ] `npm test` passes
- [ ] tests are included
- [ ] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
