### PR TITLE
Add sodium-native

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -420,5 +420,10 @@
   "esprima": {
     "maintainers": "ariya",
     "expectFail": "fips"
+  },
+  "sodium-native": {
+    "maintainers": ["mafintosh", "emilbayes"],
+    "prefix": "v",
+    "tags": "native"
   }
 }


### PR DESCRIPTION
Adding `sodium-native` which is an "alternative" to core `crypto`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
