### PR TITLE
lookup: skip spawn-wrap

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -393,6 +393,7 @@
   "spawn-wrap": {
     "prefix": "v",
     "flaky": ["win32", "sles"],
+    "skip": true,
     "maintainers": "isaacs"
   },
   "node-report": {


### PR DESCRIPTION
Currently failing on all platforms

ref: https://github.com/tapjs/spawn-wrap/issues/53
