### PR TITLE
lookup: winston as flaky

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -283,7 +283,7 @@
     "maintainers": "broofa"
   },
   "serialport": {
-    "flaky": ["ppc", "win32", "ubuntu"],
+    "flaky": ["ppc", "win32"],
     "expectFail": "fips",
     "tags": "native",
     "maintainers": "broofa"

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -264,7 +264,7 @@
     "maintainers": ["ctavan", "broofa"]
   },
   "winston": {
-    "flaky": ["win32", "ppc"],
+    "flaky": ["win32", "ppc", "s390"],
     "maintainers": "indexzero"
   },
   "yargs": {
@@ -283,7 +283,7 @@
     "maintainers": "broofa"
   },
   "serialport": {
-    "flaky": ["ppc", "win32"],
+    "flaky": ["ppc", "win32", "ubuntu"],
     "expectFail": "fips",
     "tags": "native",
     "maintainers": "broofa"


### PR DESCRIPTION
https://github.com/nodejs/node/wiki/CITGM-know-flakes
winston s390 - https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/808/nodes=rhel72-s390x/testReport/junit/(root)/citgm/winston_v2_3_1/
~serialPort ubuntu - https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/808/nodes=ubuntu1404-64/testReport/junit/(root)/citgm/serialport_v4_0_7/~

Ref: https://github.com/winstonjs/winston/pull/1028

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm test` passes
- [X] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
