### PR TITLE
lookup: skip zeromemq on s390

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -309,7 +309,8 @@
   "zeromq": {
     "prefix": "v",
     "tags": "native",
-    "maintainers": ["lgeiger", "rgbkrk"]
+    "maintainers": ["lgeiger", "rgbkrk"],
+    "skip": "s390"
   },
   "bcrypt": {
     "prefix": "v",


### PR DESCRIPTION
Test does not finish on s390
Fixes: #423
Ref: https://ci.nodejs.org/job/citgm-smoker/817/nodes=rhel72-s390x/
Ref: https://gist.github.com/refack/1554480241ded629a0639a741db72cb1

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm test` passes
- [X] tests are included
- [X] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
