### PR TITLE
lookup: add crc32-stream

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -434,6 +434,9 @@
     "tags": "native",
     "maintainers": ["nodejs/node-gyp"]
   },
+  "crc32-stream": {
+    "maintainers": "ctalkington"
+  },
   "sodium-native": {
     "maintainers": ["mafintosh", "emilbayes"],
     "prefix": "v",


### PR DESCRIPTION
Fixes: https://github.com/nodejs/citgm/issues/429

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (doesn't on master due to nodejs/node#13358)
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md) (covered in https://github.com/nodejs/citgm/issues/429)


`citgm crc32-stream` using this lookup passes on my machine.