### PR TITLE
lookup: unskip spawn-wrap

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -401,8 +401,7 @@
   },
   "spawn-wrap": {
     "prefix": "v",
-    "flaky": ["win32", "sles"],
-    "skip": true,
+    "flaky": ["win32", "sles", "aix", "darwin"],
     "maintainers": "isaacs"
   },
   "node-report": {


### PR DESCRIPTION
spawn-wrap 1.3.6 fixes the npm-shrinkwrap.json error.

Refs: https://github.com/nodejs/citgm/pull/413
Refs: https://github.com/tapjs/spawn-wrap/issues/53



##### Checklist

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
