### PR TITLE
lib: camelcase color variables

### DIFF
--- a/bin/citgm-all.js
+++ b/bin/citgm-all.js
@@ -44,7 +44,7 @@ const app = yargs.argv;
 
 const log = logger({
   level: app.verbose,
-  nocolor: app.color
+  nocolor: app.noColor
 });
 
 update(log);

--- a/bin/citgm-all.js
+++ b/bin/citgm-all.js
@@ -44,7 +44,7 @@ const app = yargs.argv;
 
 const log = logger({
   level: app.verbose,
-  nocolor: app.noColor
+  noColor: app.noColor
 });
 
 update(log);

--- a/bin/citgm.js
+++ b/bin/citgm.js
@@ -22,7 +22,7 @@ mod = app._[0];
 
 const log = logger({
   level:app.verbose,
-  nocolor: app.noColor
+  noColor: app.noColor
 });
 
 update(log);

--- a/lib/out.js
+++ b/lib/out.js
@@ -2,7 +2,7 @@
 const chalk = require('chalk');
 const columnify = require('columnify');
 const logger = require('winston');
-let supportscolor = require('supports-color'); // Mocked in tests
+let supportsColor = require('supports-color'); // Mocked in tests
 
 logger.remove(logger.transports.Console);
 logger.add(logger.transports.Console, {
@@ -42,7 +42,7 @@ module.exports = function(options) {
   options = options || {
     level: 'warn'
   };
-  colorize = !options.nocolor && supportscolor.stdout && supportscolor.stderr;
+  colorize = !options.noColor && supportsColor.stdout && supportsColor.stderr;
   logger.level = options.level;
   if (colorize) logger.cli();
   return {

--- a/test/test-out.js
+++ b/test/test-out.js
@@ -15,8 +15,8 @@ test('out: no color', function (t) {
 });
 
 test('out: with color', function (t) {
-  const supportscolor = Logger.__get__('supportscolor');
-  Logger.__set__('supportscolor', function () {
+  const supportsColor = Logger.__get__('supportsColor');
+  Logger.__set__('supportsColor', function () {
     return {stdout: true, stderr: true};
   });
   const output = Logger.__get__('output');
@@ -35,7 +35,7 @@ test('out: with color', function (t) {
       'there should be a warn logging level that is a function with no return');
   t.notok(log.error(), 'there should be a error logging level that is a'
   + ' function with no return');
-  Logger.__set__('supportscolor', supportscolor);
+  Logger.__set__('supportsColor', supportsColor);
   Logger.__set__('output', output);
   t.end();
 });


### PR DESCRIPTION
Pretty sure this was just a typo. 

Pretty sure this was just a typo. `--no-color` [is set in `lib/common-args.js`](https://github.com/nodejs/citgm/blob/8795c45ec0d192278ff612894718d7d10dea0a53/lib/common-args.js#L48) and camelCased by yargs.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
