### PR TITLE
deps: upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "async": "^2.1.2",
     "bl": "^1.2.0",
-    "chalk": "^1.1.3",
+    "chalk": "^2.0.1",
     "columnify": "^1.5.1",
     "lodash": "^4.12.0",
     "mkdirp": "^0.5.1",
@@ -45,8 +45,8 @@
     "rimraf": "^2.4.2",
     "root-check": "^1.0.0",
     "semver": "^5.0.1",
-    "strip-ansi": "^3.0.1",
-    "supports-color": "^3.1.0",
+    "strip-ansi": "^4.0.0",
+    "supports-color": "^4.2.0",
     "tar": "^2.1.1",
     "uid-number": "0.0.6",
     "update-notifier": "^2.1.0",
@@ -54,8 +54,8 @@
     "which": "^1.2.8",
     "winston": "^2.2.0",
     "xml-sanitizer": "^1.1.2",
-    "xmlbuilder": "^8.2.2",
-    "yargs": "^7.0.1"
+    "xmlbuilder": "^9.0.1",
+    "yargs": "^8.0.2"
   },
   "devDependencies": {
     "eslint": "^3.13.1",


### PR DESCRIPTION
Upgrade dependencies that had semver-major releases. The major bumps are
mostly due to changes to supported Node.js versions (up to v4.x).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
