### PR TITLE
chore: update travis to include node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ os:
   - linux
   - osx
 node_js:
-  - "7"
+  - "8"
   - "6"
   - "4"


### PR DESCRIPTION
We should be testing node 8