### PR TITLE
chore: add package-lock.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ test/scaffold/*/node_modules
 test/.*
 coverage/
 .nyc_output/
+package-lock.json


### PR DESCRIPTION
It is better if CITGM is always tested with the latest version of its
dependencies.

Closes: https://github.com/nodejs/citgm/issues/451

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
