### PR TITLE
lookup: skip coffee-script for v4

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -28,7 +28,8 @@
     "maintainers": "kriskowal"
   },
   "coffee-script": {
-    "maintainers": "jashkenas"
+    "maintainers": "jashkenas",
+    "skip": "v4"
   },
   "through2": {
     "prefix": "v",


### PR DESCRIPTION
they shipped code that doesn't work on v4