### PR TITLE
lookup: disable acorn + esprima on windows

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -424,11 +424,13 @@
     "maintainers": "tootallnate"
   },
   "acorn": {
-    "maintainers": "marijnh"
+    "maintainers": "marijnh",
+    "skip": "win32"
   },
   "esprima": {
     "maintainers": "ariya",
-    "expectFail": "fips"
+    "expectFail": "fips",
+    "skip": "win32"
   },
   "node-gyp": {
     "prefix": "v",


### PR DESCRIPTION
The test suites for these modules are not windows compatible

/cc @marijnh @ariya