### PR TITLE
lookup: mark ffi as flaky on v8.x

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -384,7 +384,7 @@
     "maintainers": ["ianobermiller", "alexlande"]
   },
   "ffi": {
-    "flaky": ["ppc", "aix", "s390", "ubuntu"],
+    "flaky": ["ppc", "aix", "s390", "ubuntu", "v8"],
     "skip": "win32",
     "tags": "native",
     "maintainers": "TooTallNate"


### PR DESCRIPTION
Left in because we should make sure it continues to compile.

Fixes: https://github.com/nodejs/citgm/issues/465

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
