### PR TITLE
lookup: skip libxmljs on Node >=8

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -372,7 +372,7 @@
   "libxmljs": {
     "prefix": "v",
     "flaky": ["aix", "sles", "rhel", "darwin"],
-    "skip": "win32",
+    "skip": ["win32", ">=8"],
     "tags": "native",
     "maintainers": "defunctzombie"
   },


### PR DESCRIPTION
Refs: https://github.com/libxmljs/libxmljs/issues/485
Refs: https://github.com/nodejs/citgm/issues/469