### PR TITLE
match-conditions: allow lack of VERSION_ID

### DIFF
--- a/lib/match-conditions.js
+++ b/lib/match-conditions.js
@@ -23,7 +23,8 @@ if (process.versions.openssl.indexOf('fips') !== -1) {
 if (fs.existsSync('/etc/os-release')) {
   const osRelease = fs.readFileSync('/etc/os-release', 'utf8');
   distro = osRelease.match(/\n\s*ID="?(.*)"?/)[1] || '';
-  release = osRelease.match(/\n\s*VERSION_ID="?(.*)"?/)[1] || '';
+  const releaseMatch = osRelease.match(/\n\s*VERSION_ID="?(.*)"?/);
+  release = releaseMatch ? (releaseMatch[1] || '') : '';
 } else if (platform === 'darwin') {
   distro = 'macos';
   release = execSync('sw_vers -productVersion').toString() || '';


### PR DESCRIPTION
On Linux systems without VERSION_ID in /etc/os-release, this was
previously preventing citgm-all from running.

Fixes: https://github.com/nodejs/citgm/issues/476

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
