### PR TITLE
lookup: skip ava on ppc and windows

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -476,6 +476,7 @@
   "ava": {
     "prefix": "v",
     "flaky": "aix",
+    "skip": ["ppc", "windows"],
     "maintainers": ["sindresorhus", "novemberborn"]
   },
   "shot": {


### PR DESCRIPTION
unsupported platforms