### PR TITLE
lookup: skip yeoman

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -266,6 +266,7 @@
   },
   "yeoman-generator": {
     "prefix": "v",
+    "skip": true,
     "flaky": ["ppc", "win32", "rhel"],
     "expectFail": "fips",
     "maintainers": ["SBoudrias", "sindresorhus"]


### PR DESCRIPTION
currently the install fails due to nsp + vulnerable modules
skip until this is fixed