### PR TITLE
lookup: semver is excepted to fail on fips

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -295,7 +295,8 @@
   },
   "semver": {
     "prefix": "v",
-    "maintainers": "isaacs"
+    "maintainers": "isaacs",
+    "expectFail": "fips"
   },
   "mime": {
     "prefix": "v",


### PR DESCRIPTION
Adding `"expectFail": "fips"` to lookup.json

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
