### PR TITLE
lookup: skip leveldb on <4

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -130,7 +130,8 @@
   "level": {
     "prefix": "v",
     "flaky": ["aix", "s390"],
-    "maintainers": ["ralphtheninja", "rvagg"]
+    "maintainers": ["ralphtheninja", "rvagg"],
+    "skip": "<6"
   },
   "torrent-stream": {
     "prefix": "v",


### PR DESCRIPTION
Leveldb is now using destructuring which is not supported on 4.x