### PR TITLE
lookup: skip ava <4

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -480,7 +480,7 @@
   },
   "ava": {
     "prefix": "v",
-    "skip": ["ppc", "win32", "rhel", "aix"],
+    "skip": ["ppc", "win32", "rhel", "aix", "<6"],
     "maintainers": ["sindresorhus", "novemberborn"]
   },
   "shot": {


### PR DESCRIPTION
It has a test to ensure snapshots are turned on