### PR TITLE
lookup: skip browserify in 8.x >

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -114,7 +114,7 @@
     "maintainers": "substack"
   },
   "browserify": {
-    "flaky": ["v7", "win32"],
+    "flaky": [">=v8", "win32"],
     "expectFail": "fips",
     "maintainers": "substack"
   },


### PR DESCRIPTION
bug in traceur compiler polyfill in browserify is causing errors
in 8.x and above.

Willing to help fix this in browserify. Will open issue in repo when
I've had a bit more time to research

Refs: https://github.com/nodejs/node/pull/14888#issuecomment-328710065

/cc @substack