### PR TITLE
Add node-core-utils in lookup.json

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -492,5 +492,9 @@
     "maintainers": ["mafintosh", "addaleax"],
     "prefix": "v",
     "skip": "<8"
+  },
+  "node-core-utils": {
+    "prefix": "v",
+    "maintainers": "joyeecheung"
   }
 }

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -495,7 +495,7 @@
   },
   "node-core-utils": {
     "prefix": "v",
-    "maintainers": ["joyeecheung", "refack", "tiriel"],
+    "maintainers": "nodejs/automation",
     "skip": "<8"
   }
 }

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -495,6 +495,7 @@
   },
   "node-core-utils": {
     "prefix": "v",
-    "maintainers": "joyeecheung"
+    "maintainers": "joyeecheung",
+    "skip": "<8"
   }
 }

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -495,7 +495,7 @@
   },
   "node-core-utils": {
     "prefix": "v",
-    "maintainers": "joyeecheung",
+    "maintainers": ["joyeecheung", "refack", "tiriel"],
     "skip": "<8"
   }
 }


### PR DESCRIPTION
Hey there!
On behalf of the Automation team, I'd like to add `node-core-utils` package to the `lookup.json`.
This package allows retrieval and formatting of PR metadatas for `nodejs/node` or any other repo. It currently sits [here](https://github.com/joyeecheung/node-core-utils) if you're interested and don't know it yet.

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)

#### Hard Requirements

* [x] Module source code must be on Github.
* [x] Published versions must include a tag on Github
* [x] The test process must be executable with only the commands
`npm install && npm test` using the tarball downloaded from the Github tag
mentioned above
* [x] The tests pass on supported major release lines
* [x] The maintainers of the module remain responsive when there are problems
* [x] At least one module maintainer must be added to the lookup maintainers field

#### Soft Requirements

At least one of:
* [x] The module fits into a key category (e.g. Testing, Streams, Monitoring, etc.)
* [x] The module is under the Node.js foundation Github org

Concerning the last point, it's not ***yet*** in the Foundation, but should be soon: [nodejs/tsc#412](https://github.com/nodejs/TSC/issues/412)

Cheers!