### PR TITLE
lookup: restore level on 4

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -131,7 +131,7 @@
     "prefix": "v",
     "flaky": ["aix", "s390"],
     "maintainers": ["ralphtheninja", "rvagg"],
-    "skip": "<6"
+    "skip": "<4"
   },
   "torrent-stream": {
     "prefix": "v",


### PR DESCRIPTION
#492 removed `level` from node 4 due to the use of destructuring. This was since fixed; the latest version of `level(up)` restores support of node 4 (Level/levelup#516).

@MylesBorins, cc @juliangruber @ralphtheninja @rvagg 
