### PR TITLE
chore: update yargs

### DIFF
--- a/lib/common-args.js
+++ b/lib/common-args.js
@@ -1,11 +1,8 @@
 'use strict';
 const citgm = require('./citgm');
-const pkg = require('../package.json');
 
 module.exports = function commonArgs (app) {
   app = app
-  .version(pkg.version)
-  .help()
   .alias('help', 'h')
   .config()
   .env('CITGM')

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "winston": "^2.2.0",
     "xml-sanitizer": "^1.1.2",
     "xmlbuilder": "^9.0.1",
-    "yargs": "^8.0.2"
+    "yargs": "^10.0.3"
   },
   "devDependencies": {
     "eslint": "^4.2.0",


### PR DESCRIPTION
Breaking changes:
- version() and help() are now enabled by default
- help command now only executes if it's the last positional in argv._
- Changes to unused "parse" method and "usage" second argument.
