### PR TITLE
resolve: use package.gitHead if available

### DIFF
--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -54,10 +54,11 @@ function getLookupTable(options) {
 /**
  * Certain known modules in npm do not publish their tests,
  * causing npm test to fail. In such cases, we need to grab
- * the tarball from github. Unfortunately, it's not that
- * simple as npm does not capture the git branch detail for
- * any particular module version. Also complicating matters
- * is the fact that git branches are not named consistently.
+ * the tarball from github. If the package has been published
+ * from its git repository, npm adds a `gitHead` property to
+ * the package.json and we can use that to generate the tarball
+ * URL. Otherwise, we fallback to the git tag. Complicating matters
+ * is the fact that git tags are not named consistently.
  * The lookup mechanism allows us to make a "best guess"
  * mapping for known modules. If the -l or --lookup CLI
  * argument is known, the npm spec is converted into a
@@ -79,6 +80,7 @@ function resolve(context, next) {
     const rep = lookup[detail.name];
     context.module.version = meta.version;
     if (rep) {
+      context.emit('data', 'info', 'lookup-found', detail.name);
       if (rep.envVar){
         context.module.envVar = rep.envVar;
       }
@@ -93,13 +95,13 @@ function resolve(context, next) {
           next(new Error('no-repository-field in package.json'));
           return;
         }
-        context.emit('data', 'info', 'lookup-found', detail.name);
+        const gitHead = rep.master ? null : meta.gitHead;
         const url = makeUrl(
           getRepo(rep.repo, meta),
           rep.master ? null : detail.fetchSpec,
           meta['dist-tags'],
           rep.master ? null : rep.prefix,
-          context.options.sha || rep.sha);
+          context.options.sha || rep.sha || gitHead);
         context.emit('data', 'info', context.module.name +
             ' lookup-replace', url);
         context.module.raw = url;
@@ -118,6 +120,17 @@ function resolve(context, next) {
           false : isMatch(rep.expectFail);
     } else {
       context.emit('data', 'info', 'lookup-notfound', detail.name);
+      if (meta.gitHead) {
+        const url = makeUrl(
+          getRepo(null, meta),
+          null,
+          null,
+          null,
+          meta.gitHead
+        );
+        context.emit('data', 'info', 'lookup-githead', url);
+        context.module.raw = url;
+      }
     }
   }
 

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -122,6 +122,34 @@ test('lookup: module not in table', function (t) {
   });
 });
 
+test('lookup: module not in table with gitHead', function (t) {
+  const context = {
+    lookup: null,
+    module: {
+      name: 'omg-i-pass',
+      raw: null
+    },
+    meta: {
+      repository: {
+        url: 'https://github.com/nodejs/omg-i-pass'
+      },
+      gitHead: 'abc123'
+    },
+    options: {
+
+    },
+    emit: function () {}
+  };
+
+  lookup(context, function (err) {
+    t.error(err);
+    t.equals(context.module.raw,
+             'https://github.com/nodejs/omg-i-pass/archive/abc123.tar.gz',
+             'raw should use commit SHA if package has gitHead');
+    t.end();
+  });
+});
+
 test('lookup: module in table', function (t) {
   const context = {
     lookup: null,
@@ -145,6 +173,34 @@ test('lookup: module in table', function (t) {
     t.equals(context.module.raw,
           'https://github.com/lodash/lodash/archive/master.tar.gz',
               'raw should be truthy if the module was in the list');
+    t.end();
+  });
+});
+
+test('lookup: module in table with gitHead', function (t) {
+  const context = {
+    lookup: null,
+    module: {
+      name: 'lodash',
+      raw: null
+    },
+    meta: {
+      repository: {
+        url: 'https://github.com/lodash/lodash'
+      },
+      gitHead: 'abc123'
+    },
+    options: {
+
+    },
+    emit: function () {}
+  };
+
+  lookup(context, function (err) {
+    t.error(err);
+    t.equals(context.module.raw,
+             'https://github.com/lodash/lodash/archive/abc123.tar.gz',
+             'raw should use commit SHA if package has gitHead');
     t.end();
   });
 });


### PR DESCRIPTION
If the package has been published from its git repository, npm adds a
`gitHead` property to the package.json file.
After this commit, the resolver will always use this if it is available
and then fallback to the git tag. This allows to run `citgm module`
with many modules without adding them to the lookup file and also
removes the need for the "prefix" option in most cases.
