### PR TITLE
lookup: remove sodium-native

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -463,12 +463,6 @@
   "crc32-stream": {
     "maintainers": "ctalkington"
   },
-  "sodium-native": {
-    "maintainers": ["mafintosh", "emilbayes"],
-    "prefix": "v",
-    "flaky": "ppc",
-    "tags": "native"
-  },
   "mocha": {
     "prefix": "v",
     "skip": ["win32", "rhel", "aix", "fedora", "ppc"],


### PR DESCRIPTION
Sodium Native now require bootstrapping a git submodule to work

Generally we would skip when there is a breakage, but this change
actively makes sodium-native no longer compatible with citgm

/cc @mafintosh @emilbayes