### PR TITLE
lookup: mark ava as flaky on <8

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -475,6 +475,7 @@
   "ava": {
     "prefix": "v",
     "skip": ["ppc", "win32", "rhel", "aix", "<6"],
+    "flaky": "<8",
     "maintainers": ["sindresorhus", "novemberborn"]
   },
   "shot": {


### PR DESCRIPTION
As of ava 0.23.0 it is consistently failing in citgm on most enviroments

In ava 0.23.0 they have introduced a new dependency that limits the
number of cores used in CI. I believe that this is triggering a race
condition bug in npm 3.x and causing the suite to bail early.

Ava 0.22.0 is consistently passing with v6.x and v8.x is consistently passing
with npm 5.x

As such I think it makes sense to simply mark ava as flaky on versions of node
shipping with older versions of npm

Refs: https://github.com/avajs/ava/commit/3f81fc431016ca115177d2d79cf9db36b05f69ad

/cc @sindresorhus @novemberborn @nodejs/npm