### PR TITLE
lookup: skip mkdirp on >= 8.x

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -263,7 +263,7 @@
   "mkdirp": {
     "master": true,
     "flaky": ["v6", "v7"],
-    "skip": ["v8"],
+    "skip": [">=8"],
     "maintainers": "substack"
   },
   "yeoman-generator": {


### PR DESCRIPTION
Test suite in mkdirp currently does not support these versions

Refs: https://github.com/substack/node-mkdirp/pull/139

/cc @substack we can remove these skips once the above PR lands