### PR TITLE
lookup: skip icu-full-test >= 9.x

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -371,7 +371,8 @@
   },
   "full-icu-test": {
     "prefix": "v",
-    "maintainers": "srl295"
+    "maintainers": "srl295",
+    "skip": ">=9"
   },
   "sqlite3": {
     "prefix": "v",


### PR DESCRIPTION
Test suite currently does not support the version of full-icu packaged
in Node.js 9.x

refs: https://github.com/unicode-org/full-icu-npm/issues/20

/cc @srl295