### PR TITLE
lookup: skip ffi on >= 8.x

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -407,8 +407,8 @@
     "maintainers": ["ianobermiller", "alexlande"]
   },
   "ffi": {
-    "flaky": ["ppc", "aix", "s390", "ubuntu", "v8"],
-    "skip": "win32",
+    "flaky": ["ppc", "aix", "s390", "ubuntu"],
+    "skip": ["win32", ">=8"],
     "tags": "native",
     "maintainers": "TooTallNate"
   },


### PR DESCRIPTION
Currently unsupported platforms for the module. It appears there are
commits on master to fix this but seeing segfaults when testing locally

We can revert this when ffi is updated upstream

/cc @TooTallNate