### PR TITLE
Add ignore githead field to lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
 "install": ["--param1", "--param2"] - Array of extra command line parameters passed to 'npm install'
 "maintainers": ["user1", "user2"] - List of module maintainers to be contacted with issues
 "tags": ["tag1", "tag2"]     Specify which tags apply to the module
+"ignoreGitHead":             Ignore the gitHead field if it exists and fallback to using github tags
 ```
 
 If you want to pass options to npm, eg `--registry`, you can usually define an

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -95,7 +95,7 @@ function resolve(context, next) {
           next(new Error('no-repository-field in package.json'));
           return;
         }
-        const gitHead = rep.master ? null : meta.gitHead;
+        const gitHead = rep.master || rep.ignoreGitHead ? null : meta.gitHead;
         const url = makeUrl(
           getRepo(rep.repo, meta),
           rep.master ? null : detail.fetchSpec,

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -88,9 +88,10 @@
     "maintainers": "mishoo"
   },
   "jquery": {
-    "skip": ["win32", true],
+    "skip": "win32",
     "flaky": ["linux", "aix"],
-    "maintainers": "jeresig"
+    "maintainers": "jeresig",
+    "ignoreGitHead": true
   },
   "rimraf": {
     "prefix": "v",


### PR DESCRIPTION
It is possible that a repo will not publish the commit that is found in
the gitHead field. One such example is the jQuery package.

This new field allows us to ignore the gitHead field on a per module
basis in the lookup.

This PR also sets `ignoreGitHead` for jquery