### PR TITLE
lookup: unskip level

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -131,8 +131,7 @@
   "level": {
     "prefix": "v",
     "flaky": ["aix", "s390"],
-    "maintainers": ["ralphtheninja", "rvagg"],
-    "skip": "<4"
+    "maintainers": ["ralphtheninja", "rvagg"]
   },
   "torrent-stream": {
     "prefix": "v",


### PR DESCRIPTION
<4 is not supported anymore

