### PR TITLE
lookup: skip zeromq on 32-bit

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -332,7 +332,7 @@
     "prefix": "v",
     "tags": "native",
     "maintainers": ["lgeiger", "rgbkrk"],
-    "skip": ["s390", "ppc"]
+    "skip": ["s390", "ppc", "linux-ia32"]
   },
   "bcrypt": {
     "prefix": "v",


### PR DESCRIPTION
I am seeing a installation failure with 32-bit, while 64-bit is fine.

<details><summary><code>32-bit:</code> fail</summary>

```
error:   failure             | Install Failed      
error:   failing module(s)   |                     
error:   module name:        | zeromq              
error:   version:            | 4.6.0               
error:   error:              | Install Failed      
error:   error:              | undefined                                                                                                                                         
error:                       | > zeromq@4.6.0 install /tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq                                                                                   
error:                       | > node scripts/prebuild-install.js || (node scripts/preinstall.js && node-gyp rebuild)                                                                    
error:                       |                                                                                                                                                           
error:                       |                                                                                                                                                           
error:                       | prebuild-install info begin Prebuild-install version 2.4.1                                                                                                
error:                       | prebuild-install info install installing standalone, skipping download.                                                                                   
error:                       |                                                                                                                                                           
error:                       | Building libzmq for linux                                                                                                                                 
error:                       | checking for a BSD-compatible install... /usr/bin/install -c                                                                                              
error:                       | checking whether build environment is sane... yes                                                                                                         
error:                       | checking for a thread-safe mkdir -p... /usr/bin/mkdir -p                                                                                                  
error:                       | checking for gawk... gawk                                                                                                                                 
error:                       | checking whether make sets $(MAKE)... yes                                                                                                                 
error:                       | checking whether make supports nested variables... yes                                                                                                    
error:                       | checking whether UID '3000' is supported by ustar format... yes                                                                                           
error:                       | checking whether GID '3000' is supported by ustar format... yes                                                                                           
error:                       | checking how to create a ustar tar archive... gnutar                                                                                                      
error:                       | checking whether make supports nested variables... (cached) yes                                                                                           
error:                       | checking for gcc... gcc                                                                                                                                   
error:                       | checking whether the C compiler works... yes                                                                                                              
error:                       | checking for C compiler default output file name... a.out                                                                                                 
error:                       | checking for suffix of executables...                                                                                                                     
error:                       | checking whether we are cross compiling... no                                                                                                             
error:                       | checking for suffix of object files... o                                                                                                                  
error:                       | checking whether we are using the GNU C compiler... yes                                                                                                   
error:                       | checking whether gcc accepts -g... yes                                                                                                                    
error:                       | checking for gcc option to accept ISO C89... none needed                                                                                                  
error:                       | checking whether gcc understands -c and -o together... yes                                                                                                
error:                       | checking for style of include used by make... GNU                                                                                                         
error:                       | checking dependency style of gcc... gcc3                                                                                                                  
error:                       | checking whether C compiler accepts -std=gnu11... yes                                                                                                     
error:                       | checking for g++... g++                                                                                                                                   
error:                       | checking whether we are using the GNU C++ compiler... yes                                                                                                 
error:                       | checking whether g++ accepts -g... yes                                                                                                                    
error:                       | checking dependency style of g++... gcc3                                                                                                                  
error:                       | checking whether g++ supports C++11 features by default... no                                                                                             
error:                       | checking whether g++ supports C++11 features with -std=gnu++11... yes                                                                                     
error:                       | checking for a sed that does not truncate output... /usr/bin/sed                                                                                          
error:                       | checking whether to build with code coverage support... no                                                                                                
error:                       | checking for a sed that does not truncate output... (cached) /usr/bin/sed                                                                                 
error:                       | checking for gawk... (cached) gawk                                                                                                                        
error:                       | checking for pkg-config... /usr/bin/pkg-config                                                                                                            
error:                       | checking pkg-config is at least version 0.9.0... yes                                                                                                      
error:                       | checking for xmlto... no                                                                                                                                  
error:                       | checking for asciidoc... no                                                                                                                               
error:                       | checking build system type... x86_64-unknown-linux-gnu                                                                                                    
error:                       | checking host system type... x86_64-unknown-linux-gnu                                                                                                     
error:                       | checking how to print strings... printf                                                                                                                   
error:                       | checking for a sed that does not truncate output... (cached) /usr/bin/sed                                                                                 
error:                       | checking for grep that handles long lines and -e... /usr/bin/grep                                                                                         
error:                       | checking for egrep... /usr/bin/grep -E                                                                                                                    
error:                       | checking for fgrep... /usr/bin/grep -F                                                                                                                    
error:                       | checking for ld used by gcc... /usr/x86_64-suse-linux/bin/ld                                                                                              
error:                       | checking if the linker (/usr/x86_64-suse-linux/bin/ld) is GNU ld... yes                                                                                   
error:                       | checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B                                                                                     
error:                       | checking the name lister (/usr/bin/nm -B) interface... BSD nm                                                                                             
error:                       | checking whether ln -s works... yes                                                                                                                       
error:                       | checking the maximum length of command line arguments... 1572864                                                                                          
error:                       | checking whether the shell understands some XSI constructs... yes                                                                                         
error:                       | checking whether the shell understands "+="... yes                                                                                                        
error:                       | checking how to convert x86_64-unknown-linux-gnu file names to x86_64-unknown-linux-gnu format... func_convert_file_noop                                  
error:                       | checking how to convert x86_64-unknown-linux-gnu file names to toolchain format... func_convert_file_noop                                                 
error:                       | checking for /usr/x86_64-suse-linux/bin/ld option to reload object files... -r                                                                            
error:                       | checking for objdump... objdump                                                                                                                           
error:                       | checking how to recognize dependent libraries... pass_all                                                                                                 
error:                       | checking for dlltool... dlltool                                                                                                                           
error:                       | checking how to associate runtime and link libraries... printf %s\n                                                                                       
error:                       | checking for ar... ar                                                                                                                                     
error:                       | checking for archiver @FILE support... @                                                                                                                  
error:                       | checking for strip... strip                                                                                                                               
error:                       | checking for ranlib... ranlib                                                                                                                             
error:                       | checking command to parse /usr/bin/nm -B output from gcc object... ok                                                                                     
error:                       | checking for sysroot... no                                                                                                                                
error:                       | checking for mt... mt                                                                                                                                     
error:                       | checking if mt is a manifest tool... no                                                                                                                   
error:                       | checking how to run the C preprocessor... gcc -E                                                                                                          
error:                       | checking for ANSI C header files... yes                                                                                                                   
error:                       | checking for sys/types.h... yes                                                                                                                           
error:                       | checking for sys/stat.h... yes                                                                                                                            
error:                       | checking for stdlib.h... yes                                                                                                                              
error:                       | checking for string.h... yes                                                                                                                              
error:                       | checking for memory.h... yes                                                                                                                              
error:                       | checking for strings.h... yes                                                                                                                             
error:                       | checking for inttypes.h... yes                                                                                                                            
error:                       | checking for stdint.h... yes                                                                                                                              
error:                       | checking for unistd.h... yes                                                                                                                              
error:                       | checking for dlfcn.h... yes                                                                                                                               
error:                       | checking for objdir... .libs                                                                                                                              
error:                       | checking if gcc supports -fno-rtti -fno-exceptions... no                                                                                                  
error:                       | checking for gcc option to produce PIC... -fPIC -DPIC                                                                                                     
error:                       | checking if gcc PIC flag -fPIC -DPIC works... yes                                                                                                         
error:                       | checking if gcc static flag -static works... no                                                                                                           
error:                       | checking if gcc supports -c -o file.o... yes                                                                                                              
error:                       | checking if gcc supports -c -o file.o... (cached) yes                                                                                                     
error:                       | checking whether the gcc linker (/usr/x86_64-suse-linux/bin/ld -m elf_x86_64) supports shared libraries... yes                                            
error:                       | checking dynamic linker characteristics... GNU/Linux ld.so                                                                                                
error:                       | checking how to hardcode library paths into programs... immediate                                                                                         
error:                       | checking whether stripping libraries is possible... yes                                                                                                   
error:                       | checking if libtool supports shared libraries... yes                                                                                                      
error:                       | checking whether to build shared libraries... no                                                                                                          
error:                       | checking whether to build static libraries... yes                                                                                                         
error:                       | checking how to run the C++ preprocessor... g++ -std=gnu++11 -E                                                                                           
error:                       | checking for ld used by g++ -std=gnu++11... /usr/x86_64-suse-linux/bin/ld -m elf_x86_64                                                                   
error:                       | checking if the linker (/usr/x86_64-suse-linux/bin/ld -m elf_x86_64) is GNU ld... yes                                                                     
error:                       | checking whether the g++ -std=gnu++11 linker (/usr/x86_64-suse-linux/bin/ld -m elf_x86_64) supports shared libraries... yes                               
error:                       | checking for g++ -std=gnu++11 option to produce PIC... -fPIC -DPIC                                                                                        
error:                       | checking if g++ -std=gnu++11 PIC flag -fPIC -DPIC works... yes                                                                                            
error:                       | checking if g++ -std=gnu++11 static flag -static works... no                                                                                              
error:                       | checking if g++ -std=gnu++11 supports -c -o file.o... yes                                                                                                 
error:                       | checking if g++ -std=gnu++11 supports -c -o file.o... (cached) yes                                                                                        
error:                       | checking whether the g++ -std=gnu++11 linker (/usr/x86_64-suse-linux/bin/ld -m elf_x86_64) supports shared libraries... yes                               
error:                       | checking dynamic linker characteristics... (cached) GNU/Linux ld.so                                                                                       
error:                       | checking how to hardcode library paths into programs... immediate                                                                                         
error:                       | checking for valgrind... no                                                                                                                               
error:                       | checking whether the C compiler works... yes                                                                                                              
error:                       | checking whether we are using Intel C compiler... no                                                                                                      
error:                       | checking whether we are using Sun Studio C compiler... no                                                                                                 
error:                       | checking whether we are using clang C compiler... no                                                                                                      
error:                       | checking whether we are using gcc >= 4 C compiler... yes                                                                                                  
error:                       | checking whether the C++ compiler works... yes                                                                                                            
error:                       | checking whether we are using Intel C++ compiler... no                                                                                                    
error:                       | checking whether we are using Sun Studio C++ compiler... no                                                                                               
error:                       | checking whether we are using clang C++ compiler... no                                                                                                    
error:                       | checking whether we are using gcc >= 4 C++ compiler... yes                                                                                                
error:                       | checking whether to enable debugging information... no                                                                                                    
error:                       | checking whether to enable code coverage... no                                                                                                            
error:                       | checking if TIPC is available and supports nonblocking connect... no                                                                                      
error:                       | checking for library containing dladdr... -ldl                                                                                                            
error:                       | checking for pthread_create in -lpthread... yes                                                                                                           
error:                       | checking for clock_gettime in -lrt... yes                                                                                                                 
error:                       | checking whether C++ compiler supports -fvisibility=hidden... yes                                                                                         
error:                       | checking whether C++ compiler supports dso visibility... yes                                                                                              
error:                       | checking whether to build documentation... no                                                                                                             
error:                       | checking whether to install manpages... no                                                                                                                
error:                       | configure: Choosing polling system from 'kqueue epoll devpoll pollset poll select'...                                                                     
error:                       | configure: Using 'epoll' polling system with CLOEXEC                                                                                                      
error:                       | checking for ANSI C header files... (cached) yes                                                                                                          
error:                       | checking errno.h usability... yes                                                                                                                         
error:                       | checking errno.h presence... yes                                                                                                                          
error:                       | checking for errno.h... yes                                                                                                                               
error:                       | checking time.h usability... yes                                                                                                                          
error:                       | checking time.h presence... yes                                                                                                                           
error:                       | checking for time.h... yes                                                                                                                                
error:                       | checking for unistd.h... (cached) yes                                                                                                                     
error:                       | checking limits.h usability... yes                                                                                                                        
error:                       | checking limits.h presence... yes                                                                                                                         
error:                       | checking for limits.h... yes                                                                                                                              
error:                       | checking stddef.h usability... yes                                                                                                                        
error:                       | checking stddef.h presence... yes                                                                                                                         
error:                       | checking for stddef.h... yes                                                                                                                              
error:                       | checking for stdlib.h... (cached) yes                                                                                                                     
error:                       | checking for string.h... (cached) yes                                                                                                                     
error:                       | checking arpa/inet.h usability... yes                                                                                                                     
error:                       | checking arpa/inet.h presence... yes                                                                                                                      
error:                       | checking for arpa/inet.h... yes                                                                                                                           
error:                       | checking netinet/tcp.h usability... yes                                                                                                                   
error:                       | checking netinet/tcp.h presence... yes                                                                                                                    
error:                       | checking for netinet/tcp.h... yes                                                                                                                         
error:                       | checking netinet/in.h usability... yes                                                                                                                    
error:                       | checking netinet/in.h presence... yes                                                                                                                     
error:                       | checking for netinet/in.h... yes                                                                                                                          
error:                       | checking sys/socket.h usability... yes                                                                                                                    
error:                       | checking sys/socket.h presence... yes                                                                                                                     
error:                       | checking for sys/socket.h... yes                                                                                                                          
error:                       | checking sys/time.h usability... yes                                                                                                                      
error:                       | checking sys/time.h presence... yes                                                                                                                       
error:                       | checking for sys/time.h... yes                                                                                                                            
error:                       | checking ifaddrs.h usability... yes                                                                                                                       
error:                       | checking ifaddrs.h presence... yes                                                                                                                        
error:                       | checking for ifaddrs.h... yes                                                                                                                             
error:                       | checking sys/uio.h usability... yes                                                                                                                       
error:                       | checking sys/uio.h presence... yes                                                                                                                        
error:                       | checking for sys/uio.h... yes                                                                                                                             
error:                       | checking sys/eventfd.h usability... yes                                                                                                                   
error:                       | checking sys/eventfd.h presence... yes                                                                                                                    
error:                       | checking for sys/eventfd.h... yes                                                                                                                         
error:                       | checking whether EFD_CLOEXEC is supported... yes                                                                                                          
error:                       | checking whether SO_PEERCRED is declared... yes                                                                                                           
error:                       | checking whether LOCAL_PEERCRED is declared... no                                                                                                         
error:                       | checking for stdbool.h that conforms to C99... yes                                                                                                        
error:                       | checking for _Bool... no                                                                                                                                  
error:                       | checking for an ANSI C-conforming const... yes                                                                                                            
error:                       | checking for inline... inline                                                                                                                             
error:                       | checking for size_t... yes                                                                                                                                
error:                       | checking for ssize_t... yes                                                                                                                               
error:                       | checking whether time.h and sys/time.h may both be included... yes                                                                                        
error:                       | checking for uint32_t... yes                                                                                                                              
error:                       | checking for working volatile... yes                                                                                                                      
error:                       | configure: Using tweetnacl for CURVE security                                                                                                             
error:                       | checking "with_norm_ext = no"... no                                                                                                                       
error:                       | checking how to enable additional warnings for C++ compiler... -Wall                                                                                      
error:                       | checking how to turn warnings to errors in C++ compiler... -Werror                                                                                        
error:                       | checking whether compiler supports __atomic_Xxx intrinsics... yes                                                                                         
error:                       | checking return type of signal handlers... void                                                                                                           
error:                       | checking for perror... yes                                                                                                                                
error:                       | checking for gettimeofday... yes                                                                                                                          
error:                       | checking for clock_gettime... yes                                                                                                                         
error:                       | checking for memset... yes                                                                                                                                
error:                       | checking for socket... yes                                                                                                                                
error:                       | checking for getifaddrs... yes                                                                                                                            
error:                       | checking for freeifaddrs... yes                                                                                                                           
error:                       | checking for fork... yes                                                                                                                                  
error:                       | checking for posix_memalign... yes                                                                                                                        
error:                       | checking for mkdtemp... yes                                                                                                                               
error:                       | checking alloca.h usability... yes                                                                                                                        
error:                       | checking alloca.h presence... yes                                                                                                                         
error:                       | checking for alloca.h... yes                                                                                                                              
error:                       | checking whether SOCK_CLOEXEC is supported... yes                                                                                                         
error:                       | checking whether SO_KEEPALIVE is supported... yes                                                                                                         
error:                       | checking whether TCP_KEEPCNT is supported... yes                                                                                                          
error:                       | checking whether TCP_KEEPIDLE is supported... yes                                                                                                         
error:                       | checking whether TCP_KEEPINTVL is supported... yes                                                                                                        
error:                       | checking whether TCP_KEEPALIVE is supported... no                                                                                                         
error:                       | checking for ./.git... no                                                                                                                                 
error:                       | configure: Building stable and legacy API (no draft API)                                                                                                  
error:                       | checking for LIBUNWIND... no                                                                                                                              
error:                       | checking that generated files are newer than configure... done                                                                                            
error:                       | configure: creating ./config.status                                                                                                                       
error:                       | config.status: creating Makefile                                                                                                                          
error:                       | config.status: creating src/libzmq.pc                                                                                                                     
error:                       | config.status: creating doc/Makefile                                                                                                                      
error:                       | config.status: creating builds/Makefile                                                                                                                   
error:                       | config.status: creating builds/msvc/Makefile                                                                                                              
error:                       | config.status: creating src/platform.hpp                                                                                                                  
error:                       | config.status: executing depfiles commands                                                                                                                
error:                       | config.status: executing libtool commands                                                                                                                 
error:                       | Making all in doc                                                                                                                                         
error:                       | make[1]: Entering directory '/tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/zmq/zeromq-4.2.2/doc'                                                       
error:                       | make[1]: Nothing to be done for 'all'.                                                                                                                    
error:                       | make[1]: Leaving directory '/tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/zmq/zeromq-4.2.2/doc'                                                        
error:                       | make[1]: Entering directory '/tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/zmq/zeromq-4.2.2'                                                           
error:                       | CXX      src/src_libzmq_la-address.lo                                                                                                                     
error:                       | CXX      src/src_libzmq_la-client.lo                                                                                                                      
error:                       | CXX      src/src_libzmq_la-clock.lo                                                                                                                       
error:                       | CXX      src/src_libzmq_la-ctx.lo                                                                                                                         
error:                       | CXX      src/src_libzmq_la-curve_client.lo                                                                                                                
error:                       | CXX      src/src_libzmq_la-curve_server.lo                                                                                                                
error:                       | CXX      src/src_libzmq_la-dealer.lo                                                                                                                      
error:                       | CXX      src/src_libzmq_la-devpoll.lo                                                                                                                     
error:                       | CXX      src/src_libzmq_la-dgram.lo                                                                                                                       
error:                       | CXX      src/src_libzmq_la-dish.lo                                                                                                                        
error:                       | CXX      src/src_libzmq_la-dist.lo                                                                                                                        
error:                       | CXX      src/src_libzmq_la-epoll.lo                                                                                                                       
error:                       | CXX      src/src_libzmq_la-err.lo                                                                                                                         
error:                       | CXX      src/src_libzmq_la-fq.lo                                                                                                                          
error:                       | CXX      src/src_libzmq_la-gather.lo                                                                                                                      
error:                       | CXX      src/src_libzmq_la-gssapi_mechanism_base.lo                                                                                                       
error:                       | CXX      src/src_libzmq_la-gssapi_client.lo                                                                                                               
error:                       | CXX      src/src_libzmq_la-gssapi_server.lo                                                                                                               
error:                       | CXX      src/src_libzmq_la-io_object.lo                                                                                                                   
error:                       | CXX      src/src_libzmq_la-io_thread.lo                                                                                                                   
error:                       | CXX      src/src_libzmq_la-ip.lo                                                                                                                          
error:                       | CXX      src/src_libzmq_la-ipc_address.lo                                                                                                                 
error:                       | CXX      src/src_libzmq_la-ipc_connecter.lo                                                                                                               
error:                       | CXX      src/src_libzmq_la-ipc_listener.lo                                                                                                                
error:                       | CXX      src/src_libzmq_la-kqueue.lo                                                                                                                      
error:                       | CXX      src/src_libzmq_la-lb.lo                                                                                                                          
error:                       | CXX      src/src_libzmq_la-mailbox.lo                                                                                                                     
error:                       | CXX      src/src_libzmq_la-mailbox_safe.lo                                                                                                                
error:                       | CXX      src/src_libzmq_la-mechanism.lo                                                                                                                   
error:                       | CXX      src/src_libzmq_la-metadata.lo                                                                                                                    
error:                       | CXX      src/src_libzmq_la-msg.lo                                                                                                                         
error:                       | CXX      src/src_libzmq_la-mtrie.lo                                                                                                                       
error:                       | CXX      src/src_libzmq_la-norm_engine.lo                                                                                                                 
error:                       | CXX      src/src_libzmq_la-null_mechanism.lo                                                                                                              
error:                       | CXX      src/src_libzmq_la-object.lo                                                                                                                      
error:                       | CXX      src/src_libzmq_la-options.lo                                                                                                                     
error:                       | CXX      src/src_libzmq_la-own.lo                                                                                                                         
error:                       | CXX      src/src_libzmq_la-pair.lo                                                                                                                        
error:                       | CXX      src/src_libzmq_la-pgm_receiver.lo                                                                                                                
error:                       | CXX      src/src_libzmq_la-pgm_sender.lo                                                                                                                  
error:                       | CXX      src/src_libzmq_la-pgm_socket.lo                                                                                                                  
error:                       | CXX      src/src_libzmq_la-pipe.lo                                                                                                                        
error:                       | CXX      src/src_libzmq_la-plain_client.lo                                                                                                                
error:                       | CXX      src/src_libzmq_la-plain_server.lo                                                                                                                
error:                       | CXX      src/src_libzmq_la-poll.lo                                                                                                                        
error:                       | CXX      src/src_libzmq_la-poller_base.lo                                                                                                                 
error:                       | CXX      src/src_libzmq_la-pollset.lo                                                                                                                     
error:                       | CXX      src/src_libzmq_la-precompiled.lo                                                                                                                 
error:                       | CXX      src/src_libzmq_la-proxy.lo                                                                                                                       
error:                       | CXX      src/src_libzmq_la-pub.lo                                                                                                                         
error:                       | CXX      src/src_libzmq_la-pull.lo                                                                                                                        
error:                       | CXX      src/src_libzmq_la-push.lo                                                                                                                        
error:                       | CXX      src/src_libzmq_la-radio.lo                                                                                                                       
error:                       | CXX      src/src_libzmq_la-random.lo                                                                                                                      
error:                       | CXX      src/src_libzmq_la-raw_decoder.lo                                                                                                                 
error:                       | CXX      src/src_libzmq_la-raw_encoder.lo                                                                                                                 
error:                       | CXX      src/src_libzmq_la-reaper.lo                                                                                                                      
error:                       | CXX      src/src_libzmq_la-rep.lo                                                                                                                         
error:                       | CXX      src/src_libzmq_la-req.lo                                                                                                                         
error:                       | CXX      src/src_libzmq_la-router.lo                                                                                                                      
error:                       | CXX      src/src_libzmq_la-scatter.lo                                                                                                                     
error:                       | CXX      src/src_libzmq_la-select.lo                                                                                                                      
error:                       | CXX      src/src_libzmq_la-server.lo                                                                                                                      
error:                       | CXX      src/src_libzmq_la-session_base.lo                                                                                                                
error:                       | CXX      src/src_libzmq_la-signaler.lo                                                                                                                    
error:                       | CXX      src/src_libzmq_la-socket_base.lo                                                                                                                 
error:                       | CXX      src/src_libzmq_la-socks.lo                                                                                                                       
error:                       | CXX      src/src_libzmq_la-socks_connecter.lo                                                                                                             
error:                       | CXX      src/src_libzmq_la-stream.lo                                                                                                                      
error:                       | CXX      src/src_libzmq_la-stream_engine.lo                                                                                                               
error:                       | CXX      src/src_libzmq_la-sub.lo                                                                                                                         
error:                       | CXX      src/src_libzmq_la-tcp.lo                                                                                                                         
error:                       | CXX      src/src_libzmq_la-tcp_address.lo                                                                                                                 
error:                       | CXX      src/src_libzmq_la-tcp_connecter.lo                                                                                                               
error:                       | CXX      src/src_libzmq_la-tcp_listener.lo                                                                                                                
error:                       | CXX      src/src_libzmq_la-thread.lo                                                                                                                      
error:                       | CXX      src/src_libzmq_la-timers.lo                                                                                                                      
error:                       | CXX      src/src_libzmq_la-tipc_address.lo                                                                                                                
error:                       | CXX      src/src_libzmq_la-tipc_connecter.lo                                                                                                              
error:                       | CXX      src/src_libzmq_la-tipc_listener.lo                                                                                                               
error:                       | CXX      src/src_libzmq_la-trie.lo                                                                                                                        
error:                       | CXX      src/src_libzmq_la-udp_address.lo                                                                                                                 
error:                       | CXX      src/src_libzmq_la-udp_engine.lo                                                                                                                  
error:                       | CXX      src/src_libzmq_la-v1_decoder.lo                                                                                                                  
error:                       | CXX      src/src_libzmq_la-v2_decoder.lo                                                                                                                  
error:                       | CXX      src/src_libzmq_la-v1_encoder.lo                                                                                                                  
error:                       | CXX      src/src_libzmq_la-v2_encoder.lo                                                                                                                  
error:                       | CXX      src/src_libzmq_la-vmci.lo                                                                                                                        
error:                       | CXX      src/src_libzmq_la-vmci_address.lo                                                                                                                
error:                       | CXX      src/src_libzmq_la-vmci_connecter.lo                                                                                                              
error:                       | CXX      src/src_libzmq_la-vmci_listener.lo                                                                                                               
error:                       | CXX      src/src_libzmq_la-xpub.lo                                                                                                                        
error:                       | CXX      src/src_libzmq_la-xsub.lo                                                                                                                        
error:                       | CXX      src/src_libzmq_la-zmq.lo                                                                                                                         
error:                       | CXX      src/src_libzmq_la-zmq_utils.lo                                                                                                                   
error:                       | CXX      src/src_libzmq_la-decoder_allocators.lo                                                                                                          
error:                       | CXX      src/src_libzmq_la-socket_poller.lo                                                                                                               
error:                       | CC       src/src_libzmq_la-tweetnacl.lo                                                                                                                   
error:                       | CXX      tools/curve_keygen.o                                                                                                                             
error:                       | CXX      perf/local_lat.o                                                                                                                                 
error:                       | CXX      perf/remote_lat.o                                                                                                                                
error:                       | CXX      perf/local_thr.o                                                                                                                                 
error:                       | CXX      perf/remote_thr.o                                                                                                                                
error:                       | CXX      perf/inproc_lat.o                                                                                                                                
error:                       | CXX      perf/inproc_thr.o                                                                                                                                
error:                       | CXXLD    src/libzmq.la                                                                                                                                    
error:                       | CXXLD    tools/curve_keygen                                                                                                                               
error:                       | CXXLD    perf/local_lat                                                                                                                                   
error:                       | CXXLD    perf/remote_lat                                                                                                                                  
error:                       | CXXLD    perf/local_thr                                                                                                                                   
error:                       | CXXLD    perf/remote_thr                                                                                                                                  
error:                       | CXXLD    perf/inproc_lat                                                                                                                                  
error:                       | CXXLD    perf/inproc_thr                                                                                                                                  
error:                       | make[1]: Leaving directory '/tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/zmq/zeromq-4.2.2'                                                            
error:                       | Making install in doc                                                                                                                                     
error:                       | make[1]: Entering directory '/tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/zmq/zeromq-4.2.2/doc'                                                       
error:                       | make[2]: Entering directory '/tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/zmq/zeromq-4.2.2/doc'                                                       
error:                       | make[2]: Nothing to be done for 'install-exec-am'.                                                                                                        
error:                       | make[2]: Leaving directory '/tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/zmq/zeromq-4.2.2/doc'                                                        
error:                       | make[1]: Leaving directory '/tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/zmq/zeromq-4.2.2/doc'                                                        
error:                       | make[1]: Entering directory '/tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/zmq/zeromq-4.2.2'                                                           
error:                       | make[2]: Entering directory '/tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/zmq/zeromq-4.2.2'                                                           
error:                       | /usr/bin/mkdir -p '/tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/scripts/../zmq/lib'                                                                   
error:                       | /bin/sh ./libtool   --mode=install /usr/bin/install -c   src/libzmq.la '/tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/scripts/../zmq/lib'              
error:                       | libtool: install: /usr/bin/install -c src/.libs/libzmq.lai /tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/scripts/../zmq/lib/libzmq.la                  
error:                       | libtool: install: /usr/bin/install -c src/.libs/libzmq.a /tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/scripts/../zmq/lib/libzmq.a                     
error:                       | libtool: install: chmod 644 /tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/scripts/../zmq/lib/libzmq.a                                                  
error:                       | libtool: install: ranlib /tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/scripts/../zmq/lib/libzmq.a                                                     
error:                       | libtool: finish: PATH="/dev/shm/usenode.jenkins/node-v6.12.2-linux-x86/lib/node_modules/npm/bin/node-gyp-bin:/tmp/55a6b249-e3b6-493e-919d-476e962a807a/zer
error:                       | ----------------------------------------------------------------------                                                                                    
error:                       | Libraries have been installed in:                                                                                                                         
error:                       | /tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/scripts/../zmq/lib                                                                                       
error:                       |                                                                                                                                                           
error:                       | If you ever happen to want to link against installed libraries                                                                                            
error:                       | in a given directory, LIBDIR, you must either use libtool, and                                                                                            
error:                       | specify the full pathname of the library, or use the `-LLIBDIR'                                                                                           
error:                       | flag during linking and do at least one of the following:                                                                                                 
error:                       | - add LIBDIR to the `LD_LIBRARY_PATH' environment variable                                                                                                
error:                       | during execution                                                                                                                                          
error:                       | - add LIBDIR to the `LD_RUN_PATH' environment variable                                                                                                    
error:                       | during linking                                                                                                                                            
error:                       | - use the `-Wl,-rpath -Wl,LIBDIR' linker flag                                                                                                             
error:                       | - have your system administrator add LIBDIR to `/etc/ld.so.conf'                                                                                          
error:                       |                                                                                                                                                           
error:                       | See any operating system documentation about shared libraries for                                                                                         
error:                       | more information, such as the ld(1) and ld.so(8) manual pages.                                                                                            
error:                       | ----------------------------------------------------------------------                                                                                    
error:                       | /usr/bin/mkdir -p '/tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/scripts/../zmq/bin'                                                                   
error:                       | /bin/sh ./libtool   --mode=install /usr/bin/install -c tools/curve_keygen '/tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/scripts/../zmq/bin'           
error:                       | libtool: install: /usr/bin/install -c tools/curve_keygen /tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/scripts/../zmq/bin/curve_keygen                 
error:                       | /usr/bin/mkdir -p '/tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/scripts/../zmq/include'                                                               
error:                       | /usr/bin/install -c -m 644 include/zmq.h include/zmq_utils.h '/tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/scripts/../zmq/include'                    
error:                       | /usr/bin/mkdir -p '/tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/scripts/../zmq/lib/pkgconfig'                                                         
error:                       | /usr/bin/install -c -m 644 src/libzmq.pc '/tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/scripts/../zmq/lib/pkgconfig'                                  
error:                       | make[2]: Leaving directory '/tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/zmq/zeromq-4.2.2'                                                            
error:                       | make[1]: Leaving directory '/tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/zmq/zeromq-4.2.2'                                                            
error:                       | Succesfully build libzmq on Mon Dec 18 2017 15:09:56 GMT+0000 (GMT)                                                                                       
error:                       | make: Entering directory '/tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/build'                                                                         
error:                       | CXX(target) Release/obj.target/zmq/binding.o                                                                                                              
error:                       | SOLINK_MODULE(target) Release/obj.target/zmq.node                                                                                                         
error:                       | zmq.target.mk:121: recipe for target 'Release/obj.target/zmq.node' failed                                                                                 
error:                       | make: Leaving directory '/tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/build'                                                                          
error:                       |                                                                                                                                                           
error:                       | configure: WARNING: Cannot find libunwind                                                                                                                 
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | /usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld: i386:x86-64 architecture of input file `./Release/../../zmq/lib/libzmq.a(src_li
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-zmq.o): In function `zmq_ctx_new':                                                                         
error:                       | zmq.cpp:(.text+0x6f): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                                         
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-zmq.o): In function `zmq_poller_new()':                                                                    
error:                       | zmq.cpp:(.text+0x198f): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                                       
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-zmq.o): In function `zmq_timers_new()':                                                                    
error:                       | zmq.cpp:(.text+0x2002): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                                       
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-zmq.o): In function `zmq_poller_poll(zmq_pollitem_t*, int, long)':                                         
error:                       | zmq.cpp:(.text._Z15zmq_poller_pollP14zmq_pollitem_til[_Z15zmq_poller_pollP14zmq_pollitem_til]+0x38): undefined reference to `operator new[](unsigned long)
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-zmq_utils.o): In function `zmq_threadstart':                                                               
error:                       | zmq_utils.cpp:(.text+0xea): undefined reference to `operator new(unsigned long)'                                                                          
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-zmq_utils.o): In function `zmq_atomic_counter_new':                                                        
error:                       | zmq_utils.cpp:(.text+0x506): undefined reference to `operator new(unsigned long)'                                                                         
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-socket_poller.o): In function `__gnu_cxx::new_allocator<zmq::socket_poller_t::item_t>::allocate(unsigned lo
error:                       | socket_poller.cpp:(.text._ZN9__gnu_cxx13new_allocatorIN3zmq15socket_poller_t6item_tEE8allocateEmPKv[_ZN9__gnu_cxx13new_allocatorIN3zmq15socket_poller_t6it
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-ctx.o): In function `zmq::ctx_t::create_socket(int)':                                                      
error:                       | ctx.cpp:(.text+0xf88): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                                        
error:                       | ctx.cpp:(.text+0x1064): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                                       
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-ctx.o): In function `__gnu_cxx::new_allocator<zmq::io_thread_t*>::allocate(unsigned long, void const*)':   
error:                       | ctx.cpp:(.text._ZN9__gnu_cxx13new_allocatorIPN3zmq11io_thread_tEE8allocateEmPKv[_ZN9__gnu_cxx13new_allocatorIPN3zmq11io_thread_tEE8allocateEmPKv]+0x3c): u
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-ctx.o): In function `__gnu_cxx::new_allocator<unsigned int>::allocate(unsigned long, void const*)':        
error:                       | ctx.cpp:(.text._ZN9__gnu_cxx13new_allocatorIjE8allocateEmPKv[_ZN9__gnu_cxx13new_allocatorIjE8allocateEmPKv]+0x3c): undefined reference to `operator new(un
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-ctx.o): In function `__gnu_cxx::new_allocator<zmq::socket_base_t*>::allocate(unsigned long, void const*)': 
error:                       | ctx.cpp:(.text._ZN9__gnu_cxx13new_allocatorIPN3zmq13socket_base_tEE8allocateEmPKv[_ZN9__gnu_cxx13new_allocatorIPN3zmq13socket_base_tEE8allocateEmPKv]+0x3c
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-ctx.o): In function `__gnu_cxx::new_allocator<zmq::tcp_address_mask_t>::allocate(unsigned long, void const*
error:                       | ctx.cpp:(.text._ZN9__gnu_cxx13new_allocatorIN3zmq18tcp_address_mask_tEE8allocateEmPKv[_ZN9__gnu_cxx13new_allocatorIN3zmq18tcp_address_mask_tEE8allocateEmP
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-ctx.o): In function `__gnu_cxx::new_allocator<std::_Rb_tree_node<std::pair<std::string const, zmq::endpoint
error:                       | ctx.cpp:(.text._ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeISt4pairIKSsN3zmq10endpoint_tEEEE8allocateEmPKv[_ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nod
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-ctx.o):ctx.cpp:(.text._ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeISt4pairIKSsN3zmq5ctx_t20pending_connec
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-epoll.o): In function `zmq::epoll_t::add_fd(int, zmq::i_poll_events*)':                                    
error:                       | epoll.cpp:(.text+0x287): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                                      
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-epoll.o): In function `__gnu_cxx::new_allocator<zmq::epoll_t::poll_entry_t*>::allocate(unsigned long, void 
error:                       | epoll.cpp:(.text._ZN9__gnu_cxx13new_allocatorIPN3zmq7epoll_t12poll_entry_tEE8allocateEmPKv[_ZN9__gnu_cxx13new_allocatorIPN3zmq7epoll_t12poll_entry_tEE8all
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-io_thread.o): In function `zmq::io_thread_t::io_thread_t(zmq::ctx_t*, unsigned int)':                      
error:                       | io_thread.cpp:(.text+0x79): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                                   
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-metadata.o): In function `__gnu_cxx::new_allocator<std::_Rb_tree_node<std::pair<std::string const, std::str
error:                       | metadata.cpp:(.text._ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeISt4pairIKSsSsEEE8allocateEmPKv[_ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeISt4pairIK
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-options.o): In function `zmq::options_t::setsockopt(int, void const*, unsigned long)':                     
error:                       | options.cpp:(.text+0xa2a): undefined reference to `std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, unsig
error:                       | options.cpp:(.text+0xc16): undefined reference to `std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, unsig
error:                       | options.cpp:(.text+0xf11): undefined reference to `std::string::assign(char const*, unsigned long)'                                                       
error:                       | options.cpp:(.text+0xfb9): undefined reference to `std::string::assign(char const*, unsigned long)'                                                       
error:                       | options.cpp:(.text+0x101e): undefined reference to `std::string::assign(char const*, unsigned long)'                                                      
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-own.o): In function `__gnu_cxx::new_allocator<std::_Rb_tree_node<zmq::own_t*> >::allocate(unsigned long, vo
error:                       | own.cpp:(.text._ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeIPN3zmq5own_tEEE8allocateEmPKv[_ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeIPN3zmq5own_tEEE
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-pipe.o): In function `zmq::pipepair(zmq::object_t**, zmq::pipe_t**, int*, bool*)':                         
error:                       | pipe.cpp:(.text+0x14b): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                                       
error:                       | pipe.cpp:(.text+0x17d): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                                       
error:                       | pipe.cpp:(.text+0x214): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                                       
error:                       | pipe.cpp:(.text+0x246): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                                       
error:                       | pipe.cpp:(.text+0x2ce): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                                       
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-pipe.o):pipe.cpp:(.text+0x394): more undefined references to `operator new(unsigned long, std::nothrow_t co
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-pipe.o): In function `__gnu_cxx::new_allocator<char>::allocate(unsigned long, void const*)':               
error:                       | pipe.cpp:(.text._ZN9__gnu_cxx13new_allocatorIcE8allocateEmPKv[_ZN9__gnu_cxx13new_allocatorIcE8allocateEmPKv]+0x38): undefined reference to `operator new(u
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-poller_base.o): In function `__gnu_cxx::new_allocator<std::_Rb_tree_node<std::pair<unsigned long const, zmq
error:                       | poller_base.cpp:(.text._ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeISt4pairIKmN3zmq13poller_base_t12timer_info_tEEEE8allocateEmPKv[_ZN9__gnu_cxx13new_al
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-reaper.o): In function `zmq::reaper_t::reaper_t(zmq::ctx_t*, unsigned int)':                               
error:                       | reaper.cpp:(.text+0xa1): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                                      
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-socket_base.o): In function `zmq::socket_base_t::create(int, zmq::ctx_t*, unsigned int, int)':             
error:                       | socket_base.cpp:(.text+0x7a): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                                 
error:                       | socket_base.cpp:(.text+0xbc): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                                 
error:                       | socket_base.cpp:(.text+0xfe): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                                 
error:                       | socket_base.cpp:(.text+0x140): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                                
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-socket_base.o):socket_base.cpp:(.text+0x182): more undefined references to `operator new(unsigned long, std
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-socket_base.o): In function `zmq::socket_base_t::socket_base_t(zmq::ctx_t*, unsigned int, int, bool)':     
error:                       | socket_base.cpp:(.text+0xac4): undefined reference to `operator new(unsigned long)'                                                                       
error:                       | socket_base.cpp:(.text+0xaf6): undefined reference to `operator new(unsigned long)'                                                                       
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-socket_base.o): In function `zmq::socket_base_t::parse_uri(char const*, std::string&, std::string&)':      
error:                       | socket_base.cpp:(.text+0x1060): undefined reference to `std::string::find(char const*, unsigned long) const'                                              
error:                       | socket_base.cpp:(.text+0x109c): undefined reference to `std::string::substr(unsigned long, unsigned long) const'                                          
error:                       | socket_base.cpp:(.text+0x10da): undefined reference to `std::string::substr(unsigned long, unsigned long) const'                                          
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-socket_base.o): In function `zmq::socket_base_t::bind(char const*)':                                       
error:                       | socket_base.cpp:(.text+0x1e63): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                               
error:                       | socket_base.cpp:(.text+0x1efc): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                               
error:                       | socket_base.cpp:(.text+0x225f): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                               
error:                       | socket_base.cpp:(.text+0x23fa): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                               
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-socket_base.o): In function `zmq::socket_base_t::connect(char const*)':                                    
error:                       | socket_base.cpp:(.text+0x323e): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                               
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-socket_base.o):socket_base.cpp:(.text+0x34ae): more undefined references to `operator new(unsigned long, st
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-socket_base.o): In function `zmq::socket_base_t::start_reaping(zmq::epoll_t*)':                            
error:                       | socket_base.cpp:(.text+0x4d70): undefined reference to `operator new(unsigned long)'                                                                      
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-socket_base.o): In function `__gnu_cxx::new_allocator<zmq::pipe_t*>::allocate(unsigned long, void const*)':
error:                       | socket_base.cpp:(.text._ZN9__gnu_cxx13new_allocatorIPN3zmq6pipe_tEE8allocateEmPKv[_ZN9__gnu_cxx13new_allocatorIPN3zmq6pipe_tEE8allocateEmPKv]+0x3c): undef
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-socket_base.o): In function `__gnu_cxx::new_allocator<std::_Rb_tree_node<std::pair<std::string const, zmq::
error:                       | socket_base.cpp:(.text._ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeISt4pairIKSsPN3zmq6pipe_tEEEE8allocateEmPKv[_ZN9__gnu_cxx13new_allocatorISt13_Rb_tree
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-socket_base.o): In function `__gnu_cxx::new_allocator<std::_Rb_tree_node<std::pair<std::string const, std::
error:                       | socket_base.cpp:(.text._ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeISt4pairIKSsS2_IPN3zmq5own_tEPNS4_6pipe_tEEEEE8allocateEmPKv[_ZN9__gnu_cxx13new_alloc
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-stream.o): In function `zmq::stream_t::xsetsockopt(int, void const*, unsigned long)':                      
error:                       | stream.cpp:(.text+0xeb3): undefined reference to `std::string::assign(char const*, unsigned long)'                                                        
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-stream.o): In function `__gnu_cxx::new_allocator<std::_Rb_tree_node<std::pair<std::basic_string<unsigned ch
error:                       | stream.cpp:(.text._ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeISt4pairIKSbIhSt11char_traitsIhESaIhEEN3zmq8stream_t9outpipe_tEEEE8allocateEmPKv[_ZN9__gnu
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-tcp_address.o): In function `zmq::tcp_address_t::resolve(char const*, bool, bool, bool)':                  
error:                       | tcp_address.cpp:(.text+0xa5e): undefined reference to `std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, u
error:                       | tcp_address.cpp:(.text+0xb64): undefined reference to `std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, u
error:                       | tcp_address.cpp:(.text+0xbc9): undefined reference to `std::string::operator[](unsigned long)'                                                            
error:                       | tcp_address.cpp:(.text+0xbef): undefined reference to `std::string::operator[](unsigned long)'                                                            
error:                       | tcp_address.cpp:(.text+0xc2e): undefined reference to `std::string::substr(unsigned long, unsigned long) const'                                           
error:                       | tcp_address.cpp:(.text+0xc65): undefined reference to `std::string::rfind(char, unsigned long) const'                                                     
error:                       | tcp_address.cpp:(.text+0xc9d): undefined reference to `std::string::substr(unsigned long, unsigned long) const'                                           
error:                       | tcp_address.cpp:(.text+0xcb9): undefined reference to `std::string::substr(unsigned long, unsigned long) const'                                           
error:                       | tcp_address.cpp:(.text+0xcec): undefined reference to `std::string::at(unsigned long)'                                                                    
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-tcp_address.o): In function `zmq::tcp_address_mask_t::resolve(char const*, bool)':                         
error:                       | tcp_address.cpp:(.text+0x1436): undefined reference to `std::string::assign(char const*, unsigned long)'                                                  
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-tcp_listener.o): In function `zmq::tcp_listener_t::in_event()':                                            
error:                       | tcp_listener.cpp:(.text+0x396): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                               
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-timers.o): In function `__gnu_cxx::new_allocator<std::_Rb_tree_node<std::pair<unsigned long const, zmq::tim
error:                       | timers.cpp:(.text._ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeISt4pairIKmN3zmq8timers_t7timer_tEEEE8allocateEmPKv[_ZN9__gnu_cxx13new_allocatorISt13_Rb_t
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-udp_address.o): In function `zmq::udp_address_t::resolve(char const*, bool)':                              
error:                       | udp_address.cpp:(.text+0x144): undefined reference to `std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, u
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-xpub.o): In function `__gnu_cxx::new_allocator<zmq::metadata_t*>::allocate(unsigned long, void const*)':   
error:                       | xpub.cpp:(.text._ZN9__gnu_cxx13new_allocatorIPN3zmq10metadata_tEE8allocateEmPKv[_ZN9__gnu_cxx13new_allocatorIPN3zmq10metadata_tEE8allocateEmPKv]+0x3c): un
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-xpub.o): In function `__gnu_cxx::new_allocator<std::basic_string<unsigned char, std::char_traits<unsigned c
error:                       | xpub.cpp:(.text._ZN9__gnu_cxx13new_allocatorISbIhSt11char_traitsIhESaIhEEE8allocateEmPKv[_ZN9__gnu_cxx13new_allocatorISbIhSt11char_traitsIhESaIhEEE8alloca
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-xpub.o): In function `__gnu_cxx::new_allocator<zmq::pipe_t**>::allocate(unsigned long, void const*)':      
error:                       | xpub.cpp:(.text._ZN9__gnu_cxx13new_allocatorIPPN3zmq6pipe_tEE8allocateEmPKv[_ZN9__gnu_cxx13new_allocatorIPPN3zmq6pipe_tEE8allocateEmPKv]+0x3c): undefined 
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-xpub.o): In function `__gnu_cxx::new_allocator<std::basic_string<unsigned char, std::char_traits<unsigned c
error:                       | xpub.cpp:(.text._ZN9__gnu_cxx13new_allocatorIPSbIhSt11char_traitsIhESaIhEEE8allocateEmPKv[_ZN9__gnu_cxx13new_allocatorIPSbIhSt11char_traitsIhESaIhEEE8allo
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-xpub.o): In function `__gnu_cxx::new_allocator<zmq::metadata_t**>::allocate(unsigned long, void const*)':  
error:                       | xpub.cpp:(.text._ZN9__gnu_cxx13new_allocatorIPPN3zmq10metadata_tEE8allocateEmPKv[_ZN9__gnu_cxx13new_allocatorIPPN3zmq10metadata_tEE8allocateEmPKv]+0x3c): 
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-xpub.o):xpub.cpp:(.text._ZN9__gnu_cxx13new_allocatorIPhE8allocateEmPKv[_ZN9__gnu_cxx13new_allocatorIPhE8all
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-ipc_listener.o): In function `zmq::ipc_listener_t::in_event()':                                            
error:                       | ipc_listener.cpp:(.text+0x607): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                               
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-ipc_listener.o): In function `zmq::ipc_listener_t::set_address(char const*)':                              
error:                       | ipc_listener.cpp:(.text+0x991): undefined reference to `std::string::operator[](unsigned long)'                                                           
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-mailbox_safe.o): In function `__gnu_cxx::new_allocator<zmq::signaler_t*>::allocate(unsigned long, void cons
error:                       | mailbox_safe.cpp:(.text._ZN9__gnu_cxx13new_allocatorIPN3zmq10signaler_tEE8allocateEmPKv[_ZN9__gnu_cxx13new_allocatorIPN3zmq10signaler_tEE8allocateEmPKv]+0
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-mtrie.o): In function `zmq::mtrie_t::add_helper(unsigned char*, unsigned long, zmq::pipe_t*)':             
error:                       | mtrie.cpp:(.text+0x216): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                                      
error:                       | mtrie.cpp:(.text+0x73f): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                                      
error:                       | mtrie.cpp:(.text+0x846): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                                      
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-mtrie.o): In function `__gnu_cxx::new_allocator<std::_Rb_tree_node<zmq::pipe_t*> >::allocate(unsigned long,
error:                       | mtrie.cpp:(.text._ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeIPN3zmq6pipe_tEEE8allocateEmPKv[_ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeIPN3zmq6pipe_
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-router.o): In function `zmq::router_t::xsetsockopt(int, void const*, unsigned long)':                      
error:                       | router.cpp:(.text+0x7ac): undefined reference to `std::string::assign(char const*, unsigned long)'                                                        
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-router.o): In function `__gnu_cxx::new_allocator<std::_Rb_tree_node<std::pair<std::basic_string<unsigned ch
error:                       | router.cpp:(.text._ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeISt4pairIKSbIhSt11char_traitsIhESaIhEEN3zmq8router_t9outpipe_tEEEE8allocateEmPKv[_ZN9__gnu
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-server.o): In function `__gnu_cxx::new_allocator<std::_Rb_tree_node<std::pair<unsigned int const, zmq::serv
error:                       | server.cpp:(.text._ZN9__gnu_cxx13new_allocatorISt13_Rb_tree_nodeISt4pairIKjN3zmq8server_t9outpipe_tEEEE8allocateEmPKv[_ZN9__gnu_cxx13new_allocatorISt13_Rb
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-session_base.o): In function `zmq::session_base_t::create(zmq::io_thread_t*, bool, zmq::socket_base_t*, zmq
error:                       | session_base.cpp:(.text+0x6e): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                                
error:                       | session_base.cpp:(.text+0xc0): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                                
error:                       | session_base.cpp:(.text+0x112): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                               
error:                       | session_base.cpp:(.text+0x161): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                               
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-session_base.o): In function `zmq::session_base_t::start_connecting(bool)':                                
error:                       | session_base.cpp:(.text+0x21e1): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                              
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-session_base.o):session_base.cpp:(.text+0x2297): more undefined references to `operator new(unsigned long, 
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-socks_connecter.o): In function `zmq::socks_connecter_t::parse_address(std::string const&, std::string&, un
error:                       | socks_connecter.cpp:(.text+0x1a21): undefined reference to `std::string::rfind(char, unsigned long) const'                                                
error:                       | socks_connecter.cpp:(.text+0x1a59): undefined reference to `std::string::operator[](unsigned long) const'                                                 
error:                       | socks_connecter.cpp:(.text+0x1a77): undefined reference to `std::string::operator[](unsigned long) const'                                                 
error:                       | socks_connecter.cpp:(.text+0x1aaa): undefined reference to `std::string::substr(unsigned long, unsigned long) const'                                      
error:                       | socks_connecter.cpp:(.text+0x1aeb): undefined reference to `std::string::substr(unsigned long, unsigned long) const'                                      
error:                       | socks_connecter.cpp:(.text+0x1b29): undefined reference to `std::string::substr(unsigned long, unsigned long) const'                                      
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-stream_engine.o): In function `zmq::stream_engine_t::plug(zmq::io_thread_t*, zmq::session_base_t*)':       
error:                       | stream_engine.cpp:(.text+0xbba): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                              
error:                       | stream_engine.cpp:(.text+0xc5d): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                              
error:                       | stream_engine.cpp:(.text+0xde8): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                              
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-stream_engine.o): In function `zmq::stream_engine_t::handshake()':                                         
error:                       | stream_engine.cpp:(.text+0x25ff): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                             
error:                       | stream_engine.cpp:(.text+0x26a2): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                             
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-stream_engine.o):stream_engine.cpp:(.text+0x2a37): more undefined references to `operator new(unsigned long
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-udp_engine.o): In function `zmq::udp_engine_t::resolve_raw_address(char*, unsigned long)':                 
error:                       | udp_engine.cpp:(.text+0xb9b): undefined reference to `std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, un
error:                       | udp_engine.cpp:(.text+0xbea): undefined reference to `std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, un
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-curve_server.o): In function `zmq::curve_server_t::receive_and_process_zap_reply()':                       
error:                       | curve_server.cpp:(.text+0x2bf0): undefined reference to `std::string::assign(char const*, unsigned long)'                                                 
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-ipc_connecter.o): In function `zmq::ipc_connecter_t::out_event()':                                         
error:                       | ipc_connecter.cpp:(.text+0x5cb): undefined reference to `operator new(unsigned long, std::nothrow_t const&)'                                              
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-mechanism.o): In function `zmq::mechanism_t::set_user_id(void const*, unsigned long)':                     
error:                       | mechanism.cpp:(.text+0x4d5): undefined reference to `std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, uns
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-mechanism.o): In function `zmq::mechanism_t::parse_metadata(unsigned char const*, unsigned long, bool)':   
error:                       | mechanism.cpp:(.text+0x858): undefined reference to `std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, uns
error:                       | mechanism.cpp:(.text+0x976): undefined reference to `std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, uns
error:                       | mechanism.cpp:(.text+0xa4c): undefined reference to `std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, uns
error:                       | mechanism.cpp:(.text+0xac7): undefined reference to `std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, uns
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-plain_server.o):plain_server.cpp:(.text+0x55d): more undefined references to `std::basic_string<char, std::
error:                       | ./Release/../../zmq/lib/libzmq.a(src_libzmq_la-plain_server.o): In function `zmq::plain_server_t::receive_and_process_zap_reply()':                       
error:                       | plain_server.cpp:(.text+0x1c76): undefined reference to `std::string::assign(char const*, unsigned long)'                                                 
error:                       | collect2: error: ld returned 1 exit status                                                                                                                
error:                       | make: *** [Release/obj.target/zmq.node] Error 1                                                                                                           
error:                       | gyp ERR! build error                                                                                                                                      
error:                       | gyp ERR! stack Error: `make` failed with exit code: 2                                                                                                     
error:                       | gyp ERR! stack     at ChildProcess.onExit (/dev/shm/usenode.jenkins/node-v6.12.2-linux-x86/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:276:23)
error:                       | gyp ERR! stack     at emitTwo (events.js:106:13)                                                                                                          
error:                       | gyp ERR! stack     at ChildProcess.emit (events.js:191:7)                                                                                                 
error:                       | gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:219:12)                                                              
error:                       | gyp ERR! System Linux 3.12.60-52.54-default                                                                                                               
error:                       | gyp ERR! command "/dev/shm/usenode.jenkins/node-v6.12.2-linux-x86/bin/node" "/dev/shm/usenode.jenkins/node-v6.12.2-linux-x86/lib/node_modules/npm/node_mod
error:                       | gyp ERR! cwd /tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq                                                                                             
error:                       | gyp ERR! node -v v6.12.2                                                                                                                                  
error:                       | gyp ERR! node-gyp -v v3.4.0                                                                                                                               
error:                       | gyp ERR! not ok                                                                                                                                           
error:                       |                                                                                                                                                           
error:                       | npm ERR! Linux 3.12.60-52.54-default                                                                                                                      
error:                       | npm ERR! argv "/dev/shm/usenode.jenkins/node-v6.12.2-linux-x86/bin/node" "/dev/shm/usenode.jenkins/node-v6.12.2-linux-x86/bin/npm" "install" "--loglevel" 
error:                       | npm ERR! node v6.12.2                                                                                                                                     
error:                       | npm ERR! npm  v3.10.10                                                                                                                                    
error:                       | npm ERR! code ELIFECYCLE                                                                                                                                  
error:                       | npm ERR! zeromq@4.6.0 install: `node scripts/prebuild-install.js || (node scripts/preinstall.js && node-gyp rebuild)`                                     
error:                       | npm ERR! Exit status 1                                                                                                                                    
error:                       | npm ERR!                                                                                                                                                  
error:                       | npm ERR! Failed at the zeromq@4.6.0 install script 'node scripts/prebuild-install.js || (node scripts/preinstall.js && node-gyp rebuild)'.                
error:                       | npm ERR! Make sure you have the latest version of node.js and npm installed.                                                                              
error:                       | npm ERR! If you do, this is most likely a problem with the zeromq package,                                                                                
error:                       | npm ERR! not with npm itself.                                                                                                                             
error:                       | npm ERR! Tell the author that this fails on your system:                                                                                                  
error:                       | npm ERR!     node scripts/prebuild-install.js || (node scripts/preinstall.js && node-gyp rebuild)                                                         
error:                       | npm ERR! You can get information on how to open an issue for this project with:                                                                           
error:                       | npm ERR!     npm bugs zeromq                                                                                                                              
error:                       | npm ERR! Or if that isn't available, you can get their info via:                                                                                          
error:                       | npm ERR!     npm owner ls zeromq                                                                                                                          
error:                       | npm ERR! There is likely additional logging output above.                                                                                                 
error:                       |                                                                                                                                                           
error:                       | npm ERR! Please include the following file with any support request:                                                                                      
error:                       | npm ERR!     /tmp/55a6b249-e3b6-493e-919d-476e962a807a/zeromq/npm-debug.log                                                                               
error:   done                | The smoke test has failed.
info:    duration            | test duration: 58267ms
```

</details>

<details><summary><code>64-bit:</code> pass</summary>

```
jenkins@jtcjs23:~> citgm zeromq
info:    starting            | zeromq              
info:    lookup              | zeromq              
info:    lookup-found        | zeromq              
info:    zeromq lookup-replace| https://github.com/zeromq/zeromq.js/archive/394a60a2f076131a742deb600431fdb76bb9d83b.tar.gz
info:    zeromq npm:         | Downloading project: https://github.com/zeromq/zeromq.js/archive/394a60a2f076131a742deb600431fdb76bb9d83b.tar.gz
info:    zeromq npm:         | Project downloaded zeromq-4.6.0.tgz
info:    zeromq npm:         | npm install started 
warn:    zeromq npm-install: | configure: WARNING: Cannot find libunwind
info:    zeromq npm:         | npm install successfully completed
info:    zeromq npm:         | test suite started  
info:    passing module(s)   |                     
info:    module name:        | zeromq              
info:    version:            | 4.6.0               
info:    done                | The smoke test has passed.
info:    duration            | test duration: 64957ms
```

</details><br>

Suggest skipping on 32-bit.

##### Checklist
- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
