### PR TITLE
lookup: mocha expect failure on FIPS

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -465,6 +465,7 @@
   "mocha": {
     "prefix": "v",
     "skip": ["win32", "rhel", "aix", "fedora", "ppc"],
+    "expectFail": "fips",
     "maintainers": ["tj", "boneskull"]
   },
   "rewire": {


### PR DESCRIPTION
I am seeing mocha failures on FIPS:
```
  # [32m12 12 2017 18:04:33.812:INFO [launcher]: [39mStarting browser PhantomJS
  # [31m12 12 2017 18:04:33.941:ERROR [phantomjs.launcher]: [39mAuto configuration failed
  
  # 139797356906304:error:060B10A7:digital envelope routines:ALG_MODULE_INIT:fips mode not supported:evp_cnf.c:106:
  
  # 139797356906304:error:0E07606D:configuration file routines:MODULE_RUN:module initialization error:conf_mod.c:235:module=alg_section, value=evp_sect, retcode=-1      
  # [31m12 12 2017 18:04:33.944:ERROR [launcher]: [39mCannot start PhantomJS
  # 	Auto configuration failed
```
<details><summary>full stack tree</summary>

```
not ok 98 - mocha v4.0.1 The canary is dead:
  ---
  # > phantomjs-prebuilt@2.1.16 install /svt/jenkins/workspace/SVT-V4-COMMUNITY-CITGM-FIPS/ARCH/x64/GCC/gcc48/OS/sles12/TAG/svt/tmp/d607f45e-75fa-4271-934c-6ec0530dc168/mocha/node_modules/karma-phantomjs-launcher/node_modules/phantomjs-prebuilt
  # > node install.js
  # PhantomJS not found on PATH
  # Downloading https://github.com/Medium/phantomjs/releases/download/v2.1.1/phantomjs-2.1.1-linux-x86_64.tar.bz2
  # Saving to /svt/jenkins/workspace/SVT-V4-COMMUNITY-CITGM-FIPS/ARCH/x64/GCC/gcc48/OS/sles12/TAG/svt/tmp/d607f45e-75fa-4271-934c-6ec0530dc168/npm_config_tmp/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
  # Receiving...
  # Received 22866K total.
  # Extracting tar contents (via spawned process)
  # Removing /svt/jenkins/workspace/SVT-V4-COMMUNITY-CITGM-FIPS/ARCH/x64/GCC/gcc48/OS/sles12/TAG/svt/tmp/d607f45e-75fa-4271-934c-6ec0530dc168/mocha/node_modules/karma-phantomjs-launcher/node_modules/phantomjs-prebuilt/lib/phantom
  # Copying extracted folder /svt/jenkins/workspace/SVT-V4-COMMUNITY-CITGM-FIPS/ARCH/x64/GCC/gcc48/OS/sles12/TAG/svt/tmp/d607f45e-75fa-4271-934c-6ec0530dc168/npm_config_tmp/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2-extract-1513101776383/phantomjs-2.1.1-linux-x86_64 -> /svt/jenkins/workspace/SVT-V4-COMMUNITY-CITGM-FIPS/ARCH/x64/GCC/gcc48/OS/sles12/TAG/svt/tmp/d607f45e-75fa-4271-934c-6ec0530dc168/mocha/node_modules/karma-phantomjs-launcher/node_modules/phantomjs-prebuilt/lib/phantom
  # Writing location.js file
  # Done. Phantomjs binary available at /svt/jenkins/workspace/SVT-V4-COMMUNITY-CITGM-FIPS/ARCH/x64/GCC/gcc48/OS/sles12/TAG/svt/tmp/d607f45e-75fa-4271-934c-6ec0530dc168/mocha/node_modules/karma-phantomjs-launcher/node_modules/phantomjs-prebuilt/lib/phantom/bin/phantomjs
  # > sauce-connect-launcher@1.2.3 postinstall /svt/jenkins/workspace/SVT-V4-COMMUNITY-CITGM-FIPS/ARCH/x64/GCC/gcc48/OS/sles12/TAG/svt/tmp/d607f45e-75fa-4271-934c-6ec0530dc168/mocha/node_modules/karma-sauce-launcher/node_modules/sauce-connect-launcher
  # > node scripts/install.js || nodejs scripts/install.js
  # > wd@1.5.0 install /svt/jenkins/workspace/SVT-V4-COMMUNITY-CITGM-FIPS/ARCH/x64/GCC/gcc48/OS/sles12/TAG/svt/tmp/d607f45e-75fa-4271-934c-6ec0530dc168/mocha/node_modules/karma-sauce-launcher/node_modules/wd
  # > node scripts/build-browser-scripts
  # escape-string-regexp@1.0.5 node_modules/escape-string-regexp
  # browser-stdout@1.3.0 node_modules/browser-stdout
  # commander@2.11.0 node_modules/commander
  # expect.js@0.3.1 node_modules/expect.js
  # rimraf@2.6.2 node_modules/rimraf
  # he@1.1.1 node_modules/he
  # growl@1.10.3 node_modules/growl
  # eslint-config-standard@10.2.1 node_modules/eslint-config-standard
  # eslint-config-semistandard@11.0.0 node_modules/eslint-config-semistandard
  # karma-expect@1.1.3 node_modules/karma-expect
  # eslint-plugin-standard@3.0.1 node_modules/eslint-plugin-standard
  # supports-color@4.4.0 node_modules/supports-color
  # └── has-flag@2.0.0
  # eslint-plugin-promise@3.6.0 node_modules/eslint-plugin-promise
  # debug@3.1.0 node_modules/debug
  # └── ms@2.0.0
  # coffee-script@1.12.7 node_modules/coffee-script
  # diff@3.3.1 node_modules/diff
  # should@13.1.3 node_modules/should
  # ├── should-type@1.4.0
  # ├── should-util@1.0.0
  # ├── should-format@3.0.3
  # ├── should-type-adaptors@1.0.1
  # └── should-equal@2.0.0
  # karma-mocha@1.3.0 node_modules/karma-mocha
  # └── minimist@1.2.0
  # karma-chrome-launcher@2.2.0 node_modules/karma-chrome-launcher
  # ├── fs-access@1.0.1 (null-check@1.0.0)
  # └── which@1.3.0 (isexe@2.0.0)
  # mkdirp@0.5.1 node_modules/mkdirp
  # └── minimist@0.0.8
  # cross-spawn@5.1.0 node_modules/cross-spawn
  # ├── shebang-command@1.2.0 (shebang-regex@1.0.0)
  # ├── lru-cache@4.1.1 (yallist@2.1.2, pseudomap@1.0.2)
  # └── which@1.3.0 (isexe@2.0.0)
  # assert@1.4.1 node_modules/assert
  # └── util@0.10.3 (inherits@2.0.1)
  # glob@7.1.2 node_modules/glob
  # ├── path-is-absolute@1.0.1
  # ├── inherits@2.0.3
  # ├── fs.realpath@1.0.0
  # ├── inflight@1.0.6 (wrappy@1.0.2)
  # ├── once@1.4.0 (wrappy@1.0.2)
  # └── minimatch@3.0.4 (brace-expansion@1.1.8)
  # through2@2.0.3 node_modules/through2
  # ├── xtend@4.0.1
  # └── readable-stream@2.3.3 (inherits@2.0.3, string_decoder@1.0.3, process-nextick-args@1.0.7, util-deprecate@1.0.2, core-util-is@1.0.2, safe-buffer@5.1.1, isarray@1.0.0)
  # buffer@4.9.1 node_modules/buffer
  # ├── ieee754@1.1.8
  # ├── isarray@1.0.0
  # └── base64-js@1.2.1
  # karma-mocha-reporter@2.2.5 node_modules/karma-mocha-reporter
  # ├── log-symbols@2.1.0
  # ├── strip-ansi@4.0.0 (ansi-regex@3.0.0)
  # └── chalk@2.3.0 (ansi-styles@3.2.0)
  # eslint-plugin-node@5.2.1 node_modules/eslint-plugin-node
  # ├── ignore@3.3.7
  # ├── semver@5.3.0
  # ├── minimatch@3.0.4 (brace-expansion@1.1.8)
  # └── resolve@1.5.0 (path-parse@1.0.5)
  # watchify@3.9.0 node_modules/watchify
  # ├── defined@1.0.0
  # ├── xtend@4.0.1
  # ├── outpipe@1.1.1 (shell-quote@1.6.1)
  # ├── chokidar@1.7.0 (path-is-absolute@1.0.1, async-each@1.0.1, inherits@2.0.3, glob-parent@2.0.0, is-glob@2.0.1, is-binary-path@1.0.1, readdirp@2.1.0)
  # └── anymatch@1.3.2 (normalize-path@2.1.1, micromatch@2.3.11)
  # eslint-plugin-import@2.8.0 node_modules/eslint-plugin-import
  # ├── contains-path@0.1.0
  # ├── lodash.cond@4.5.2
  # ├── builtin-modules@1.1.1
  # ├── doctrine@1.5.0 (esutils@2.0.2, isarray@1.0.0)
  # ├── debug@2.6.9 (ms@2.0.0)
  # ├── has@1.0.1 (function-bind@1.1.1)
  # ├── minimatch@3.0.4 (brace-expansion@1.1.8)
  # ├── eslint-module-utils@2.1.1 (pkg-dir@1.0.0)
  # ├── read-pkg-up@2.0.0 (find-up@2.1.0, read-pkg@2.0.0)
  # └── eslint-import-resolver-node@0.3.1 (resolve@1.5.0)
  # coveralls@3.0.0 node_modules/coveralls
  # ├── log-driver@1.2.5
  # ├── lcov-parse@0.0.10
  # ├── minimist@1.2.0
  # ├── js-yaml@3.10.0 (esprima@4.0.0, argparse@1.0.9)
  # └── request@2.83.0 (aws-sign2@0.7.0, oauth-sign@0.8.2, tunnel-agent@0.6.0, forever-agent@0.6.1, caseless@0.12.0, is-typedarray@1.0.0, safe-buffer@5.1.1, stringstream@0.0.5, aws4@1.6.0, isstream@0.1.2, json-stringify-safe@5.0.1, extend@3.0.1, performance-now@2.1.0, uuid@3.1.0, qs@6.5.1, combined-stream@1.0.5, mime-types@2.1.17, tough-cookie@2.3.3, form-data@2.3.1, hawk@6.0.2, http-signature@1.2.0, har-validator@5.0.3)
  # karma-browserify@5.1.2 node_modules/karma-browserify
  # ├── convert-source-map@1.5.1
  # ├── js-string-escape@1.0.1
  # ├── hat@0.0.3
  # ├── os-shim@0.1.3
  # ├── minimatch@3.0.4 (brace-expansion@1.1.8)
  # └── lodash@3.10.1
  # browserify@14.5.0 node_modules/browserify
  # ├── tty-browserify@0.0.0
  # ├── path-browserify@0.0.0
  # ├── https-browserify@1.0.0
  # ├── punycode@1.4.1
  # ├── duplexer2@0.1.4
  # ├── constants-browserify@1.0.0
  # ├── inherits@2.0.3
  # ├── os-browserify@0.3.0
  # ├── htmlescape@1.1.1
  # ├── process@0.11.10
  # ├── stream-browserify@2.0.1
  # ├── cached-path-relative@1.0.1
  # ├── defined@1.0.0
  # ├── domain-browser@1.1.7
  # ├── xtend@4.0.1
  # ├── read-only-stream@2.0.0
  # ├── querystring-es3@0.2.1
  # ├── timers-browserify@1.4.2
  # ├── deps-sort@2.0.0
  # ├── string_decoder@1.0.3 (safe-buffer@5.1.1)
  # ├── parents@1.0.1 (path-platform@0.11.15)
  # ├── events@1.1.1
  # ├── vm-browserify@0.0.4 (indexof@0.0.1)
  # ├── has@1.0.1 (function-bind@1.1.1)
  # ├── console-browserify@1.1.0 (date-now@0.1.4)
  # ├── util@0.10.3 (inherits@2.0.1)
  # ├── shell-quote@1.6.1 (array-filter@0.0.1, jsonify@0.0.0, array-map@0.0.0, array-reduce@0.0.0)
  # ├── url@0.11.0 (punycode@1.3.2, querystring@0.2.0)
  # ├── subarg@1.0.0 (minimist@1.2.0)
  # ├── readable-stream@2.3.3 (util-deprecate@1.0.2, process-nextick-args@1.0.7, core-util-is@1.0.2, safe-buffer@5.1.1, isarray@1.0.0)
  # ├── labeled-stream-splicer@2.0.0 (isarray@0.0.1, stream-splicer@2.0.0)
  # ├── concat-stream@1.5.2 (typedarray@0.0.6, readable-stream@2.0.6)
  # ├── stream-http@2.7.2 (builtin-status-codes@3.0.0, to-arraybuffer@1.0.1)
  # ├── shasum@1.0.2 (json-stable-stringify@0.0.1, sha.js@2.4.9)
  # ├── buffer@5.0.8 (ieee754@1.1.8, base64-js@1.2.1)
  # ├── browserify-zlib@0.2.0 (pako@1.0.6)
  # ├── JSONStream@1.3.1 (through@2.3.8, jsonparse@1.3.1)
  # ├── syntax-error@1.3.0 (acorn@4.0.13)
  # ├── browser-pack@6.0.2 (umd@3.0.1, combine-source-map@0.7.2)
  # ├── browser-resolve@1.11.2 (resolve@1.1.7)
  # ├── resolve@1.5.0 (path-parse@1.0.5)
  # ├── insert-module-globals@7.0.1 (is-buffer@1.1.6, combine-source-map@0.7.2, lexical-scope@1.2.0)
  # ├── crypto-browserify@3.12.0 (randomfill@1.0.3, randombytes@2.0.5, create-hmac@1.1.6, pbkdf2@3.0.14, diffie-hellman@5.0.2, create-hash@1.1.3, browserify-cipher@1.0.0, create-ecdh@4.0.0, browserify-sign@4.0.4, public-encrypt@4.0.0)
  # └── module-deps@4.1.1 (stream-combiner2@1.1.1, detective@4.7.0)
  # karma-phantomjs-launcher@1.0.4 node_modules/karma-phantomjs-launcher
  # ├── phantomjs-prebuilt@2.1.16 (progress@1.1.8, kew@0.7.0, which@1.3.0, request-progress@2.0.1, es6-promise@4.1.1, hasha@2.2.0, fs-extra@1.0.0, extract-zip@1.6.6, request@2.83.0)
  # └── lodash@4.17.4
  # karma-sauce-launcher@1.2.0 node_modules/karma-sauce-launcher
  # ├── q@1.5.1
  # ├── saucelabs@1.4.0 (https-proxy-agent@1.0.0)
  # ├── sauce-connect-launcher@1.2.3 (adm-zip@0.4.7, https-proxy-agent@1.0.0, async@2.6.0, lodash@4.17.4)
  # └── wd@1.5.0 (vargs@0.1.0, q@1.4.1, archiver@1.3.0, async@2.0.1, underscore.string@3.3.4, request@2.79.0, lodash@4.16.2)
  # eslint@4.13.1 node_modules/eslint
  # ├── path-is-inside@1.0.2
  # ├── natural-compare@1.4.0
  # ├── imurmurhash@0.1.4
  # ├── ignore@3.3.7
  # ├── strip-json-comments@2.0.1
  # ├── pluralize@7.0.0
  # ├── globals@11.1.0
  # ├── estraverse@4.2.0
  # ├── esquery@1.0.0
  # ├── functional-red-black-tree@1.0.1
  # ├── esutils@2.0.2
  # ├── semver@5.4.1
  # ├── progress@2.0.0
  # ├── doctrine@2.0.2
  # ├── text-table@0.2.0
  # ├── json-stable-stringify-without-jsonify@1.0.1
  # ├── strip-ansi@4.0.0 (ansi-regex@3.0.0)
  # ├── is-resolvable@1.0.0 (tryit@1.0.3)
  # ├── levn@0.3.0 (type-check@0.3.2, prelude-ls@1.1.2)
  # ├── optionator@0.8.2 (fast-levenshtein@2.0.6, type-check@0.3.2, wordwrap@1.0.0, deep-is@0.1.3, prelude-ls@1.1.2)
  # ├── require-uncached@1.0.3 (resolve-from@1.0.1, caller-path@0.1.0)
  # ├── minimatch@3.0.4 (brace-expansion@1.1.8)
  # ├── eslint-scope@3.7.1 (esrecurse@4.2.0)
  # ├── babel-code-frame@6.26.0 (js-tokens@3.0.2, chalk@1.1.3)
  # ├── chalk@2.3.0 (ansi-styles@3.2.0)
  # ├── concat-stream@1.6.0 (inherits@2.0.3, typedarray@0.0.6, readable-stream@2.3.3)
  # ├── table@4.0.2 (string-width@2.1.1, slice-ansi@1.0.0, ajv-keywords@2.1.1)
  # ├── file-entry-cache@2.0.0 (object-assign@4.1.1, flat-cache@1.3.0)
  # ├── inquirer@3.3.0 (figures@2.0.0, ansi-escapes@3.0.0, rx-lite-aggregates@4.0.8, cli-width@2.2.0, rx-lite@4.0.8, through@2.3.8, mute-stream@0.0.7, string-width@2.1.1, run-async@2.3.0, cli-cursor@2.1.0, external-editor@2.1.0)
  # ├── espree@3.5.2 (acorn@5.2.1, acorn-jsx@3.0.1)
  # ├── js-yaml@3.10.0 (esprima@4.0.0, argparse@1.0.9)
  # ├── ajv@5.5.1 (co@4.6.0, json-schema-traverse@0.3.1, fast-deep-equal@1.0.0, fast-json-stable-stringify@2.0.0)
  # └── lodash@4.17.4
  # karma@1.7.1 node_modules/karma
  # ├── isbinaryfile@3.0.2
  # ├── range-parser@1.2.0
  # ├── safe-buffer@5.1.1
  # ├── graceful-fs@4.1.11
  # ├── di@0.0.1
  # ├── mime@1.6.0
  # ├── qjobs@1.1.5
  # ├── tmp@0.0.31 (os-tmpdir@1.0.2)
  # ├── colors@1.1.2
  # ├── source-map@0.5.7
  # ├── http-proxy@1.16.2 (eventemitter3@1.2.0, requires-port@1.0.0)
  # ├── dom-serialize@2.2.1 (void-elements@2.0.1, custom-event@1.0.1, extend@3.0.1, ent@2.2.0)
  # ├── minimatch@3.0.4 (brace-expansion@1.1.8)
  # ├── useragent@2.2.1 (lru-cache@2.2.4)
  # ├── bluebird@3.5.1
  # ├── connect@3.6.5 (utils-merge@1.0.1, parseurl@1.3.2, debug@2.6.9, finalhandler@1.0.6)
  # ├── optimist@0.6.1 (wordwrap@0.0.3, minimist@0.0.10)
  # ├── body-parser@1.18.2 (content-type@1.0.4, bytes@3.0.0, depd@1.1.1, qs@6.5.1, on-finished@2.3.0, raw-body@2.3.2, http-errors@1.6.2, debug@2.6.9, iconv-lite@0.4.19, type-is@1.6.15)
  # ├── expand-braces@0.1.2 (array-slice@0.2.3, array-unique@0.2.1, braces@0.1.5)
  # ├── socket.io@1.7.3 (object-assign@4.1.0, socket.io-adapter@0.5.0, has-binary@0.1.7, debug@2.3.3, socket.io-parser@2.3.1, engine.io@1.8.3, socket.io-client@1.7.3)
  # ├── log4js@0.6.38 (semver@4.3.6, readable-stream@1.0.34)
  # ├── chokidar@1.7.0 (path-is-absolute@1.0.1, inherits@2.0.3, async-each@1.0.1, glob-parent@2.0.0, is-glob@2.0.1, is-binary-path@1.0.1, readdirp@2.1.0, anymatch@1.3.2)
  # ├── lodash@3.10.1
  # ├── combine-lists@1.0.1 (lodash@4.17.4)
  # └── core-js@2.5.3
  # nyc@11.3.0 node_modules/nyc
  # > mocha@4.0.1 test /svt/jenkins/workspace/SVT-V4-COMMUNITY-CITGM-FIPS/ARCH/x64/GCC/gcc48/OS/sles12/TAG/svt/tmp/d607f45e-75fa-4271-934c-6ec0530dc168/mocha
  # > make clean && make test
  # ==> [Clean]
  # rm -f mocha.js
  # ==> [Test :: Lint]
  # npm run lint
  # > mocha@4.0.1 lint /svt/jenkins/workspace/SVT-V4-COMMUNITY-CITGM-FIPS/ARCH/x64/GCC/gcc48/OS/sles12/TAG/svt/tmp/d607f45e-75fa-4271-934c-6ec0530dc168/mocha
  # > eslint . bin/*
  # ==> [Test :: BDD]
  # "bin/mocha" --ui bdd \
  # 	test/interfaces/bdd.spec
  #   integer primitives
  #     arithmetic
  #       ✓ should add
  #       ✓ should subtract
  #   integer primitives
  #     arithmetic is not
  #       ✓ should add
  #   test suite
  #     ✓ share a property
  #   4 passing (18ms)
  # ==> [Test :: TDD]
  # "bin/mocha" --ui tdd \
  # 	test/interfaces/tdd.spec
  #   integer primitives
  #     arithmetic
  #       ✓ should add
  #       ✓ should subtract
  #       - should skip this test
  #       should skip this suite
  #         - should skip this test
  #   2 passing (20ms)
  #   2 pending
  # ==> [Test :: QUnit]
  # "bin/mocha" --ui qunit \
  # 	test/interfaces/qunit.spec
  #   integer primitives
  #     ✓ should add
  #     ✓ should decrement
  #   String
  #     ✓ #length
  #   3 passing (10ms)
  # ==> [Test :: Exports]
  # "bin/mocha" --ui exports \
  # 	test/interfaces/exports.spec
  #   Array
  #     #indexOf()
  #       ✓ should return -1 when the value is not present
  #       ✓ should return the correct index when the value is present
  #   2 passing (20ms)
  # ==> [Test :: Unit]
  # "bin/mocha" test/unit/*.spec.js \
  # 	test/node-unit/*.spec.js \
  # 	--growl
  #   ✓ should work
  #   Context
  #     nested
  #       ✓ should work
  #   Context Siblings
  #     sequestered sibling
  #       ✓ should work
  #     sibling verifiction
  #       ✓ should not have value set within a sibling describe
  #       ✓ should allow test siblings to modify shared context
  #       ✓ should have reset this.calls before describe
  #   timeout()
  #     ✓ should return the timeout
  #   durations
  #     when slow
  #       ✓ should highlight in red (101ms)
  #     when reasonable
  #       ✓ should highlight in yellow (51ms)
  #     when fast
  #       ✓ should not highlight
  #   global leaks
  #     ✓ should cause tests to fail
  #     ✓ should pass when accepted
  #     ✓ should pass with wildcard
  #     ✓ should pass when prefixed "mocha-"
  #   Mocha
  #     "grep" option
  #       ✓ should add a RegExp to the mocha.options object
  #       ✓ should convert string to a RegExp
  #     "fgrep" option
  #       ✓ should escape and convert string to a RegExp
  #     .grep()
  #       ✓ should add a RegExp to the mocha.options object
  #       ✓ should convert grep string to a RegExp
  #       ✓ should covert grep regex-like string to a RegExp
  #       ✓ should return it's parent Mocha object for chainability
  #     "invert" option
  #       ✓ should add a Boolean to the mocha.options object
  #   async
  #     hooks
  #       ✓ one
  #       ✓ two
  #       ✓ three
  #   serial
  #     nested
  #       ✓ foo
  #       ✓ bar
  #       hooks
  #         ✓ one
  #         ✓ two
  #   serial
  #     hooks
  #       ✓ one
  #       ✓ two
  #       ✓ three
  #   Mocha
  #     .run(fn)
  #       ✓ should not raise errors if callback was not provided
  #       ✓ should execute the callback when complete
  #       ✓ should execute the callback with the number of failures as parameter
  #     .addFile()
  #       ✓ should add the given file to the files array
  #     .invert()
  #       ✓ should set the invert option to true
  #       ✓ should be chainable
  #     .ignoreLeaks()
  #       ✓ should set the ignoreLeaks option to true when param equals true
  #       ✓ should set the ignoreLeaks option to false when param equals false
  #       ✓ should set the ignoreLeaks option to false when the param is undefined
  #       ✓ should be chainable
  #     .checkLeaks()
  #       ✓ should set the ignoreLeaks option to false
  #       ✓ should be chainable
  #     .fullTrace()
  #       ✓ should set the fullStackTrace option to true
  #       ✓ should be chainable
  #     .growl()
  #       ✓ should set the growl option to true
  #       ✓ should be chainable
  #     .useInlineDiffs()
  #       ✓ should set the useInlineDiffs option to true when param equals true
  #       ✓ should set the useInlineDiffs option to false when param equals false
  #       ✓ should set the useInlineDiffs option to false when the param is undefined
  #       ✓ should be chainable
  #     .noHighlighting()
  #       ✓ should set the noHighlighting option to true
  #     .allowUncaught()
  #       ✓ should set the allowUncaught option to true
  #     .delay()
  #       ✓ should set the delay option to true
  #   .ms()
  #     get a value that less than 1 second
  #       ✓ should return milliseconds representation
  #     seconds representation
  #       ✓ should return short format
  #       ✓ should return long format
  #     minutes representation
  #       ✓ should return short format
  #       ✓ should return long format
  #     hours representation
  #       ✓ should return short format
  #       ✓ should return long format
  #     days representation
  #       ✓ should return short format
  #       ✓ should return long format
  #     Getting string value
  #       ✓ should return the milliseconds representation(Number)
  #   overspecified asynchronous resolution method
  #     ✓ should fail when multiple methods are used
  #   using imported describe
  #     ✓ using imported it
  #   root
  #     ✓ should be a valid suite
  #   Runnable(title, fn)
  #     #timeout(ms)
  #       ✓ should set the timeout
  #     #timeout(ms) when ms>2^31
  #       ✓ should set disabled
  #     #enableTimeouts(enabled)
  #       ✓ should set enabled
  #     #slow(ms)
  #       ✓ should set the slow threshold
  #       ✓ should not set the slow threshold if the parameter is not passed
  #       ✓ should not set the slow threshold if the parameter is undefined
  #     .title
  #       ✓ should be present
  #     .titlePath()
  #       ✓ returns the concatenation of the parent's title path and runnable's title
  #     when arity >= 1
  #       ✓ should be .async
  #     when arity == 0
  #       ✓ should be .sync
  #     #globals
  #       ✓ should allow for whitelisting globals
  #     #retries(n)
  #       ✓ should set the number of retries
  #     .run(fn)
  #       when .pending
  #         ✓ should not invoke the callback
  #       when sync
  #         without error
  #           ✓ should invoke the callback
  #         when an exception is thrown
  #           ✓ should invoke the callback
  #         when an exception is thrown and is allowed to remain uncaught
  #           ✓ throws an error when it is allowed
  #       when timeouts are disabled
  #         ✓ should not error with timeout
  #       when async
  #         ✓ should allow updating the timeout (53ms)
  #         - should allow a timeout of 0
  #         without error
  #           ✓ should invoke the callback
  #         when the callback is invoked several times
  #           without an error
  #             ✓ should emit a single "error" event
  #           with an error
  #             ✓ should emit a single "error" event
  #         when an exception is thrown
  #           ✓ should invoke the callback
  #           ✓ should not throw its own exception if passed a non-object
  #         when an exception is thrown and is allowed to remain uncaught
  #           ✓ throws an error when it is allowed
  #         when an error is passed
  #           ✓ should invoke the callback
  #         when done() is invoked with a non-Error object
  #           ✓ should invoke the callback
  #         when done() is invoked with a string
  #           ✓ should invoke the callback
  #       when fn returns a promise
  #         when the promise is fulfilled with no value
  #           ✓ should invoke the callback
  #         when the promise is fulfilled with a value
  #           ✓ should invoke the callback
  #         when the promise is rejected
  #           ✓ should invoke the callback
  #         when the promise is rejected without a reason
  #           ✓ should invoke the callback
  #         when the promise takes too long to settle
  #           ✓ should give the timeout error
  #       when fn returns a non-promise
  #         ✓ should invoke the callback
  #   Runner
  #     .grep()
  #       ✓ should update the runner.total with number of matched tests
  #       ✓ should update the runner.total with number of matched tests when inverted
  #     .grepTotal()
  #       ✓ should return the total number of matched tests
  #       ✓ should return the total number of matched tests when inverted
  #     .globalProps()
  #       ✓ should include common non enumerable globals
  #     .globals()
  #       ✓ should default to the known globals
  #       ✓ should white-list globals
  #     .checkGlobals(test)
  #       ✓ should allow variables that match a wildcard
  #       ✓ should emit "fail" when a new global is introduced
  #       ✓ should emit "fail" when a single new disallowed global is introduced after a single extra global is allowed
  #       ✓ should not fail when a new common global is introduced
  #       ✓ should pluralize the error message when several are introduced
  #       ✓ should respect per test whitelisted globals
  #       ✓ should respect per test whitelisted globals but still detect other leaks
  #       ✓ should emit "fail" when a global beginning with d is introduced
  #     .hook(name, fn)
  #       ✓ should execute hooks after failed test if suite bail is true
  #     .fail(test, err)
  #       ✓ should increment .failures
  #       ✓ should set test.state to "failed"
  #       ✓ should emit "fail"
  #       ✓ should emit a helpful message when failed with a string
  #       ✓ should emit a the error when failed with an Error instance
  #       ✓ should emit the error when failed with an Error-like object
  #       ✓ should emit a helpful message when failed with an Object
  #       ✓ should emit a helpful message when failed with an Array
  #       ✓ should recover if the error stack is not writable
  #     .failHook(hook, err)
  #       ✓ should increment .failures
  #       ✓ should augment hook title with current test title
  #       ✓ should emit "fail"
  #       ✓ should emit "end" if suite bail is true
  #       ✓ should not emit "end" if suite bail is not true
  #     allowUncaught
  #       ✓ should allow unhandled errors to propagate through
  #     stackTrace
  #       shortStackTrace
  #         ✓ should prettify the stack-trace
  #       longStackTrace
  #         ✓ should display the full stack-trace
  #   Suite
  #     .clone()
  #       ✓ should copy the title
  #       ✓ should copy the timeout value
  #       ✓ should copy the slow value
  #       ✓ should copy the bail value
  #       ✓ should not copy the values from the suites array
  #       ✓ should not copy the values from the tests array
  #       ✓ should not copy the values from the _beforeEach array
  #       ✓ should not copy the values from the _beforeAll array
  #       ✓ should not copy the values from the _afterEach array
  #       ✓ should not copy the values from the _afterAll array
  #     .timeout()
  #       when no argument is passed
  #         ✓ should return the timeout value
  #       when argument is passed
  #         ✓ should return the Suite object
  #     .slow()
  #       when given a string
  #         ✓ should parse it
  #       when no argument is passed
  #         ✓ should return the slow value
  #       when argument is passed
  #         ✓ should return the Suite object
  #     .bail()
  #       when no argument is passed
  #         ✓ should return the bail value
  #       when argument is passed
  #         ✓ should return the Suite object
  #     .beforeAll()
  #       wraps the passed in function in a Hook
  #         ✓ adds it to _beforeAll
  #         ✓ appends title to hook
  #         ✓ uses function name if available
  #     .afterAll()
  #       wraps the passed in function in a Hook
  #         ✓ adds it to _afterAll
  #         ✓ appends title to hook
  #         ✓ uses function name if available
  #     .beforeEach()
  #       wraps the passed in function in a Hook
  #         ✓ adds it to _beforeEach
  #         ✓ appends title to hook
  #         ✓ uses function name if available
  #     .afterEach()
  #       wraps the passed in function in a Hook
  #         ✓ adds it to _afterEach
  #         ✓ appends title to hook
  #         ✓ uses function name if available
  #     .addSuite()
  #       ✓ sets the parent on the added Suite
  #       ✓ copies the timeout value
  #       ✓ copies the slow value
  #       ✓ adds the suite to the suites collection
  #       ✓ treats suite as pending if its parent is pending
  #     .fullTitle()
  #       when there is no parent
  #         ✓ returns the suite title
  #       when there is a parent
  #         ✓ returns the combination of parent's and suite's title
  #     .titlePath()
  #       when there is no parent
  #         ✓ returns the suite title
  #       when there is a parent
  #         the parent is the root suite
  #           ✓ returns the suite title
  #         the parent is not the root suite
  #           ✓ returns the concatenation of parent's and suite's title
  #     .total()
  #       when there are no nested suites or tests
  #         ✓ should return 0
  #       when there are several tests in the suite
  #         ✓ should return the number
  #     .eachTest(fn)
  #       when there are no nested suites or tests
  #         ✓ should return 0
  #       when there are several tests in the suite
  #         ✓ should return the number
  #       when there are several levels of nested suites
  #         ✓ should return the number
  #     initialization
  #       ✓ should throw an error if the title isn't a string
  #       ✓ should not throw if the title is a string
  #   Test
  #     initialization
  #       ✓ should throw an error if the title isn't a string
  #       ✓ should not throw if the title is a string
  #   Test
  #     .clone()
  #       ✓ should copy the title
  #       ✓ should copy the timeout value
  #       ✓ should copy the slow value
  #       ✓ should copy the enableTimeouts value
  #       ✓ should copy the retries value
  #       ✓ should copy the currentRetry value
  #       ✓ should copy the globals value
  #       ✓ should copy the parent value
  #       ✓ should copy the file value
  #     .isPending()
  #       ✓ should not be pending by default
  #       ✓ should be pending when marked as such
  #       ✓ should be pending when its parent is pending
  #   a test that throws
  #     undefined
  #       ✓ should not pass if throwing sync and test is sync
  #       ✓ should not pass if throwing sync and test is async
  #       ✓ should not pass if throwing async and test is async
  #     null
  #       ✓ should not pass if throwing sync and test is sync
  #       ✓ should not pass if throwing sync and test is async
  #       ✓ should not pass if throwing async and test is async
  #   timeouts
  #     ✓ should error on timeout
  #     ✓ should allow overriding per-test (51ms)
  #     disabling
  #       ✓ should allow overriding per-test
  #       ✓ should work with timeout(0)
  #       using beforeEach
  #         ✓ should work with timeout(0)
  #       using before
  #         ✓ should work with timeout(0)
  #       using enableTimeouts(false)
  #         ✓ should suppress timeout(4)
  #       suite-level
  #         ✓ should work with timeout(0)
  #         nested suite
  #           ✓ should work with timeout(0)
  #   lib/utils
  #     clean
  #       ✓ should remove the wrapping function declaration
  #       ✓ should handle newlines in the function declaration
  #       ✓ should remove space character indentation from the function body
  #       ✓ should remove tab character indentation from the function body
  #       ✓ should handle functions with tabs in their declarations
  #       ✓ should handle named functions without space after name
  #       ✓ should handle named functions with space after name
  #       ✓ should handle functions with no space between the end and the closing brace
  #       ✓ should handle functions with parentheses in the same line
  #       ✓ should handle empty functions
  #       ✓ should format a single line test function
  #       ✓ should format a multi line test indented with spaces
  #       ✓ should format a multi line test indented with tabs
  #       ✓ should format functions saved in windows style - spaces
  #       ✓ should format functions saved in windows style - tabs
  #       ✓ should format es6 arrow functions
  #       ✓ should format es6 arrow functions with implicit return
  #     stringify
  #       ✓ should return an object representation of a string created with a String constructor
  #       ✓ should return Buffer with .toJSON representation
  #       ✓ should return Date object with .toISOString() + string prefix
  #       ✓ should return invalid Date object with .toString() + string prefix
  #       ✓ should canonicalize the object
  #       ✓ should handle circular structures in objects
  #       ✓ should handle circular structures in arrays
  #       ✓ should handle circular structures in functions
  #       ✓ should handle various non-undefined, non-null, non-object, non-array, non-date, and non-function values
  #       ✓ should handle arrays
  #       ✓ should handle functions
  #       ✓ should handle empty objects
  #       ✓ should handle empty arrays
  #       ✓ should handle non-empty arrays
  #       ✓ should handle empty functions (with no properties)
  #       ✓ should handle functions w/ properties
  #       ✓ should handle undefined values
  #       ✓ should recurse
  #       ✓ might get confusing
  #       ✓ should not freak out if it sees a primitive twice
  #       ✓ should stringify dates
  #       ✓ should handle object without an Object prototype
  #       ✓ should handle Symbol
  #       ✓ should handle length properties that cannot be coerced to a number
  #       #Number
  #         ✓ should show the handle -0 situations
  #         ✓ should work well with `NaN` and `Infinity`
  #         ✓ floats and ints
  #       canonicalize example
  #         ✓ should represent the actual full result
  #     type
  #       ✓ should recognize various types
  #       when toString on null or undefined stringifies window
  #         ✓ should recognize null and undefined
  #     parseQuery()
  #       ✓ should get queryString and return key-value object
  #       ✓ should parse "+" as a space
  #     isPromise
  #       ✓ should return true if the value is Promise-ish
  #       ✓ should return false if the value is not an object
  #       ✓ should return false if the value is an object w/o a "then" function
  #     escape
  #       ✓ replaces the usual xml suspects
  #       ✓ replaces invalid xml characters
  #   Mocha
  #     ✓ should not output colors to pipe (396ms)
  #   file utils
  #     .lookupFiles
  #       ✓ should not return broken symlink file path
  #       ✓ should accept a glob "path" value
  #     .files
  #       ✓ should return broken symlink file path
  #   fs.readFile()
  #     when the file exists
  #       ✓ should succeed
  #     when the file does not exist
  #       ✓ should fail
  #   stackTraceFilter()
  #     on node
  #       on POSIX OS
  #         ✓ should get a stack-trace as a string and prettify it
  #         ✓ does not ignore other bower_components and components
  #         ✓ should replace absolute with relative paths
  #       on Windows
  #         - should work on Windows
  #     on browser
  #       ✓ does not strip out other bower_components
  #   273 passing (1s)
  #   2 pending
  # ==> [Test :: Integrations]
  # "bin/mocha" --timeout 5000 --slow 500 \
  # 	test/integration/*.spec.js
  #   globbing like --compilers
  #     ✓ should find a file of each type (563ms)
  #   diffs
  #     ✓ should display a diff for small strings
  #     ✓ should display a diff of canonicalized objects
  #     ✓ should display a diff for medium strings
  #     ✓ should display a diff for entire object dumps
  #     ✓ should display a diff for multi-line strings
  #     ✓ should display a diff for entire object dumps
  #     ✓ should display a full-comparison with escaped special characters
  #     ✓ should display a word diff for large strings
  #     ✓ should work with objects
  #     ✓ should show value diffs and not be affected by commas
  #     ✓ should display diff by data and not like an objects
  #   globbing
  #     by the shell
  #       ✓ should find the first level test (420ms)
  #       ✓ should not find a non-matching pattern (402ms)
  #       ✓ should handle both matching and non-matching patterns in the same command (430ms)
  #     by Mocha
  #       ✓ should find the first level test (434ms)
  #       ✓ should not find a non-matching pattern (402ms)
  #       ✓ should handle both matching and non-matching patterns in the same command (433ms)
  #       double-starred
  #         ✓ should find the tests on multiple levels (423ms)
  #         ✓ should not find a non-matching pattern (406ms)
  #         ✓ should handle both matching and non-matching patterns in the same command (437ms)
  #   hook error handling
  #     before hook error
  #       ✓ should verify results
  #     before hook error tip
  #       ✓ should verify results
  #     before each hook error
  #       ✓ should verify results
  #     after hook error
  #       ✓ should verify results
  #     after each hook error
  #       ✓ should verify results
  #     multiple hook errors
  #       ✓ should verify results
  #     async - before hook error
  #       ✓ should verify results
  #     async - before hook error tip
  #       ✓ should verify results
  #     async - before each hook error
  #       ✓ should verify results
  #     async - after hook error
  #       ✓ should verify results
  #     async - after each hook error
  #       ✓ should verify results
  #     async - multiple hook errors
  #       ✓ should verify results
  #   hooks
  #     ✓ are ran in correct order (441ms)
  #   multiple calls to done()
  #     from a spec
  #       ✓ results in failures
  #       ✓ throws a descriptive error
  #     with multiple specs
  #       ✓ results in a failure
  #       ✓ correctly attributes the error
  #     from a before hook
  #       ✓ results in a failure
  #       ✓ correctly attributes the error
  #     from a beforeEach hook
  #       ✓ results in a failure
  #       ✓ correctly attributes the errors
  #   .only()
  #     bdd
  #       ✓ should run only tests that marked as `only` (434ms)
  #     tdd
  #       ✓ should run only tests that marked as `only` (443ms)
  #     qunit
  #       ✓ should run only tests that marked as `only` (435ms)
  #   options
  #     --async-only
  #       ✓ should fail synchronous specs (444ms)
  #       ✓ should allow asynchronous specs (427ms)
  #     --bail
  #       ✓ should stop after the first error (435ms)
  #     --sort
  #       ✓ should sort tests in alphabetical order (448ms)
  #     --delay
  #       ✓ should run the generated test suite (629ms)
  #       ✓ should throw an error if the test suite failed to run (536ms)
  #     --grep
  #       ✓ runs specs matching a string (433ms)
  #       runs specs matching a RegExp
  #         ✓ with RegExp like strings(pattern follow by flag) (453ms)
  #         ✓ string as pattern (445ms)
  #       with --invert
  #         ✓ runs specs that do not match the pattern (446ms)
  #     --retries
  #       ✓ retries after a certain threshold (441ms)
  #     --forbid-only
  #       ✓ succeeds if there are only passed tests (431ms)
  #       ✓ fails if there are tests marked only (450ms)
  #       ✓ fails if there are tests in suites marked only (443ms)
  #     --forbid-pending
  #       ✓ succeeds if there are only passed tests (432ms)
  #       ✓ fails if there are tests marked skip (440ms)
  #       ✓ fails if there are pending tests (447ms)
  #       ✓ fails if tests call `skip()` (439ms)
  #       ✓ fails if beforeEach calls `skip()` (434ms)
  #       ✓ fails if before calls `skip()` (435ms)
  #       ✓ fails if there are tests in suites marked skip (438ms)
  #     --exit
  #       default behavior
  #         ✓ should force exit after root suite completion (2030ms)
  #       with exit enabled
  #         ✓ should force exit after root suite completion
  #       with exit disabled
  #         ✓ should not force exit after root suite completion (2025ms)
  #   pending
  #     pending specs
  #       ✓ should be created by omitting a function (432ms)
  #     synchronous skip()
  #       in spec
  #         ✓ should immediately skip the spec and run all others (433ms)
  #       in before
  #         ✓ should skip all suite specs (434ms)
  #       in beforeEach
  #         ✓ should skip all suite specs (435ms)
  #     asynchronous skip()
  #       in spec
  #         ✓ should immediately skip the spec and run all others (488ms)
  #       in before
  #         ✓ should skip all suite specs (494ms)
  #       in beforeEach
  #         ✓ should skip all suite specs (441ms)
  #   regressions
  #     ✓ issue-1327: should run all 3 specs exactly once (442ms)
  #     ✓ should not duplicate mocha.opts args in process.argv
  #     ✓ issue-1794: Can't --require custom UI and use it (433ms)
  #     ✓ issue-1991: Declarations do not get cleaned up unless you set them to `null` - Memory Leak (6940ms)
  #     ✓ issue-2315: cannot read property currentRetry of undefined (403ms)
  #     ✓ issue-2406: should run nested describe.only suites (402ms)
  #     ✓ issue-2417: should not recurse infinitely with .only suites nested within each other (385ms)
  #     ✓ issue-1417 uncaught exceptions from async specs (397ms)
  #     issue-2286: after doesn't execute if test was skipped in beforeEach
  #       suite with skipped test for meta test
  #         - should be pending
  #   reporters
  #     markdown
  #       ✓ does not exceed maximum callstack (issue: 1875)
  #       ✓ contains spec src
  #     xunit
  #       ✓ prints test cases with --reporter-options output (issue: 1864) (396ms)
  #     loader
  #       ✓ loads a reporter from a path relative to the current working directory (397ms)
  #       ✓ loads a reporter from an absolute path (406ms)
  #   retries
  #     ✓ are ran in correct order (408ms)
  #     ✓ should exit early if test passes (392ms)
  #     ✓ should let test override (394ms)
  #     ✓ should not hang w/ async test (807ms)
  #   suite w/no callback
  #     ✓ should throw a helpful error message when a callback for suite is not supplied (392ms)
  #   skipped suite w/no callback
  #     ✓ should not throw an error when a callback for skipped suite is not supplied (404ms)
  #   skipped suite w/ callback
  #     ✓ should not throw an error when a callback for skipped suite is supplied (389ms)
  #   this.timeout()
  #     ✓ is respected by sync and async suites (408ms)
  #   uncaught exceptions
  #     ✓ handles uncaught exceptions from hooks (398ms)
  #     ✓ handles uncaught exceptions from async specs (416ms)
  #   99 passing (47s)
  #   1 pending
  # ==> [Test :: JS API]
  # node test/jsapi
  #   Suite
  #     .clone()
  #       ✓ should copy the title
  #       ✓ should copy the timeout value
  #       ✓ should copy the slow value
  #       ✓ should copy the bail value
  #       ✓ should not copy the values from the suites array
  #       ✓ should not copy the values from the tests array
  #       ✓ should not copy the values from the _beforeEach array
  #       ✓ should not copy the values from the _beforeAll array
  #       ✓ should not copy the values from the _afterEach array
  #       ✓ should not copy the values from the _afterAll array
  #     .timeout()
  #       when no argument is passed
  #         ✓ should return the timeout value
  #       when argument is passed
  #         ✓ should return the Suite object
  #     .slow()
  #       when given a string
  #         ✓ should parse it
  #       when no argument is passed
  #         ✓ should return the slow value
  #       when argument is passed
  #         ✓ should return the Suite object
  #     .bail()
  #       when no argument is passed
  #         ✓ should return the bail value
  #       when argument is passed
  #         ✓ should return the Suite object
  #     .beforeAll()
  #       wraps the passed in function in a Hook
  #         ✓ adds it to _beforeAll
  #         ✓ appends title to hook
  #         ✓ uses function name if available
  #     .afterAll()
  #       wraps the passed in function in a Hook
  #         ✓ adds it to _afterAll
  #         ✓ appends title to hook
  #         ✓ uses function name if available
  #     .beforeEach()
  #       wraps the passed in function in a Hook
  #         ✓ adds it to _beforeEach
  #         ✓ appends title to hook
  #         ✓ uses function name if available
  #     .afterEach()
  #       wraps the passed in function in a Hook
  #         ✓ adds it to _afterEach
  #         ✓ appends title to hook
  #         ✓ uses function name if available
  #     .addSuite()
  #       ✓ sets the parent on the added Suite
  #       ✓ copies the timeout value
  #       ✓ copies the slow value
  #       ✓ adds the suite to the suites collection
  #       ✓ treats suite as pending if its parent is pending
  #     .fullTitle()
  #       when there is no parent
  #         ✓ returns the suite title
  #       when there is a parent
  #         ✓ returns the combination of parent's and suite's title
  #     .titlePath()
  #       when there is no parent
  #         ✓ returns the suite title
  #       when there is a parent
  #         the parent is the root suite
  #           ✓ returns the suite title
  #         the parent is not the root suite
  #           ✓ returns the concatenation of parent's and suite's title
  #     .total()
  #       when there are no nested suites or tests
  #         ✓ should return 0
  #       when there are several tests in the suite
  #         ✓ should return the number
  #     .eachTest(fn)
  #       when there are no nested suites or tests
  #         ✓ should return 0
  #       when there are several tests in the suite
  #         ✓ should return the number
  #       when there are several levels of nested suites
  #         ✓ should return the number
  #     initialization
  #       ✓ should throw an error if the title isn't a string
  #       ✓ should not throw if the title is a string
  #   Test
  #     initialization
  #       ✓ should throw an error if the title isn't a string
  #       ✓ should not throw if the title is a string
  #   Runner
  #     .grep()
  #       ✓ should update the runner.total with number of matched tests
  #       ✓ should update the runner.total with number of matched tests when inverted
  #     .grepTotal()
  #       ✓ should return the total number of matched tests
  #       ✓ should return the total number of matched tests when inverted
  #     .globalProps()
  #       ✓ should include common non enumerable globals
  #     .globals()
  #       ✓ should default to the known globals
  #       ✓ should white-list globals
  #     .checkGlobals(test)
  #       ✓ should allow variables that match a wildcard
  #       ✓ should emit "fail" when a new global is introduced
  #       ✓ should emit "fail" when a single new disallowed global is introduced after a single extra global is allowed
  #       ✓ should not fail when a new common global is introduced
  #       ✓ should pluralize the error message when several are introduced
  #       ✓ should respect per test whitelisted globals
  #       ✓ should respect per test whitelisted globals but still detect other leaks
  #       ✓ should emit "fail" when a global beginning with d is introduced
  #     .hook(name, fn)
  #       ✓ should execute hooks after failed test if suite bail is true
  #     .fail(test, err)
  #       ✓ should increment .failures
  #       ✓ should set test.state to "failed"
  #       ✓ should emit "fail"
  #       ✓ should emit a helpful message when failed with a string
  #       ✓ should emit a the error when failed with an Error instance
  #       ✓ should emit the error when failed with an Error-like object
  #       ✓ should emit a helpful message when failed with an Object
  #       ✓ should emit a helpful message when failed with an Array
  #       ✓ should recover if the error stack is not writable
  #     .failHook(hook, err)
  #       ✓ should increment .failures
  #       ✓ should augment hook title with current test title
  #       ✓ should emit "fail"
  #       ✓ should emit "end" if suite bail is true
  #       ✓ should not emit "end" if suite bail is not true
  #     allowUncaught
  #       ✓ should allow unhandled errors to propagate through
  #     stackTrace
  #       shortStackTrace
  #         ✓ should prettify the stack-trace
  #       longStackTrace
  #         ✓ should display the full stack-trace
  #   Runnable(title, fn)
  #     #timeout(ms)
  #       ✓ should set the timeout
  #     #timeout(ms) when ms>2^31
  #       ✓ should set disabled
  #     #enableTimeouts(enabled)
  #       ✓ should set enabled
  #     #slow(ms)
  #       ✓ should set the slow threshold
  #       ✓ should not set the slow threshold if the parameter is not passed
  #       ✓ should not set the slow threshold if the parameter is undefined
  #     .title
  #       ✓ should be present
  #     .titlePath()
  #       ✓ returns the concatenation of the parent's title path and runnable's title
  #     when arity >= 1
  #       ✓ should be .async
  #     when arity == 0
  #       ✓ should be .sync
  #     #globals
  #       ✓ should allow for whitelisting globals
  #     #retries(n)
  #       ✓ should set the number of retries
  #     .run(fn)
  #       when .pending
  #         ✓ should not invoke the callback
  #       when sync
  #         without error
  #           ✓ should invoke the callback
  #         when an exception is thrown
  #           ✓ should invoke the callback
  #         when an exception is thrown and is allowed to remain uncaught
  #           ✓ throws an error when it is allowed
  #       when timeouts are disabled
  #         ✓ should not error with timeout
  #       when async
  #         ✓ should allow updating the timeout (53ms)
  #         - should allow a timeout of 0
  #         without error
  #           ✓ should invoke the callback
  #         when the callback is invoked several times
  #           without an error
  #             ✓ should emit a single "error" event
  #           with an error
  #             ✓ should emit a single "error" event
  #         when an exception is thrown
  #           ✓ should invoke the callback
  #           ✓ should not throw its own exception if passed a non-object
  #         when an exception is thrown and is allowed to remain uncaught
  #           ✓ throws an error when it is allowed
  #         when an error is passed
  #           ✓ should invoke the callback
  #         when done() is invoked with a non-Error object
  #           ✓ should invoke the callback
  #         when done() is invoked with a string
  #           ✓ should invoke the callback
  #       when fn returns a promise
  #         when the promise is fulfilled with no value
  #           ✓ should invoke the callback
  #         when the promise is fulfilled with a value
  #           ✓ should invoke the callback
  #         when the promise is rejected
  #           ✓ should invoke the callback
  #         when the promise is rejected without a reason
  #           ✓ should invoke the callback
  #         when the promise takes too long to settle
  #           ✓ should give the timeout error
  #       when fn returns a non-promise
  #         ✓ should invoke the callback
  #   serial
  #     hooks
  #       ✓ one
  #       ✓ two
  #       ✓ three
  #   serial
  #     nested
  #       ✓ foo
  #       ✓ bar
  #       hooks
  #         ✓ one
  #         ✓ two
  #   async
  #     hooks
  #       ✓ one
  #       ✓ two
  #       ✓ three
  #   durations
  #     when slow
  #       ✓ should highlight in red (101ms)
  #     when reasonable
  #       ✓ should highlight in yellow (50ms)
  #     when fast
  #       ✓ should not highlight
  #   fs.readFile()
  #     when the file exists
  #       ✓ should succeed
  #     when the file does not exist
  #       ✓ should fail
  #   global leaks
  #     ✓ should cause tests to fail
  #     ✓ should pass when accepted
  #     ✓ should pass with wildcard
  #     ✓ should pass when prefixed "mocha-"
  #   timeouts
  #     ✓ should error on timeout
  #     ✓ should allow overriding per-test (50ms)
  #     disabling
  #       ✓ should allow overriding per-test
  #       ✓ should work with timeout(0)
  #       using beforeEach
  #         ✓ should work with timeout(0)
  #       using before
  #         ✓ should work with timeout(0)
  #       using enableTimeouts(false)
  #         ✓ should suppress timeout(4) (51ms)
  #       suite-level
  #         ✓ should work with timeout(0)
  #         nested suite
  #           ✓ should work with timeout(0)
  #   142 passing (578ms)
  #   1 pending
  # done
  # ==> [Test :: Compilers]
  # "bin/mocha" --compilers coffee:coffee-script/register \
  # 	test/compiler
  #   coffeescript
  #     ✓ should work
  #   1 passing (13ms)
  # "bin/mocha" \
  # --compilers foo:./test/compiler-fixtures/foo.fixture \
  # 	test/compiler
  #   custom compiler
  #     ✓ should work
  #   1 passing (8ms)
  # "bin/mocha" \
  # 	--compilers coffee:coffee-script/register,foo:./test/compiler-fixtures/foo.fixture \
  # 	test/compiler
  #   coffeescript
  #     ✓ should work
  #   custom compiler
  #     ✓ should work
  #   2 passing (13ms)
  # ==> [Test :: Requires]
  # "bin/mocha" --compilers coffee:coffee-script/register \
  # 	--require test/require/a.js \
  # 	--require test/require/b.coffee \
  # 	--require test/require/c.js \
  # 	--require test/require/d.coffee \
  # 	test/require/require.spec.js
  #   require test
  #     ✓ should require args in order
  #   1 passing (16ms)
  # ==> [Test :: Reporters]
  # "bin/mocha" test/reporters/*.spec.js
  #   Base reporter
  #     showDiff
  #     Getting two strings
  #     Inline strings diff
  #     unified diff reporter
  #   Doc reporter
  #     on suite
  #       if suite root does not exist
  #         ✓ should log html with indents and expected title
  #         ✓ should escape title where necessary
  #       if suite root does exist
  #         ✓ should not log any html
  #     on suite end
  #       if suite root does not exist
  #         ✓ should log expected html with indents
  #       if suite root does exist
  #         ✓ should not log any html
  #     on pass
  #       ✓ should log html with indents and expected title and body
  #       ✓ should escape title and body where necessary
  #     on fail
  #       ✓ should log html with indents and expected title, body and error
  #       ✓ should escape title, body and error where necessary
  #   Dot reporter
  #     on start
  #       ✓ should return a new line
  #     on pending
  #       if window width is greater than 1
  #         ✓ should return a new line and then a coma
  #       if window width is equal to or less than 1
  #         ✓ should return a coma
  #     on pass
  #       if window width is greater than 1
  #         if test speed is fast
  #           ✓ should return a new line and then a dot
  #       if window width is equal to or less than 1
  #         if test speed is fast
  #           ✓ should return a dot
  #         if test speed is slow
  #           ✓ should return a dot
  #     on fail
  #       if window width is greater than 1
  #         ✓ should return a new line and then an exclamation mark
  #       if window width is equal to or less than 1
  #         ✓ should return an exclamation mark
  #     on end
  #       ✓ should call the epilogue
  #   json reporter
  # {
  #   "stats": {
  #     "suites": 1,
  #     "tests": 1,
  #     "passes": 0,
  #     "pending": 0,
  #     "failures": 1,
  #     "start": "2017-12-12T18:04:24.246Z",
  #     "end": "2017-12-12T18:04:24.250Z",
  #     "duration": 4
  #   },
  #   "tests": [
  #     {
  #       "title": "json test 1",
  #       "fullTitle": "JSON suite json test 1",
  #       "duration": 1,
  #       "currentRetry": 0,
  #       "err": {
  #         "stack": "Error: oh shit\n    at Object.<anonymous> (test/reporters/json.spec.js:26:12)\n    at callFnAsync (lib/runnable.js:377:21)\n    at Test.Runnable.run (lib/runnable.js:324:7)\n    at Runner.runTest (lib/runner.js:442:10)\n    at lib/runner.js:560:12\n    at next (lib/runner.js:356:14)\n    at lib/runner.js:366:7\n    at next (lib/runner.js:290:14)\n    at Immediate._onImmediate (lib/runner.js:334:5)",
  #         "message": "oh shit"
  #       }
  #     }
  #   ],
  #   "pending": [],
  #   "failures": [
  #     {
  #       "title": "json test 1",
  #       "fullTitle": "JSON suite json test 1",
  #       "duration": 1,
  #       "currentRetry": 0,
  #       "err": {
  #         "stack": "Error: oh shit\n    at Object.<anonymous> (test/reporters/json.spec.js:26:12)\n    at callFnAsync (lib/runnable.js:377:21)\n    at Test.Runnable.run (lib/runnable.js:324:7)\n    at Runner.runTest (lib/runner.js:442:10)\n    at lib/runner.js:560:12\n    at next (lib/runner.js:356:14)\n    at lib/runner.js:366:7\n    at next (lib/runner.js:290:14)\n    at Immediate._onImmediate (lib/runner.js:334:5)",
  #         "message": "oh shit"
  #       }
  #     }
  #   ],
  #   "passes": []
  # }    ✓ should have 1 test failure
  # {
  #   "stats": {
  #     "suites": 1,
  #     "tests": 1,
  #     "passes": 0,
  #     "pending": 1,
  #     "failures": 0,
  #     "start": "2017-12-12T18:04:24.255Z",
  #     "end": "2017-12-12T18:04:24.256Z",
  #     "duration": 1
  #   },
  #   "tests": [
  #     {
  #       "title": "json test 1",
  #       "fullTitle": "JSON suite json test 1",
  #       "currentRetry": 0,
  #       "err": {}
  #     }
  #   ],
  #   "pending": [
  #     {
  #       "title": "json test 1",
  #       "fullTitle": "JSON suite json test 1",
  #       "currentRetry": 0,
  #       "err": {}
  #     }
  #   ],
  #   "failures": [],
  #   "passes": []
  # }    ✓ should have 1 test pending
  #   Json Stream reporter
  #     on start
  #       ✓ should write stringified start with expected total
  #     on pass
  #       ✓ should write stringified test data
  #     on fail
  #       if error stack exists
  #         ✓ should write stringified test data with error data
  #       if error stack does not exist
  #         ✓ should write stringified test data with error data
  #     on end
  #       ✓ should write end details
  #   Landing reporter
  #     on start
  #       ✓ should write new lines
  #       ✓ should call cursor hide
  #     on test end
  #       if test has failed
  #         ✓ should write expected landing strip
  #       if test has not failed
  #         ✓ should write expected landing strip
  #     on end
  #       ✓ should call cursor show and epilogue
  #   List reporter
  #     on start and test
  #       ✓ should write expected new line and title to the console
  #     on pending
  #       ✓ should write expected title to the console
  #     on pass
  #       ✓ should call cursor CR
  #       OK should write expected symbol, title and duration to the console
  #     on fail
  #       OK should call cursor CR
  #       OK should write expected error number and title
  #     on end
  #       OK should call epilogue
  #   Markdown reporter
  #     on 'suite'
  #       OK should write expected slugged titles on 'end' event
  #     on 'pass'
  #       OK should write test code inside js code block, on 'end' event
  #   Min reporter
  #     on start
  #       OK should clear screen then set cursor position
  #     on end
  #       OK should call epilogue
  #   Nyan reporter
  #     events
  #       on start
  #         OK should call draw
  #       on pending
  #         OK should call draw
  #       on pass
  #         OK should call draw
  #       on fail
  #         OK should call draw
  #       on end
  #         OK should call epilogue
  #         OK should write numberOfLines amount of new lines
  #         OK should call Base show
  #     draw
  #       if tick is false
  #         OK should draw face with expected spaces, _ and ^
  #       if tick is true
  #         OK should draw face with expected spaces, _ and ~
  #     cursorDown
  #       OK should write cursor down interaction with expected number
  #     cursorUp
  #       OK should write cursor up interaction with expected number
  #     rainbowify
  #       useColors is false
  #         OK should return argument string
  #       useColors is true
  #       [32m  OK[0m[90m should return rainbowified string from the given string and predefined codes[0m
  #     appendRainbow
  #       if tick is true
  #         OK should set an _ segment
  #         OK should shift each trajectory item, if its length is greater of equal to its max width
  #       if tick is false
  #         OK should set an - segment
  #     drawScoreboard
  #       OK should write scoreboard with color set with each stat
  #       OK should call cursorUp with given numberOfLines
  #     drawRainbow
  #       OK should write width, contents and newline for each trajectory
  #       OK should call cursorUp with given numberOfLines
  #     face
  #       OK expected face:(x .x) when "failures" at least one
  #       OK expected face:(x .x) when "pending" at least one and no failing
  #       OK expected face:(^ .^) when "passing" only
  #       OK expected face:(- .-) when otherwise
  #   Progress reporter
  #     on start
  #       OK should call cursor hide
  #     on test end
  #       if line has not changed
  #         OK should return and not write anything
  #       if line has changed
  #         OK should write expected progress of open and close options
  #     on end
  #       OK should call cursor show and epilogue
  #   Spec reporter
  #     on suite
  #       OK should return title
  #     on pending
  #       OK should return title
  #     on pass
  #       if test speed is slow
  #         OK should return expected tick, title and duration
  #       if test speed is fast
  #         OK should return expected tick, title and without a duration
  #     on fail
  #       OK should return title and function count
  #   TAP reporter
  #     on start
  #       OK should hand runners suite into grepTotal and log the total
  #     on pending
  #       OK should write expected message including count and title
  #     on pass
  #       OK should write expected message including count and title
  #     on fail
  #       if there is an error stack
  #         OK should write expected message and stack
  #       if there is no error stack
  #         OK should write expected message only
  #     on end
  #       OK should write total tests, passes and failures
  #   XUnit reporter
  #     if reporter options output is given
  #       but it cant create a write stream
  #         OK should throw expected error
  #       and it can create a write stream
  #         OK should locate the output dir, create it, then assign as fileStream
  #     on 'pending', 'pass' and 'fail' events
  #       OK should add test to tests called on 'end' event
  #     done
  #       if fileStream is truthly
  #         OK should run callback with failure inside streams end
  #       if fileStream is falsy
  #         OK should run callback with failure
  #     write
  #       if fileStream is truthly
  #         OK should call fileStream write with line and new line
  #       if fileStream is falsy and stdout exists
  #         OK should call write with line and new line
  #       if fileStream is falsy and stdout does not exist
  #         OK should call write with line
  #     test
  #       on test failure
  #         OK should write expected tag with error details
  #       on test pending
  #         OK should write expected tag
  #       on test in any other state
  #         OK should write expected tag
  #     custom suite name
  #       OK should use "Mocha Tests" as the suite name if no custom name is provided
  #       OK should use the custom suite name as the suite name when provided in the reporter options
  #   109 passing (156ms)
  # ==> [Test :: Only]
  # "bin/mocha" --ui tdd \
  # 	test/only/tdd.spec
  #   ✓ #Root-Suite, should run this test-case #1
  #   ✓ #Root-Suite, should run this test-case #2
  #   2 passing (11ms)
  # "bin/mocha" --ui bdd \
  # 	test/only/bdd.spec
  #   ✓ #Root-Suite, should run this test-case #1
  #   ✓ #Root-Suite, should run this test-case #2
  #   2 passing (12ms)
  # "bin/mocha" --ui qunit \
  # 	test/only/bdd-require.spec
  #   it.only via require("mocha")
  #     nested within a describe/context
  #       ✓ should run all enclosing beforeEach hooks
  #   1 passing (10ms)
  # ==> [Test :: Global Only]
  # "bin/mocha" --ui tdd \
  # 	test/only/global/tdd.spec
  #   ✓ #Root-Suite, should run this tdd test-case #1
  #   1 passing (11ms)
  # "bin/mocha" --ui bdd \
  # 	test/only/global/bdd.spec
  #   ✓ #Root-Suite, should run this bdd test-case #1
  #   1 passing (10ms)
  # "bin/mocha" --ui qunit \
  # 	test/only/global/qunit.spec
  #   ✓ #Root-Suite, should run this qunit test-case #1
  #   1 passing (11ms)
  # ==> [Clean]
  # rm -f mocha.js
  # ==> [Browser :: build]
  # mkdir -p .
  # "node_modules/.bin/browserify" ./browser-entry \
  # 	--require buffer/:buffer \
  # 	--plugin ./scripts/dedefine \
  # 	--ignore 'fs' \
  # 	--ignore 'glob' \
  # 	--ignore 'path' \
  # 	--ignore 'supports-color' > mocha.js
  # ==> [Test :: Browser]
  # NODE_PATH=. "node_modules/.bin/karma" start --single-run
  # START:
  # [32m12 12 2017 18:04:33.790:INFO [framework.browserify]: [39mbundle built
  # [32m12 12 2017 18:04:33.806:INFO [karma]: [39mKarma v1.7.1 server started at http://0.0.0.0:9876/
  # [32m12 12 2017 18:04:33.807:INFO [launcher]: [39mLaunching browser PhantomJS with unlimited concurrency
  # [32m12 12 2017 18:04:33.812:INFO [launcher]: [39mStarting browser PhantomJS
  # [31m12 12 2017 18:04:33.941:ERROR [phantomjs.launcher]: [39mAuto configuration failed
  # 139797356906304:error:060B10A7:digital envelope routines:ALG_MODULE_INIT:fips mode not supported:evp_cnf.c:106:
  # 139797356906304:error:0E07606D:configuration file routines:MODULE_RUN:module initialization error:conf_mod.c:235:module=alg_section, value=evp_sect, retcode=-1      
  # [31m12 12 2017 18:04:33.944:ERROR [launcher]: [39mCannot start PhantomJS
  # 	Auto configuration failed
  # 139797356906304:error:060B10A7:digital envelope routines:ALG_MODULE_INIT:fips mode not supported:evp_cnf.c:106:
  # 139797356906304:error:0E07606D:configuration file routines:MODULE_RUN:module initialization error:conf_mod.c:235:module=alg_section, value=evp_sect, retcode=-1      
  # [31m12 12 2017 18:04:33.944:ERROR [launcher]: [39mPhantomJS stdout: 
  # [31m12 12 2017 18:04:33.944:ERROR [launcher]: [39mPhantomJS stderr: Auto configuration failed
  # 139797356906304:error:060B10A7:digital envelope routines:ALG_MODULE_INIT:fips mode not supported:evp_cnf.c:106:
  # 139797356906304:error:0E07606D:configuration file routines:MODULE_RUN:module initialization error:conf_mod.c:235:module=alg_section, value=evp_sect, retcode=-1      
  # [32m12 12 2017 18:04:33.949:INFO [launcher]: [39mTrying to start PhantomJS again (1/2).
  # [31m12 12 2017 18:04:33.979:ERROR [phantomjs.launcher]: [39mAuto configuration failed
  # 139980760930112:error:060B10A7:digital envelope routines:ALG_MODULE_INIT:fips mode not supported:evp_cnf.c:106:
  # 139980760930112:error:0E07606D:configuration file routines:MODULE_RUN:module initialization error:conf_mod.c:235:module=alg_section, value=evp_sect, retcode=-1      
  # [31m12 12 2017 18:04:33.980:ERROR [launcher]: [39mCannot start PhantomJS
  # 	Auto configuration failed
  # 139980760930112:error:060B10A7:digital envelope routines:ALG_MODULE_INIT:fips mode not supported:evp_cnf.c:106:
  # 139980760930112:error:0E07606D:configuration file routines:MODULE_RUN:module initialization error:conf_mod.c:235:module=alg_section, value=evp_sect, retcode=-1      
  # [31m12 12 2017 18:04:33.980:ERROR [launcher]: [39mPhantomJS stdout: 
  # [31m12 12 2017 18:04:33.980:ERROR [launcher]: [39mPhantomJS stderr: Auto configuration failed
  # 139980760930112:error:060B10A7:digital envelope routines:ALG_MODULE_INIT:fips mode not supported:evp_cnf.c:106:
  # 139980760930112:error:0E07606D:configuration file routines:MODULE_RUN:module initialization error:conf_mod.c:235:module=alg_section, value=evp_sect, retcode=-1      
  # [32m12 12 2017 18:04:33.981:INFO [launcher]: [39mTrying to start PhantomJS again (2/2).
  # [31m12 12 2017 18:04:34.009:ERROR [phantomjs.launcher]: [39mAuto configuration failed
  # 140563732670272:error:060B10A7:digital envelope routines:ALG_MODULE_INIT:fips mode not supported:evp_cnf.c:106:
  # 140563732670272:error:0E07606D:configuration file routines:MODULE_RUN:module initialization error:conf_mod.c:235:module=alg_section, value=evp_sect, retcode=-1      
  # [31m12 12 2017 18:04:34.010:ERROR [launcher]: [39mCannot start PhantomJS
  # 	Auto configuration failed
  # 140563732670272:error:060B10A7:digital envelope routines:ALG_MODULE_INIT:fips mode not supported:evp_cnf.c:106:
  # 140563732670272:error:0E07606D:configuration file routines:MODULE_RUN:module initialization error:conf_mod.c:235:module=alg_section, value=evp_sect, retcode=-1      
  # [31m12 12 2017 18:04:34.010:ERROR [launcher]: [39mPhantomJS stdout: 
  # [31m12 12 2017 18:04:34.010:ERROR [launcher]: [39mPhantomJS stderr: Auto configuration failed
  # 140563732670272:error:060B10A7:digital envelope routines:ALG_MODULE_INIT:fips mode not supported:evp_cnf.c:106:
  # 140563732670272:error:0E07606D:configuration file routines:MODULE_RUN:module initialization error:conf_mod.c:235:module=alg_section, value=evp_sect, retcode=-1      
  # [31m12 12 2017 18:04:34.011:ERROR [launcher]: [39mPhantomJS failed 2 times (cannot start). Giving up.
  # Finished in 0 secs / 0 secs @ 18:04:34 GMT+0000 (GMT)
  # Makefile:46: recipe for target 'test-browser-unit' failed
  # An error occured. { [Error: spawn notify-send ENOENT]
  #   code: 'ENOENT',
  #   errno: 'ENOENT',
  #   syscall: 'spawn notify-send',
  #   path: 'notify-send',
  #   spawnargs: 
  #    [ '-i',
  #      '/svt/jenkins/workspace/SVT-V4-COMMUNITY-CITGM-FIPS/ARCH/x64/GCC/gcc48/OS/sles12/TAG/svt/tmp/d607f45e-75fa-4271-934c-6ec0530dc168/mocha/images/ok.png',
  #      '--hint=int:transient:1',
  #      'Passed',
  #      '',
  #      '273 tests passed in 1211ms' ] }
  # An error occured. { [Error: spawn notify-send ENOENT]
  #   code: 'ENOENT',
  #   errno: 'ENOENT',
  #   syscall: 'spawn notify-send',
  #   path: 'notify-send',
  #   spawnargs: 
  #    [ '-i',
  #      '/svt/jenkins/workspace/SVT-V4-COMMUNITY-CITGM-FIPS/ARCH/x64/GCC/gcc48/OS/sles12/TAG/svt/tmp/d607f45e-75fa-4271-934c-6ec0530dc168/mocha/images/ok.png',
  #      '--hint=int:transient:1',
  #      'Passed',
  #      '',
  #      '142 tests passed in 578ms' ] }
  # "--compilers" will be removed in a future version of Mocha; see https://git.io/vdcSr for more info
  # "--compilers" will be removed in a future version of Mocha; see https://git.io/vdcSr for more info
  # "--compilers" will be removed in a future version of Mocha; see https://git.io/vdcSr for more info
  # "--compilers" will be removed in a future version of Mocha; see https://git.io/vdcSr for more info
  # CI mode disabled
  # make: *** [test-browser-unit] Error 1
  # npm ERR! Test failed.  See above for more details.
  duration_ms: 137733
```

</details><br>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
