### PR TITLE
lookup: serialport is not expected to fail on fips

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -306,7 +306,6 @@
   "serialport": {
     "prefix": "v",
     "flaky": ["ppc", "win32"],
-    "expectFail": "fips",
     "tags": "native",
     "maintainers": "reconbot"
   },


### PR DESCRIPTION
I have been seeing a failure on fips, suggesting that it should have failed:
```
not ok 65 - serialport v6.0.4 this module should have failed
```

Since `npm test` passes fine on fips, I suggest not expecting a failure.

<details><summary><code>npm test</code> pass</summary>

```
$ npm test

> serialport@6.0.4 test /home/alk/node-serialport
> istanbul cover ./node_modules/mocha/bin/_mocha

Transformation error; return original code
[Error: error:060A80A3:digital envelope routines:FIPS_DIGESTINIT:disabled for fips]
Transformation error; return original code
[Error: error:060A80A3:digital envelope routines:FIPS_DIGESTINIT:disabled for fips]
Transformation error; return original code
[Error: error:060A80A3:digital envelope routines:FIPS_DIGESTINIT:disabled for fips]
Transformation error; return original code
[Error: error:060A80A3:digital envelope routines:FIPS_DIGESTINIT:disabled for fips]
Transformation error; return original code
[Error: error:060A80A3:digital envelope routines:FIPS_DIGESTINIT:disabled for fips]
Transformation error; return original code
[Error: error:060A80A3:digital envelope routines:FIPS_DIGESTINIT:disabled for fips]
Transformation error; return original code
[Error: error:060A80A3:digital envelope routines:FIPS_DIGESTINIT:disabled for fips]
Transformation error; return original code
[Error: error:060A80A3:digital envelope routines:FIPS_DIGESTINIT:disabled for fips]
Transformation error; return original code
[Error: error:060A80A3:digital envelope routines:FIPS_DIGESTINIT:disabled for fips]
Transformation error; return original code
[Error: error:060A80A3:digital envelope routines:FIPS_DIGESTINIT:disabled for fips]
Transformation error; return original code
[Error: error:060A80A3:digital envelope routines:FIPS_DIGESTINIT:disabled for fips]
Transformation error; return original code
[Error: error:060A80A3:digital envelope routines:FIPS_DIGESTINIT:disabled for fips]
Transformation error; return original code
[Error: error:060A80A3:digital envelope routines:FIPS_DIGESTINIT:disabled for fips]
Transformation error; return original code
[Error: error:060A80A3:digital envelope routines:FIPS_DIGESTINIT:disabled for fips]
Transformation error; return original code
[Error: error:060A80A3:digital envelope routines:FIPS_DIGESTINIT:disabled for fips]
Transformation error; return original code
[Error: error:060A80A3:digital envelope routines:FIPS_DIGESTINIT:disabled for fips]
Transformation error; return original code
[Error: error:060A80A3:digital envelope routines:FIPS_DIGESTINIT:disabled for fips]
Transformation error; return original code
[Error: error:060A80A3:digital envelope routines:FIPS_DIGESTINIT:disabled for fips]
Transformation error; return original code
[Error: error:060A80A3:digital envelope routines:FIPS_DIGESTINIT:disabled for fips]
Transformation error; return original code
[Error: error:060A80A3:digital envelope routines:FIPS_DIGESTINIT:disabled for fips]


  listLinux
    ✓ lists available serialports

  serialNumParser
    ✓ parses pnp id for FTDI Device
    ✓ parses pnp id for Arduino Mega
    ✓ parses pnp id for Atlas Scientific EZO-RGB Sensor
    ✓ parses pnp id for Gearmo FTDI2-LED USB RS-232 Serial Adapter
    ✓ parses pnp id for Arducam Nano V3.0 (Arduino Nano with FTDI)
    ✓ parses pnp id for Pretend Device with an unknown pnp id

  bindings/mock
    static method
      .list
        ✓ returns an array
        ✓ has objects with undefined when there is no data
    constructor
      ✓ creates a binding object
      ✓ throws when not given an options object
    instance property
      #isOpen
        ✓ is true after open and false after close
    instance method
      #open
        ✓ errors when providing a bad port
        ✓ throws when not given a path
        ✓ throws when not given options
        ✓ cannot open if already open
        ✓ keeps open state
        ✓ supports a custom baudRate of 25000
        ✓ supports a custom baudRate of 1000000
        ✓ supports a custom baudRate of 1000000
        optional locking
          ✓ locks the port by default
          ✓ can unlock the port
      #close
        ✓ errors when already closed
        ✓ closes an open file descriptor
      #update
        ✓ throws when not given an object
        ✓ errors asynchronously when not open
        ✓ throws errors when updating nothing
        ✓ errors when not called with options
        ✓ updates baudRate
      #write
        ✓ errors asynchronously when not open
        ✓ throws when not given a buffer
        ✓ resolves after a small write
        ✓ resolves after a large write (2k)
      #drain
        ✓ errors asynchronously when not open
        ✓ drains the port
        ✓ waits for in progress writes to finish
      #flush
        ✓ errors asynchronously when not open
        ✓ flushes the port
      #set
        ✓ errors asynchronously when not open
        ✓ throws when not called with options
        ✓ sets flags on the port
      #read
        ✓ errors asynchronously when not open
        ✓ doesn't throw if the port is open
        ✓ returns at maximum the requested number of bytes
      #get
        ✓ errors asynchronously when not open
        ✓ gets modem line status from the port

  bindings/linux
    static method
      .list
        ✓ returns an array (81ms)
        ✓ has objects with undefined when there is no data (54ms)
    constructor
      ✓ creates a binding object
      ✓ throws when not given an options object
    instance property
      #isOpen
        - Cannot be tested. Set the TEST_PORT env var with an available serialport for more testing.
    instance method
      #open
        ✓ errors when providing a bad port
        ✓ throws when not given a path
        ✓ throws when not given options
        - Cannot be tested further. Set the TEST_PORT env var with an available serialport for more testing.
      #close
        ✓ errors when already closed
        - Cannot be tested further. Set the TEST_PORT env var with an available serialport for more testing.
      #update
        ✓ throws when not given an object
        ✓ errors asynchronously when not open
        - Cannot be tested further. Set the TEST_PORT env var with an available serialport for more testing.
      #write
        ✓ errors asynchronously when not open
        ✓ throws when not given a buffer
        - Cannot be tested as we have no test ports on linux
      #drain
        ✓ errors asynchronously when not open
        - Cannot be tested further. Set the TEST_PORT env var with an available serialport for more testing.
      #flush
        ✓ errors asynchronously when not open
        - Cannot be tested further. Set the TEST_PORT env var with an available serialport for more testing.
      #set
        ✓ errors asynchronously when not open
        ✓ throws when not called with options
        - Cannot be tested further. Set the TEST_PORT env var with an available serialport for more testing.
      #read
        ✓ errors asynchronously when not open
        - Cannot be tested further. Set the TEST_PORT env var with an available serialport for more testing.
      #get
        ✓ errors asynchronously when not open
        - Cannot be tested further. Set the TEST_PORT env var with an available serialport for more testing.

  mock SerialPort Integration Tests
    static Method
      .list
        ✓ contains the test port
    constructor
      ✓ provides an error in callback when trying to open an invalid port
      ✓ emits an error event when trying to open an invalid port
    opening and closing
      ✓ can open and close
      ✓ cannot be opened again after open
      ✓ cannot be opened while opening
      ✓ can open and close ports repetitively
      ✓ can be read after closing and opening
      ✓ errors if closing during a write
    #update
      ✓ allows changing the baud rate of an open port
    #read and #write
      ✓ 2k test
    #flush
      ✓ discards any received data
      ✓ deals with flushing during a read
    #drain
      ✓ waits for in progress or queued writes to finish

  linux SerialPort Integration Tests
    - linux tests requires an Arduino loaded with the arduinoEcho program on a serialport set to the TEST_PORT env var

  ByteLengthParser
    ✓ emits data events every 8 bytes
    ✓ throws when not provided with a length
    ✓ throws when length is zero
    ✓ throws when called with a non numeric length
    ✓ continues looking for bytes in additional writes
    ✓ flushes remaining data when the stream ends

  CCTalkParser
    ✓ emits data for a default length message
    ✓ emits data for a 7 byte length message
    ✓ emits 2 times data first length 7 secund length 5

  DelimiterParser
    ✓ transforms data to strings split on a delimiter
    ✓ flushes remaining data when the stream ends
    ✓ throws when not provided with a delimiter
    ✓ throws when called with a 0 length delimiter
    ✓ allows setting of the delimiter with a string
    ✓ allows setting of the delimiter with a buffer
    ✓ allows setting of the delimiter with an array of bytes
    ✓ emits data events every time it meets 00x 00x
    ✓ accepts single byte delimiter
    ✓ Works when buffer starts with delimiter
    ✓ should only emit if delimiters are strictly in row
    ✓ continues looking for delimiters in the next buffers

  ReadlineParser
    ✓ transforms data to strings split on a delimiter
    ✓ allows setting of the delimiter with a string
    ✓ allows setting of the delimiter with a buffer
    ✓ allows setting of the delimiter with an array of bytes
    ✓ allows setting of encoding
    ✓ encoding should be reflected in a string delimiter
    ✓ throws when called with a 0 length delimiter
    ✓ allows setting of the delimiter with a string
    ✓ allows setting of the delimiter with a buffer
    ✓ allows setting of the delimiter with an array of bytes
    ✓ doesn't emits empty data events

  ReadyParser
    ✓ emits data received after the ready data
    ✓ emits the ready event before the data event
    ✓ has a ready property
    ✓ throws when not provided with a delimiter
    ✓ throws when called with a 0 length delimiter
    ✓ allows setting of the delimiter with a string
    ✓ allows setting of the delimiter with a buffer
    ✓ allows setting of the delimiter with an array of bytes
    ✓ allows receiving the delimiter over small writes

  RegexParser
    ✓ transforms data to strings split on either carriage return or new line
    ✓ flushes remaining data when the stream ends
    ✓ throws when not provided with a regex
    ✓ throws when called with an invalid regex expression
    ✓ allows setting of the regex with a regex string
    ✓ allows setting of the regex with a buffer
    ✓ allows setting of encoding
    ✓ Works when buffer starts with regex regex
    ✓ should match unicode in buffer string
    ✓ continues looking for regexs in the next buffers
    ✓ doesn't emits empty data events

  SerialPort
    constructor
      ✓ provides auto construction
      ✓ passes the error to the callback when an bad port is provided
      ✓ emits an error when an bad port is provided
      ✓ throws an error when bindings are missing
      ✓ throws an error when no port is provided
      ✓ throws an error when given bad options even with a callback
      ✓ throws an error when given bad baudrate even with a callback
      ✓ errors with a non number baudRate
      ✓ errors with invalid databits
      ✓ errors with invalid stopbits
      ✓ errors with invalid parity
      ✓ errors with invalid flow control
      ✓ sets valid flow control individually
      ✓ allows optional options
      autoOpen
        ✓ opens the port automatically
        ✓ emits the open event
        ✓ doesn't open if told not to
    static methods
      ✓ calls to the bindings
      ✓ errors if there are no bindings
    property
      .baudRate
        ✓ is a read only property set during construction
      .path
        ✓ is a read only property set during construction
      .isOpen
        ✓ is a read only property
        ✓ returns false when the port is created
        ✓ returns false when the port is opening
        ✓ returns true when the port is open
        ✓ returns false when the port is closing
        ✓ returns false when the port is closed
    instance method
      #open
        ✓ passes the port to the bindings
        ✓ passes default options to the bindings
        ✓ calls back an error when opening an invalid port
        ✓ emits data after being reopened
        ✓ cannot be opened again after open
        ✓ cannot be opened while opening
        ✓ allows opening after an open error
      #write
        ✓ writes to the bindings layer
        ✓ converts strings to buffers
        ✓ converts strings with encodings to buffers
        ✓ converts arrays to buffers
        ✓ queues writes when the port is closed
        ✓ combines many writes into one
      #close
        ✓ emits a close event
        ✓ has a close callback
        ✓ emits the close event and runs the callback
        ✓ emits an error event or error callback but not both
        ✓ fires a close event after being reopened
        ✓ errors when the port is not open
        ✓ handles errors in callback
        ✓ handles errors in event
      #update
        ✓ errors when the port is not open
        ✓ errors when called without options
        ✓ sets the baudRate on the port
        ✓ handles errors in callback
        ✓ handles errors in event
      #set
        ✓ errors when serialport not open
        ✓ errors without an options object
        ✓ sets the flags on the ports bindings
        ✓ sets missing options to default values
        ✓ resets all flags if none are provided
        ✓ handles errors in callback
        ✓ handles errors in event
      #flush
        ✓ errors when serialport not open
        ✓ calls flush on the bindings
        ✓ handles errors in callback
        ✓ handles errors in event
      #drain
        ✓ waits for an open port
        ✓ calls drain on the bindings
        ✓ handles errors in callback
        ✓ handles errors in event
        ✓ waits for in progress or queued writes to finish
      #get
        ✓ errors when serialport not open
        ✓ gets the status from the ports bindings
        ✓ handles errors in callback
        ✓ handles errors in event
    reading data
      ✓ emits data events by default
    disconnect close errors
      ✓ emits as a disconnected close event on a bad read


  205 passing (474ms)
  11 pending
```

</details>

##### Checklist

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
