### PR TITLE
WIP deps: downgrade tar to 3.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "semver": "^5.0.1",
     "strip-ansi": "^4.0.0",
     "supports-color": "^5.0.0",
-    "tar": "^4.1.1",
+    "tar": "3.0.9",
     "uid-number": "0.0.6",
     "update-notifier": "^2.1.0",
     "uuid": "^3.0.0",


### PR DESCRIPTION
As discussed in #525, we will downgrade tar to 3.0.9 until we can find
a fix for AIX

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
