### PR TITLE
lookup: skip fs-extra on >=8

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -75,6 +75,7 @@
   },
   "fs-extra": {
     "flaky": ["linux-ia32", "aix", "s390", "win32"],
+    "skip": ">=8",
     "expectFail": "fips",
     "maintainers": "jprichardson"
   },


### PR DESCRIPTION
oh no!
  
fs-extra is busted on 8.x+ rn