### PR TITLE
upgrade tar

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "semver": "^5.0.1",
     "strip-ansi": "^4.0.0",
     "supports-color": "^5.0.0",
-    "tar": "^3.2.1",
+    "tar": "^4.3.1",
     "uid-number": "0.0.6",
     "update-notifier": "^2.1.0",
     "uuid": "^3.0.0",


### PR DESCRIPTION
Fixes: https://github.com/nodejs/citgm/issues/525

Ran citgm on aix machine with a new version of tar and  got it to  pass.

```shell
$ ./bin/citgm.js express
info:    starting            | express             
info:    lookup              | express             
info:    lookup-found        | express             
info:    express lookup-replace| https://github.com/expressjs/express/archive/351396f971280ab79faddcf9782ea50f4e88358d.tar.gz
info:    express npm:        | Downloading project: https://github.com/expressjs/express/archive/351396f971280ab79faddcf9782ea50f4e88358d.tar.gz
info:    express npm:        | Project downloaded express-4.16.2.tgz
info:    express npm:        | npm install started 
info:    express npm:        | npm install successfully completed
info:    express npm:        | test suite started  
info:    passing module(s)   |                     
info:    module name:        | express             
info:    version:            | 4.16.2              
info:    done                | The smoke test has passed.
info:    duration            | test duration: 45304ms
```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
