### PR TITLE
lookup: unmark node-report as flaky

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -427,7 +427,6 @@
   },
   "node-report": {
     "prefix": "v",
-    "flaky": "win32",
     "tags": "native",
     "maintainers": ["rnchamberlain", "richardlau"]
   },


### PR DESCRIPTION
I'm on a tablet at the moment so can't test locally but I don't believe node-report tests should be flaky on Windows. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
