### PR TITLE
lookup: skip browserify <=8

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -116,6 +116,7 @@
   },
   "browserify": {
     "flaky": [">=v8", "win32"],
+    "skip": "<=v8",
     "expectFail": "fips",
     "maintainers": "substack"
   },


### PR DESCRIPTION
tests require async/await:

```
error:                       | 1..120                                                                                                    
error:                       | # failed 1 of 120 tests                                                                                   
error:                       | # skip: 1                                                                                                 
error:                       | # time=78898.158ms                                                                                        
error:                       |                                                                                                           
error:                       | # async/await unsupported in this environment                                                             
error:                       | npm ERR! Test failed.  See above for more details.                                                        
error:   done                | The smoke test has failed.
info:    duration            | test duration: 112751ms
```


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
