### PR TITLE
lookup: skip spdy-transport

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -217,7 +217,7 @@
   },
   "spdy-transport": {
     "prefix": "v",
-    "skip": "win32",
+    "skip": [">9", "win32"],
     "flaky": "aix",
     "maintainers": "diasdavid"
   },


### PR DESCRIPTION
The module is broken due removing the `noAssert` argument in
the Buffer module.

This disable running it for versions > 9. The maintainers got
contacted and an issue opened.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
