### PR TITLE
lookup: zeromq override MSBUILD version

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -332,7 +332,10 @@
     "prefix": "v",
     "tags": "native",
     "maintainers": ["lgeiger", "rgbkrk"],
-    "skip": ["s390", "ppc"]
+    "skip": ["s390", "ppc"],
+    "envVar": {
+      "npm_config_msvs_version": 2015
+    }
   },
   "bcrypt": {
     "prefix": "v",


### PR DESCRIPTION
This is failing for a while - https://github.com/zeromq/zeromq.js/issues/231
 
This is not an actual fix more of a workaround while this is not fix. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
