### PR TITLE
lookup: skip sax and semver on win32

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -222,6 +222,7 @@
     "maintainers": "diasdavid"
   },
   "sax": {
+    "skip": "win32",
     "prefix": "v",
     "expectFail": "fips",
     "maintainers": "isaacs"
@@ -295,6 +296,7 @@
     "maintainers": ["bcoe", "addaleax"]
   },
   "semver": {
+    "skip": "win32",
     "prefix": "v",
     "maintainers": "isaacs",
     "expectFail": "fips"


### PR DESCRIPTION
Both of those packages depend on older tap, which is broken on Windows (see https://github.com/tapjs/node-tap/issues/373). Skip those two packages on Windows, until tap version is updated.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
