### PR TITLE
WIP: add --lkgr and --ulkgr options

### DIFF
--- a/bin/citgm-all.js
+++ b/bin/citgm-all.js
@@ -39,10 +39,10 @@ const yargs = commonArgs(require('yargs'))
     type: 'array',
     description: 'Define which tags from the lookup to skip'
   })
-  .option('latest-know-good-release', {
+  .option('last-know-good-release', {
     alias: 'lkgr',
     type: 'boolean',
-    description: 'Latest know good release'
+    description: 'Uses last know good release'
   });
 
 const app = yargs.argv;

--- a/bin/citgm-all.js
+++ b/bin/citgm-all.js
@@ -38,6 +38,11 @@ const yargs = commonArgs(require('yargs'))
   .option('excludeTags', {
     type: 'array',
     description: 'Define which tags from the lookup to skip'
+  })
+  .option('latest-know-good-release', {
+    alias: 'lkgr',
+    type: 'boolean',
+    description: 'Latest know good release'
   });
 
 const app = yargs.argv;
@@ -65,6 +70,7 @@ const options = {
   npmLevel: app.npmLoglevel,
   timeoutLength: app.timeout,
   tmpDir: app.tmpDir,
+  lkgr: app.lkgr,
   includeTags: app.includeTags || [],
   excludeTags: app.excludeTags || []
 };

--- a/bin/citgm-all.js
+++ b/bin/citgm-all.js
@@ -39,10 +39,15 @@ const yargs = commonArgs(require('yargs'))
     type: 'array',
     description: 'Define which tags from the lookup to skip'
   })
-  .option('last-know-good-release', {
+  .option('last-known-good-release', {
     alias: 'lkgr',
     type: 'boolean',
-    description: 'Uses last know good release'
+    description: 'Uses last known good release'
+  })
+  .option('update-lkgr', {
+    alias: 'ulkgr',
+    type: 'boolean',
+    description: 'Uses last known good release'
   });
 
 const app = yargs.argv;
@@ -71,6 +76,7 @@ const options = {
   timeoutLength: app.timeout,
   tmpDir: app.tmpDir,
   lkgr: app.lkgr,
+  ulkgr: app.ulkgr,
   includeTags: app.includeTags || [],
   excludeTags: app.excludeTags || []
 };

--- a/bin/citgm.js
+++ b/bin/citgm.js
@@ -14,6 +14,16 @@ const yargs = commonArgs(require('yargs'))
     alias: 'c',
     type: 'string',
     description: 'Install module from commit-sha'
+  })
+  .option('last-known-good-release', {
+    alias: 'lkgr',
+    type: 'boolean',
+    description: 'Install last know good release'
+  })
+  .option('update-last-known-good-release', {
+    alias: 'ulkgr',
+    type: 'boolean',
+    description: 'Update last know good release'
   });
 
 const app = yargs.argv;
@@ -47,7 +57,9 @@ const options = {
   npmLevel: app.npmLoglevel,
   timeoutLength: app.timeout,
   sha: app.sha,
-  tmpDir: app.tmpDir
+  tmpDir: app.tmpDir,
+  lkgr: app.lkgr,
+  ulkgr: app.ulkgr
 };
 
 if (!citgm.windows) {

--- a/bin/citgm.js
+++ b/bin/citgm.js
@@ -18,12 +18,12 @@ const yargs = commonArgs(require('yargs'))
   .option('last-known-good-release', {
     alias: 'lkgr',
     type: 'boolean',
-    description: 'Install last know good release'
+    description: 'Install last known good release'
   })
-  .option('update-last-known-good-release', {
+  .option('update-lkgr', {
     alias: 'ulkgr',
     type: 'boolean',
-    description: 'Update last know good release'
+    description: 'Update last known good release'
   });
 
 const app = yargs.argv;

--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -13,6 +13,7 @@ const lookup = require('./lookup');
 const npm = require('./npm');
 const tempDirectory = require('./temp-directory');
 const unpack = require('./unpack');
+const update = require('./update-lookup');
 
 const windows = (process.platform === 'win32');
 exports.windows = windows;
@@ -106,7 +107,8 @@ Tester.prototype.run = function() {
     grabProject,
     unpack,
     npm.install,
-    npm.test
+    npm.test,
+    update
   ], (err) => {
     if (!this.cleanexit) {
       const payload = {

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -7,7 +7,7 @@ const normgit = require('normalize-git-url');
 const isMatch = require('./match-conditions');
 
 // Construct the tarball url using the repo, spec and prefix config
-function makeUrl(repo, spec, tags, prefix, sha) {
+function makeUrl(repo, spec, tags, prefix, lkgr, sha) {
   let version;
   if (!spec) // Spec should already have defaulted to latest.
     version = 'master';
@@ -22,6 +22,10 @@ function makeUrl(repo, spec, tags, prefix, sha) {
   if (sha) {
     prefix = '';
     version = sha;
+  }
+
+  if (lkgr) {
+    version = lkgr;
   }
 
   return util.format('%s/archive/%s%s.tar.gz', repo, prefix, version);
@@ -90,6 +94,9 @@ function resolve(context, next) {
       if (typeof rep.replace === 'boolean' && !rep.replace) {
         rep.npm = true;
       }
+      if (context.options.lkgr && rep.lkgr) {
+        context.module.lkgr = rep.lkgr;
+      }
       if (!rep.npm){
         if (!rep.repo && !meta.repository) {
           next(new Error('no-repository-field in package.json'));
@@ -101,6 +108,7 @@ function resolve(context, next) {
           rep.master ? null : detail.fetchSpec,
           meta['dist-tags'],
           rep.master ? null : rep.prefix,
+          context.module.lkgr ? context.module.lkgr : null,
           context.options.sha || rep.sha || gitHead);
         context.emit('data', 'info', context.module.name +
             ' lookup-replace', url);

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -126,6 +126,9 @@ function resolve(context, next) {
           false : isMatch(rep.flaky);
       context.module.expectFail = context.options.expectFail ?
           false : isMatch(rep.expectFail);
+      if (context.options.ulkgr && rep.lkgr) {
+        context.module.lkgr = rep.lkgr;
+      }
     } else {
       context.emit('data', 'info', 'lookup-notfound', detail.name);
       if (meta.gitHead) {

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -22,9 +22,7 @@ function makeUrl(repo, spec, tags, prefix, lkgr, sha) {
   if (sha) {
     prefix = '';
     version = sha;
-  }
-
-  if (lkgr) {
+  } else if (lkgr) {
     version = lkgr;
   }
 
@@ -94,9 +92,6 @@ function resolve(context, next) {
       if (typeof rep.replace === 'boolean' && !rep.replace) {
         rep.npm = true;
       }
-      if (context.options.lkgr && rep.lkgr) {
-        context.module.lkgr = rep.lkgr;
-      }
       if (!rep.npm){
         if (!rep.repo && !meta.repository) {
           next(new Error('no-repository-field in package.json'));
@@ -108,7 +103,7 @@ function resolve(context, next) {
           rep.master ? null : detail.fetchSpec,
           meta['dist-tags'],
           rep.master ? null : rep.prefix,
-          context.module.lkgr ? context.module.lkgr : null,
+          context.options.lkgr ? rep.lkgr : null,
           context.options.sha || rep.sha || gitHead);
         context.emit('data', 'info', context.module.name +
             ' lookup-replace', url);

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -1,7 +1,8 @@
 {
   "lodash": {
     "expectFail": "fips",
-    "maintainers": "jdalton"
+    "maintainers": "jdalton",
+    "lkgr": "4.17.5"
   },
   "underscore": {
     "flaky": ["aix", "s390"],

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -2,7 +2,7 @@
   "lodash": {
     "expectFail": "fips",
     "maintainers": "jdalton",
-    "lkgr": "4.17.5"
+    "lkgr": "4.17.3"
   },
   "underscore": {
     "flaky": ["aix", "s390"],

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -2,68 +2,81 @@
   "lodash": {
     "expectFail": "fips",
     "maintainers": "jdalton",
-    "lkgr": "4.17.3"
+    "lkgr": "4.17.5"
   },
   "underscore": {
     "flaky": ["aix", "s390"],
     "skip": "win32",
-    "maintainers": "jashkenas"
+    "maintainers": "jashkenas",
+    "lkgr": "1.8.3"
   },
   "request": {
     "prefix": "v",
     "flaky": true,
     "skip": "aix",
-    "maintainers": "mikeal"
+    "maintainers": "mikeal",
+    "lkgr": "2.83.0"
   },
   "commander": {
     "prefix": "v",
     "skip": "win32",
-    "maintainers": "tj"
+    "maintainers": "tj",
+    "lkgr": "2.14.1"
   },
   "express": {
     "flaky": "ppc",
-    "maintainers": "dougwilson"
+    "maintainers": "dougwilson",
+    "lkgr": "4.16.2"
   },
   "router": {
     "prefix": "v",
-    "maintainers": "dougwilson"
+    "maintainers": "dougwilson",
+    "lkgr": "1.3.2"
   },
   "path-to-regexp": {
     "prefix": "v",
-    "maintainers": "blakeembrey"
+    "maintainers": "blakeembrey",
+    "lkgr": "2.1.0"
   },
   "multer": {
     "prefix": "v",
     "skip": "win32",
-    "maintainers": "linusu"
+    "maintainers": "linusu",
+    "lkgr": "1.3.0"
   },
   "express-session": {
     "prefix": "v",
-    "maintainers": "dougwilson"
+    "maintainers": "dougwilson",
+    "lkgr": "1.15.6"
   },
   "q": {
     "prefix": "v",
-    "maintainers": "kriskowal"
+    "maintainers": "kriskowal",
+    "lkgr": "1.5.1"
   },
   "coffeescript": {
     "maintainers": ["jashkenas", "GeoffreyBooth"],
-    "skip": ["<=v4", "win32"]
+    "skip": ["<=v4", "win32"],
+    "lkgr": "2.2.2"
   },
   "through2": {
     "prefix": "v",
     "stripAnsi": true,
-    "maintainers": "rvagg"
+    "maintainers": "rvagg",
+    "lkgr": "2.0.3"
   },
   "glob": {
     "prefix": "v",
     "flaky": ["v6", "v7", "win32"],
     "expectFail": "fips",
-    "maintainers": "isaacs"
+    "maintainers": "isaacs",
+    "lkgr": "7.1.2"
   },
   "gulp-util": {
     "prefix": "v",
     "flaky": "rhel",
-    "maintainers": "contra"
+    "maintainers": "contra",
+    "lkgr": "3.0.8"
   },
   "pug": {
     "flaky": "ppc",
@@ -72,7 +85,8 @@
   },
   "socket.io": {
     "flaky": true,
-    "maintainers": "rauchg"
+    "maintainers": "rauchg",
+    "lkgr": "2.0.4"
   },
   "fs-extra": {
     "flaky": ["linux-ia32", "aix", "s390", "win32"],
@@ -82,63 +96,75 @@
   },
   "body-parser": {
     "flaky": "aix",
-    "maintainers": "dougwilson"
+    "maintainers": "dougwilson",
+    "lkgr": "1.18.2"
   },
   "uglify-js": {
     "prefix": "v",
     "flaky": ["ppc", "win32", "v7", "darwin"],
-    "maintainers": "mishoo"
+    "maintainers": "mishoo",
+    "lkgr": "3.3.12"
   },
   "jquery": {
     "skip": "win32",
     "flaky": ["linux", "aix"],
     "maintainers": "jeresig",
-    "ignoreGitHead": true
+    "ignoreGitHead": true,
+    "lkgr": "3.3.1"
   },
   "rimraf": {
     "prefix": "v",
     "flaky": "win32",
-    "maintainers": "isaacs"
+    "maintainers": "isaacs",
+    "lkgr": "2.6.2"
   },
   "david": {
     "prefix": "v",
-    "maintainers": "alanshaw"
+    "maintainers": "alanshaw",
+    "lkgr": "11.0.0"
   },
   "eslint": {
     "prefix": "v",
     "flaky": ["v7", "s390", "ubuntu"],
     "skip": ["v8", "ppc"],
     "expectFail": "fips",
-    "maintainers": ["nzakas", "mysticatea", "not-an-aardvark"]
+    "maintainers": ["nzakas", "mysticatea", "not-an-aardvark"],
+    "lkgr": "4.18.1"
   },
   "tape": {
     "prefix": "v",
     "flaky": ["linux", "win32"],
-    "maintainers": "substack"
+    "maintainers": "substack",
+    "lkgr": "4.9.0"
   },
   "browserify": {
     "flaky": [">=v8", "win32"],
     "expectFail": "fips",
-    "maintainers": "substack"
+    "maintainers": "substack",
+    "lkgr": "16.1.0"
   },
   "watchify": {
     "prefix": "v",
     "flaky": ["ppc", "v7", "s390", "ubuntu", "rhel"],
-    "maintainers": "substack"
+    "maintainers": "substack",
+    "lkgr": "3.10.0"
   },
   "stylus": {
     "flaky": ["win32", "aix"],
-    "maintainers": "tj"
+    "maintainers": "tj",
+    "lkgr": "0.54.5"
   },
   "level": {
     "prefix": "v",
     "flaky": ["aix", "s390"],
-    "maintainers": ["ralphtheninja", "rvagg"]
+    "maintainers": ["ralphtheninja", "rvagg"],
+    "lkgr": "3.0.0"
   },
   "torrent-stream": {
     "prefix": "v",
     "flaky": true,
-    "maintainers": "mafintosh"
+    "maintainers": "mafintosh",
+    "lkgr": "1.0.3"
   },
   "react": {
     "prefix": "v",
@@ -150,7 +176,8 @@
     "prefix": "v",
     "flaky": ["ppc", "rhel"],
     "skip": "win32",
-    "maintainers": "contra"
+    "maintainers": "contra",
+    "lkgr": "3.9.1"
   },
   "moment": {
     "flaky": true,
@@ -160,108 +187,130 @@
     "flaky": "linux",
     "skip": "win32",
     "expectFail": "fips",
-    "maintainers": ["einaros", "3rd-Eden", "lpinca"]
+    "maintainers": ["einaros", "3rd-Eden", "lpinca"],
+    "lkgr": "4.1.0"
   },
   "vinyl": {
     "prefix": "v",
-    "maintainers": ["contra", "phated"]
+    "maintainers": ["contra", "phated"],
+    "lkgr": "2.1.0"
   },
   "vinyl-fs": {
     "prefix": "v",
     "flaky": true,
     "master": true,
-    "maintainers": ["contra", "phated"]
+    "maintainers": ["contra", "phated"],
+    "lkgr": "3.0.2"
   },
   "readable-stream": {
     "prefix": "v",
     "flaky": ["ppc", "darwin"],
-    "maintainers": "nodejs/streams"
+    "maintainers": "nodejs/streams",
+    "lkgr": "2.3.4"
   },
   "ftp": {
     "prefix": "v",
     "skip": ">=8",
-    "maintainers": "mscdex"
+    "maintainers": "mscdex",
+    "lkgr": "0.3.10"
   },
   "split2": {
     "prefix": "v",
-    "maintainers": "mcollina"
+    "maintainers": "mcollina",
+    "lkgr": "2.2.0"
   },
   "throughv": {
     "prefix": "v",
     "stripAnsi": true,
-    "maintainers": "mcollina"
+    "maintainers": "mcollina",
+    "lkgr": "1.0.3"
   },
   "duplexer2": {
     "prefix": "v",
-    "maintainers": ["shinn", "deoxxa"]
+    "maintainers": ["shinn", "deoxxa"],
+    "lkgr": "0.1.4"
   },
   "bl": {
     "prefix": "v",
     "stripAnsi": true,
     "expectFail": "fips",
-    "maintainers": "rvagg"
+    "maintainers": "rvagg",
+    "lkgr": "1.2.1"
   },
   "binary-split": {
     "prefix": "v",
     "flaky": "win32",
-    "maintainers": ["maxogden", "mourner"]
+    "maintainers": ["maxogden", "mourner"],
+    "lkgr": "1.0.3"
   },
   "spdy": {
     "prefix": "v",
     "flaky": ["aix", "sles"],
     "skip": "win32",
-    "maintainers": "diasdavid"
+    "maintainers": "diasdavid",
+    "lkgr": "3.4.7"
   },
   "dicer": {
     "prefix": "v",
-    "maintainers": "mscdex"
+    "maintainers": "mscdex",
+    "lkgr": "0.2.5"
   },
   "spdy-transport": {
     "prefix": "v",
     "skip": "win32",
     "flaky": "aix",
-    "maintainers": "diasdavid"
+    "maintainers": "diasdavid",
+    "lkgr": "2.0.20"
   },
   "sax": {
     "skip": "win32",
     "prefix": "v",
     "expectFail": "fips",
-    "maintainers": "isaacs"
+    "maintainers": "isaacs",
+    "lkgr": "1.2.4"
   },
   "duplexify": {
     "prefix": "v",
-    "maintainers": "mafintosh"
+    "maintainers": "mafintosh",
+    "lkgr": "3.5.3"
   },
   "pumpify": {
     "prefix": "v",
-    "maintainers": "mafintosh"
+    "maintainers": "mafintosh",
+    "lkgr": "1.4.0"
   },
   "from2": {
     "prefix": "v",
-    "maintainers": ["mafintosh", "hughsk"]
+    "maintainers": ["mafintosh", "hughsk"],
+    "lkgr": "2.3.0"
   },
   "flush-write-stream": {
     "prefix": "v",
-    "maintainers": "mafintosh"
+    "maintainers": "mafintosh",
+    "lkgr": "1.0.2"
   },
   "jsonstream": {
     "prefix": "v",
     "skip": "win32",
-    "maintainers": "dominictarr"
+    "maintainers": "dominictarr",
+    "lkgr": "1.0.3"
   },
   "csv-parser": {
     "prefix": "v",
     "flaky": "win32",
-    "maintainers": "mafintosh"
+    "maintainers": "mafintosh",
+    "lkgr": "1.12.0"
   },
   "async": {
     "prefix": "v",
     "flaky": true,
-    "maintainers": ["aearly", "megawac"]
+    "maintainers": ["aearly", "megawac"],
+    "lkgr": "2.6.0"
   },
   "bluebird": {
     "prefix": "v",
-    "maintainers": "petkaantonov"
+    "maintainers": "petkaantonov",
+    "lkgr": "3.5.1"
   },
   "mkdirp": {
     "master": true,
@@ -273,91 +322,108 @@
     "prefix": "v",
     "flaky": ["ppc", "win32", "rhel"],
     "expectFail": "fips",
-    "maintainers": ["SBoudrias", "sindresorhus"]
+    "maintainers": ["SBoudrias", "sindresorhus"],
+    "lkgr": "2.0.3"
   },
   "minimist": {
-    "maintainers": "substack"
+    "maintainers": "substack",
+    "lkgr": "1.2.0"
   },
   "cheerio": {
     "skip": "win32",
-    "maintainers": ["matthewmueller", "jugglinmike"]
+    "maintainers": ["matthewmueller", "jugglinmike"],
+    "lkgr": "1.0.0-rc.2"
   },
   "uuid": {
     "prefix": "v",
-    "maintainers": ["ctavan", "broofa"]
+    "maintainers": ["ctavan", "broofa"],
+    "lkgr": "3.2.1"
   },
   "winston": {
     "flaky": ["win32", "ppc", "s390"],
-    "maintainers": "indexzero"
+    "maintainers": "indexzero",
+    "lkgr": "2.4.0"
   },
   "yargs": {
     "prefix": "v",
     "flaky": "ppc",
     "expectFail": "fips",
-    "maintainers": ["bcoe", "addaleax"]
+    "maintainers": ["bcoe", "addaleax"],
+    "lkgr": "11.0.0"
   },
   "semver": {
     "skip": "win32",
     "prefix": "v",
     "maintainers": "isaacs",
-    "expectFail": "fips"
+    "expectFail": "fips",
+    "lkgr": "5.5.0"
   },
   "mime": {
     "prefix": "v",
     "flaky": true,
-    "maintainers": "broofa"
+    "maintainers": "broofa",
+    "lkgr": "2.2.0"
   },
   "serialport": {
     "prefix": "v",
     "flaky": ["ppc", "win32"],
     "tags": "native",
-    "maintainers": "reconbot"
+    "maintainers": "reconbot",
+    "lkgr": "6.1.1"
   },
   "isarray": {
     "prefix": "v",
-    "maintainers": "juliangruber"
+    "maintainers": "juliangruber",
+    "lkgr": "2.0.4"
   },
   "inherits": {
     "prefix": "v",
-    "maintainers": "isaacs"
+    "maintainers": "isaacs",
+    "lkgr": "2.0.3"
   },
   "graceful-fs": {
     "prefix": "v",
-    "maintainers": "isaacs"
+    "maintainers": "isaacs",
+    "lkgr": "4.1.11"
   },
   "leveldown": {
     "prefix": "v",
     "flaky": ["ppc", "s390"],
     "tags": "native",
-    "maintainers": "rvagg"
+    "maintainers": "rvagg",
+    "lkgr": "3.0.0"
   },
   "zeromq": {
     "prefix": "v",
-    "skip": "win32",
+    "skip": ["s390", "ppc"],
     "tags": "native",
     "maintainers": ["lgeiger", "rgbkrk"],
-    "skip": ["s390", "ppc"]
+    "lkgr": "4.6.0"
   },
   "bcrypt": {
     "prefix": "v",
     "skip": "win32",
     "tags": "native",
-    "maintainers": "ncb000gt"
+    "maintainers": "ncb000gt",
+    "lkgr": "1.0.3"
   },
   "ref": {
     "flaky": "aix",
     "tags": "native",
-    "maintainers": "TooTallNate"
+    "maintainers": "TooTallNate",
+    "lkgr": "1.3.5"
   },
   "time": {
     "flaky": ["linux-ia32", "s390"],
     "skip": ["win32", "aix"],
     "tags": "native",
-    "maintainers": "TooTallNate"
+    "maintainers": "TooTallNate",
+    "lkgr": "0.12.0"
   },
   "bson": {
     "prefix": "V",
-    "maintainers": "christkv"
+    "maintainers": "christkv",
+    "lkgr": "2.0.1"
   },
   "ember-cli": {
     "prefix": "v",
@@ -370,54 +436,63 @@
     "prefix": "v",
     "flaky": true,
     "tags": "native",
-    "maintainers": "xzyfer"
+    "maintainers": "xzyfer",
+    "lkgr": "4.7.2"
   },
   "full-icu-test": {
     "prefix": "v",
-    "maintainers": "srl295"
+    "maintainers": "srl295",
+    "lkgr": "1.0.3"
   },
   "sqlite3": {
     "prefix": "v",
     "tags": "native",
     "flaky": "ppc",
-    "maintainers": "koistya"
+    "maintainers": "koistya",
+    "lkgr": "3.1.13"
   },
   "iconv": {
     "prefix": "v",
     "flaky": "aix",
     "tags": "native",
-    "maintainers": "bnoordhuis"
+    "maintainers": "bnoordhuis",
+    "lkgr": "2.3.0"
   },
   "electron-prebuilt": {
     "prefix": "v",
     "flaky": "s390",
     "skip": "ppc",
-    "maintainers": "maxogden"
+    "maintainers": "maxogden",
+    "lkgr": "1.4.13"
   },
   "libxmljs": {
     "prefix": "v",
     "flaky": ["aix", "sles", "rhel", "darwin"],
     "skip": ["win32", ">=8"],
     "tags": "native",
-    "maintainers": "defunctzombie"
+    "maintainers": "defunctzombie",
+    "lkgr": "0.18.7"
   },
   "radium": {
     "prefix": "v",
     "flaky": ["fedora", "ubuntu"],
     "skip": ["ppc", "s390", "v4"],
     "expectFail": "fips",
-    "maintainers": ["ianobermiller", "alexlande"]
+    "maintainers": ["ianobermiller", "alexlande"],
+    "lkgr": "0.22.1"
   },
   "ffi": {
     "flaky": ["ppc", "aix", "s390", "ubuntu"],
     "skip": ["win32", ">=8"],
     "tags": "native",
-    "maintainers": "TooTallNate"
+    "maintainers": "TooTallNate",
+    "lkgr": "2.2.0"
   },
   "microtime": {
     "prefix": "v",
     "tags": "native",
-    "maintainers": "wadey"
+    "maintainers": "wadey",
+    "lkgr": "2.1.7"
   },
   "koa": {
     "skip": "<7",
@@ -427,44 +502,53 @@
   "spawn-wrap": {
     "prefix": "v",
     "flaky": ["win32", "sles", "aix", "darwin"],
-    "maintainers": "isaacs"
+    "maintainers": "isaacs",
+    "lkgr": "1.4.2"
   },
   "node-report": {
     "prefix": "v",
     "flaky": "win32",
     "tags": "native",
-    "maintainers": ["rnchamberlain", "richardlau"]
+    "maintainers": ["rnchamberlain", "richardlau"],
+    "lkgr": "2.2.1"
   },
   "thread-sleep": {
     "install": ["--build-from-source"],
     "tags": "native",
-    "maintainers": ["forbeslindesay", "timothygu"]
+    "maintainers": ["forbeslindesay", "timothygu"],
+    "lkgr": "2.0.0"
   },
   "bufferutil": {
     "prefix": "v",
     "tags": "native",
-    "maintainers": ["3rdeden", "einaros", "lpinca"]
+    "maintainers": ["3rdeden", "einaros", "lpinca"],
+    "lkgr": "3.0.3"
   },
   "weak": {
     "tags": "native",
-    "maintainers": "tootallnate"
+    "maintainers": "tootallnate",
+    "lkgr": "1.0.1"
   },
   "acorn": {
     "maintainers": "marijnh",
-    "skip": "win32"
+    "skip": "win32",
+    "lkgr": "5.5.0"
   },
   "esprima": {
     "maintainers": "ariya",
     "expectFail": "fips",
-    "skip": "win32"
+    "skip": "win32",
+    "lkgr": "4.0.0"
   },
   "node-gyp": {
     "prefix": "v",
     "tags": "native",
-    "maintainers": ["nodejs/node-gyp"]
+    "maintainers": ["nodejs/node-gyp"],
+    "lkgr": "3.6.2"
   },
   "crc32-stream": {
-    "maintainers": "ctalkington"
+    "maintainers": "ctalkington",
+    "lkgr": "2.0.0"
   },
   "mocha": {
     "prefix": "v",
@@ -474,7 +558,8 @@
   },
   "rewire": {
     "prefix": "v",
-    "maintainers": "jhnns"
+    "maintainers": "jhnns",
+    "lkgr": "3.0.2"
   },
   "ava": {
     "prefix": "v",

--- a/lib/update-lookup.js
+++ b/lib/update-lookup.js
@@ -1,0 +1,46 @@
+'use strict';
+const fs = require('fs');
+
+// If got up to here then npm test passed
+// If `--ulkgr` option passed then update lookup
+
+function update(context, next) {
+
+  if (context.options.ulkgr) {
+    const details = context.module;
+
+    context.emit('data', 'info', 'update-lookup', 'true');
+    context.emit('data', 'info', 'update-lookup',
+    'npm: ' + details.version + ' lookup: ' + details.lkgr);
+
+    if (details.version !== details.lkgr) {
+      context.emit('data', 'info', 'update-lookup', 'updating');
+      var lookup = JSON.parse(fs.readFileSync(__dirname + '/lookup.json', 'utf8'));
+
+      lookup[details.name].lkgr = details.version;
+
+      let lookupString = JSON.stringify(lookup, (k,v) => {
+         if(v instanceof Array) {
+            return JSON.stringify(v)
+            .replace(/,/g, ', ');
+         }
+         return v;
+      },2)// regex to remove line breaks and tabs inside arrays.
+        .replace(/\\/g, '')
+        .replace(/\"\[/g, '[')
+        .replace(/\]\"/g,']')
+
+      fs.writeFileSync(__dirname + '/l.json', lookupString, 'utf8');
+
+    } else {
+      context.emit('data', 'info', 'update-lookup', 'lookup is already up to date');
+    }
+  } else {
+    context.emit('data', 'info', 'update-lookup', 'false');
+  }
+
+  next(null, context);
+
+}
+
+module.exports = update;

--- a/lib/update-lookup.js
+++ b/lib/update-lookup.js
@@ -30,7 +30,7 @@ function update(context, next) {
         .replace(/\"\[/g, '[')
         .replace(/\]\"/g,']')
 
-      fs.writeFileSync(__dirname + '/l.json', lookupString, 'utf8');
+      fs.writeFileSync(__dirname + '/lookup.json', lookupString, 'utf8');
 
     } else {
       context.emit('data', 'info', 'update-lookup', 'lookup is already up to date');


### PR DESCRIPTION
Added: 
- `lkgr` to the lookup (modules that passed on my mac).
- `--lkgr` option for citgm and citgm-all, which rans `lkgr` from the lookup, instead of defaulting to taking npm latest.
- `--ulkgr` option for citgm and citgm-all, to update lookup

Let me know what you think and let's discuss if we want to include platforms flakiness for `lkgr`.

TODO:

- [ ] Support for different platforms and node versions.
- [ ] Error handling 
- [ ] Raise a PR
- [ ] Tests
- [ ] Documentation 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)

Refs: https://github.com/nodejs/citgm/issues/407
