### PR TITLE
Add module name to its tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Options:
   --tmpDir <path>             Directory to test modules in
   --includeTags tag1 tag2     Only test modules from the lookup that contain a matching tag field
   --excludeTags tag1 tag2     Specify which tags to skip from the lookup (takes priority over includeTags)
+                              Module names are automatically added as tags.
 ```
 
 When using a JSON config file, the properties need to be the same as the

--- a/bin/citgm-all.js
+++ b/bin/citgm-all.js
@@ -38,7 +38,9 @@ const yargs = commonArgs(require('yargs'))
   .option('excludeTags', {
     type: 'array',
     description: 'Define which tags from the lookup to skip'
-  });
+  })
+  .example('citgm-all --includeTags express', 'Only test express.')
+  .example('citgm-all --excludeTags native', 'Don\'t test native modules.');
 
 const app = yargs.argv;
 

--- a/bin/citgm-all.js
+++ b/bin/citgm-all.js
@@ -39,6 +39,9 @@ const yargs = commonArgs(require('yargs'))
     type: 'array',
     description: 'Define which tags from the lookup to skip'
   })
+  .example('citgm-all -t /path/to/output.tap',
+           'Write test results as tap to file.')
+  .example('citgm-all -l /path/to/lookup.json', 'Test a custom set of modules.')
   .example('citgm-all --includeTags express', 'Only test express.')
   .example('citgm-all --excludeTags native', 'Don\'t test native modules.');
 

--- a/lib/check-tags.js
+++ b/lib/check-tags.js
@@ -4,16 +4,16 @@ const _ = require('lodash');
 function checkTags(options, mod, name, log) {
   // Returns true if the module should be skipped.
 
-  if ((options.excludeTags.length && !options.includeTags.length && !mod.tags)
-    || (!options.includeTags.length && !options.excludeTags.length)) {
+  if (!options.includeTags.length && !options.excludeTags.length) {
     return false; // No checks to run.
-  } else if (options.includeTags.length && !mod.tags) {
-    return true; // No tags for this module.
   }
 
   if (typeof mod.tags === 'string') {
     mod.tags = [mod.tags]; // If mod.tags is a single string, convert to array.
   }
+
+  if (!mod.tags) mod.tags = [];
+  mod.tags.push(name);
 
   let excludeTagMatches = _.intersection(options.excludeTags, mod.tags);
 

--- a/test/bin/test-citgm-all.js
+++ b/test/bin/test-citgm-all.js
@@ -152,6 +152,30 @@ test('citgm-all: includeTags multiple', function (t) {
   });
 });
 
+test('citgm-all: excludeTags modulename', function (t) {
+  t.plan(1);
+  const proc = spawn(citgmAllPath, ['--excludeTags', 'omg-i-fail', '-l',
+    'test/fixtures/custom-lookup-tags.json']);
+  proc.on('error', function(err) {
+    t.error(err);
+  });
+  proc.on('close', function (code) {
+    t.equals(code, 0, 'citgm-all should not run omg-i-fail');
+  });
+});
+
+test('citgm-all: includeTags modulename multiple', function (t) {
+  t.plan(1);
+  const proc = spawn(citgmAllPath, ['--includeTags', 'omg-i-pass noTag1 NoTag2',
+    '-l', 'test/fixtures/custom-lookup-tags.json']);
+  proc.on('error', function(err) {
+    t.error(err);
+  });
+  proc.on('close', function (code) {
+    t.equals(code, 0, 'citgm-all should only run omg-i-pass');
+  });
+});
+
 test('citgm-all: skip /w rootcheck /w tap to fs /w junit to fs /w append',
 function (t) {
   t.plan(1);

--- a/test/test-check-tags.js
+++ b/test/test-check-tags.js
@@ -316,3 +316,48 @@ test('test excludeTags, includeTags and no matching tags', function (t) {
   const result = checkTags(options, mod, 'test', log);
   t.true(result, 'should return true');
 });
+
+test('test module name can be used in includeTags/excludeTags', function (t) {
+  t.plan(2);
+
+  t.equal(
+    checkTags(
+      { excludeTags: [], includeTags: ['test'] },
+      { tags: 'b' },
+      'test',
+      log),
+    false
+  );
+
+  t.equal(
+    checkTags(
+      { excludeTags: ['test'], includeTags: [] },
+      { tags: 'b' },
+      'test',
+      log),
+    true
+  );
+});
+
+test('test tags matching module name with includeTags/excludeTags',
+    function (t) {
+      t.plan(2);
+
+      t.equal(
+        checkTags(
+          { excludeTags: [], includeTags: ['test'] },
+          { tags: 'test' },
+          'test',
+          log),
+        false
+      );
+
+      t.equal(
+        checkTags(
+          { excludeTags: ['test'], includeTags: [] },
+          { tags: 'test' },
+          'test',
+          log),
+        true
+      );
+    });


### PR DESCRIPTION
Allows includeTags and excludeTags to be used with individual module
names.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
