### PR TITLE
fix: linter for consecutive comments 

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -15,7 +15,7 @@
     no-useless-escape: 2
     array-bracket-spacing: [2, never]
     brace-style: 2
-    capitalized-comments: 2
+    capitalized-comments: [2, always, { ignoreConsecutiveComments: true }]
     eol-last: [2, always]
     func-call-spacing: [2, never]
     semi-spacing: 2


### PR DESCRIPTION
 No need to have a capital letter for a consecutive comment.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
