### PR TITLE
lookup: skip spdy on Node.js > 9

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -208,7 +208,7 @@
   "spdy": {
     "prefix": "v",
     "flaky": ["aix", "sles"],
-    "skip": "win32",
+    "skip": [">9", "win32"],
     "maintainers": "diasdavid"
   },
   "dicer": {


### PR DESCRIPTION
SPDY relies on spdy-transport and that broke due to a BC in 10.0.0.
However, neither of these modules are maintained anymore as they
got pretty much obsolete due to http2.

Refs: https://github.com/spdy-http2/spdy-transport/issues/52
Refs: #558

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
