### PR TITLE
lookup: mark thread-sleep flaky

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -436,6 +436,7 @@
   },
   "thread-sleep": {
     "install": ["--build-from-source"],
+    "flaky": true,
     "tags": "native",
     "maintainers": ["forbeslindesay", "timothygu"]
   },


### PR DESCRIPTION
This is some times showing up as failure. Since the test is inherently flaky (it is timers based without having any guarantee that the test works with e.g., heavy load) let us mark is as such.

It came up e.g. here: https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/1418/nodes=aix61-ppc64/testReport/junit/(root)/citgm/thread_sleep_v2_0_0/

I also opened a PR to change the test but there is still no guarantee that it will work:
https://github.com/ForbesLindesay/thread-sleep/pull/17

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
