### PR TITLE
lookup: skip ws on aix and osx

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -157,7 +157,7 @@
   },
   "ws": {
     "flaky": "linux",
-    "skip": "win32",
+    "skip": ["win32", "aix", "darwin"],
     "expectFail": "fips",
     "maintainers": ["einaros", "3rd-Eden", "lpinca"]
   },


### PR DESCRIPTION
`ws` is constantly failing on osx and aix. See https://github.com/nodejs/node/issues/20858 for further infos. I think it is best to skip these until this is resolved.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
