### PR TITLE
lookup: consolidate duplicated keys

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -332,10 +332,9 @@
   },
   "zeromq": {
     "prefix": "v",
-    "skip": "win32",
     "tags": "native",
     "maintainers": ["lgeiger", "rgbkrk"],
-    "skip": ["s390", "ppc"]
+    "skip": ["s390", "ppc", "win32"]
   },
   "bcrypt": {
     "prefix": "v",


### PR DESCRIPTION
`zeromq` was not skipped in windows because the skip entries were
duplicated and therefore it was overriden.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
