### PR TITLE
loopup: skip ava on all x86 systems

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -477,7 +477,7 @@
   },
   "ava": {
     "prefix": "v",
-    "skip": ["ppc", "win32", "rhel", "aix", "<6", "10"],
+    "skip": ["ppc", "win32", "x86", "rhel", "aix", "<6", "10"],
     "flaky": "<8",
     "maintainers": ["sindresorhus", "novemberborn"]
   },


### PR DESCRIPTION
Only x64 systems are supported. This includes Windows.

See https://github.com/flowtype/flow-bin/blob/master/index.js (this is a peer dependency).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
