### PR TITLE
lookup: skip sqlite3 on windows

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -379,6 +379,7 @@
     "prefix": "v",
     "tags": "native",
     "flaky": "ppc",
+    "skip": "win32",
     "maintainers": "koistya"
   },
   "iconv": {


### PR DESCRIPTION
Currently sqlite3 does not compile with Node.js 10 and Windows.

There is active development and they plan to fully support Node.js 10 on Windows. See https://github.com/mapbox/node-sqlite3/issues/973 as a tracking issue.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
