### PR TITLE
WIP: add repeat option to citgm

### DIFF
--- a/bin/citgm.js
+++ b/bin/citgm.js
@@ -69,6 +69,7 @@ if (!citgm.windows) {
   launch(mod, options);
 }
 
+let numOfFails = 0;
 const start = new Date();
 function launch(mod, options) {
   const runner = citgm.Tester(mod, options);
@@ -109,8 +110,14 @@ function launch(mod, options) {
     process.removeListener('SIGHUP', cleanup);
     process.removeListener('SIGBREAK', cleanup);
 
-    if (options.repeat && --options.repeat > 0) {
-      launch(mod, options);
+    if (options.repeat) {
+      module.error ? numOfFails++ : numOfFails;
+      if (--options.repeat > 0) {
+        launch(mod, options);
+      } else {
+        log.info('number of failures', `${module.name} failed ${numOfFails} times`);
+        process.exit(numOfFails > 0 ? 1 : 0);
+      }
     } else {
       process.exit(module.error ? 1 : 0);
     }

--- a/bin/citgm.js
+++ b/bin/citgm.js
@@ -10,6 +10,11 @@ let mod;
 
 const yargs = commonArgs(require('yargs'))
   .usage('citgm [options] <module>')
+  .option('repeat', {
+    alias: 'r',
+    type: 'number',
+    description: 'Number of times to test each module.'
+  })
   .option('sha', {
     alias: 'c',
     type: 'string',
@@ -46,6 +51,7 @@ const options = {
   level: app.verbose,
   npmLevel: app.npmLoglevel,
   timeoutLength: app.timeout,
+  repeat: app.repeat,
   sha: app.sha,
   tmpDir: app.tmpDir
 };
@@ -102,6 +108,12 @@ function launch(mod, options) {
     process.removeListener('SIGINT', cleanup);
     process.removeListener('SIGHUP', cleanup);
     process.removeListener('SIGBREAK', cleanup);
-    process.exit(module.error ? 1 : 0);
+
+    if (options.repeat && --options.repeat > 0) {
+      launch(mod, options);
+    } else {
+      process.exit(module.error ? 1 : 0);
+    }
+
   }).run();
 }


### PR DESCRIPTION
Run CITGM with `--repeat` option to test specific module a number of times.

Do we want to keep testing even if CITGM fails on one of the runs (then log how many times it failed)? or do we want CITGM to fail after the first fail? 

Alternative to https://github.com/nodejs/citgm/pull/411.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
