### PR TITLE
lookup: unflakey tape on Windows

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -424,7 +424,7 @@
   },
   "tape": {
     "prefix": "v",
-    "flaky": ["linux", "win32"],
+    "flaky": "linux",
     "maintainers": "substack"
   },
   "thread-sleep": {


### PR DESCRIPTION
Tape is no longer falky on Windows

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
