### PR TITLE
test: fix test-npm-install for Node.js 6

### DIFF
--- a/test/npm/test-npm-install.js
+++ b/test/npm/test-npm-install.js
@@ -92,9 +92,7 @@ test('npm-install: failed install', function (t) {
   });
   const expected = {
     testOutput: /^$/,
-    testError: new RegExp(['npm ERR! 404 Registry returned 404 for GET on',
-      'https://registry.npmjs.org/THIS-WILL-FAIL|npm ERR! 404 Not Found:',
-      'THIS-WILL-FAIL@0\\.0\\.1'].join(' '))
+    testError: /npm ERR! 404 Not [Ff]ound\s*: THIS-WILL-FAIL(@0\.0\.1)?/
   };
   npmInstall(context, function (err) {
     t.notOk(context.module.flaky, 'Module failed is not flaky');


### PR DESCRIPTION
The checked error message differs between the version of npm included
in Node.js 6 compared to later versions.

Fixes: https://github.com/nodejs/citgm/issues/577
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
