### PR TITLE
lookup: use JSONStream instead of jsonstream

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -244,7 +244,7 @@
     "prefix": "v",
     "maintainers": "mafintosh"
   },
-  "jsonstream": {
+  "JSONStream": {
     "prefix": "v",
     "skip": "win32",
     "maintainers": "dominictarr"


### PR DESCRIPTION
jsonstream (500 weekly downloads) has been deprecated in favor of to
JSONStream (1m weekly downloads). The test framework still does not
work on Windows, so we keep the skip clause.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
