### PR TITLE
Serialport is switching to Lerna

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -307,7 +307,7 @@
     "maintainers": "broofa"
   },
   "serialport": {
-    "prefix": "v",
+    "prefix": "serialport@",
     "flaky": "ppc",
     "tags": "native",
     "maintainers": "reconbot"


### PR DESCRIPTION
The new tags look like `serialport@7.0.0` for the serialport package

##### Checklist
- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)

`serialport` no longer builds binaries but depends on `@serialport/bindings` that has the binaries now. (As of yet unpublished, still working out precompiled binary build process issues.) Tests and `bin/citgm serialport` both worked but unsure of how they use the prefix.