### PR TITLE
lib: fix npm pack

### DIFF
--- a/lib/grab-project.js
+++ b/lib/grab-project.js
@@ -16,13 +16,9 @@ function grabProject(context, next) {
   let bailed = false;
   context.emit('data', 'info', context.module.name + ' npm:',
       'Downloading project: ' + packageName);
-  const proc =
-    spawn(
-      'npm',
-      ['pack', packageName],
-      createOptions(
-        context.path,
-        context));
+  let options = createOptions(context.path, context);
+  options.stdio = ['ignore', 'pipe', 'ignore'];
+  const proc = spawn('npm', ['pack', packageName], options);
 
   let filename = '';
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "test": "npm run lint && npm run tap",
-    "tap": "tap -J --timeout 120 \"test/**/test-*.js\"",
+    "tap": "tap -J --timeout 240 \"test/**/test-*.js\"",
     "coverage": "npm run tap -- --coverage",
     "coverage-html": "npm run tap -- --coverage --coverage-report=html",
     "lint": "eslint bin/* lib/ test/ --cache"


### PR DESCRIPTION
Closes `stdin` and `stderr` when calling `npm pack`. This makes CITGM work with never `npm`.

Fixes: https://github.com/nodejs/citgm/issues/593

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
