### PR TITLE
chore: use prettier for code style

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,29 +1,17 @@
-  env:
-    node: true
-    es6: true
+env:
+  node: true
+  es6: true
 
-  rules:
-    indent-legacy: [2, 2]
-    quotes: [2, single]
-    no-trailing-spaces: 2
-    comma-spacing: [2, { before: false, after: true }]
-    eqeqeq: [2, always]
-    linebreak-style: [2, unix]
-    semi: [2, always]
-    max-len: [2, 80]
-    no-multi-spaces: 2
-    no-useless-escape: 2
-    array-bracket-spacing: [2, never]
-    brace-style: 2
-    capitalized-comments: [2, always, { ignoreConsecutiveComments: true }]
-    eol-last: [2, always]
-    func-call-spacing: [2, never]
-    semi-spacing: 2
-    strict: 2
-    no-var: 2
-    prefer-template: 2
-    template-curly-spacing: 2
-    no-template-curly-in-string: 2
-    prefer-arrow-callback: 2
+rules:
+  eqeqeq: [2, always]
+  no-useless-escape: 2
+  capitalized-comments: [2, always, { ignoreConsecutiveComments: true }]
+  strict: 2
+  no-var: 2
+  prefer-template: 2
+  no-template-curly-in-string: 2
+  prefer-arrow-callback: 2
 
-  extends: eslint:recommended
+extends:
+  - eslint:recommended
+  - plugin:prettier/recommended

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,8 +10,9 @@ Platform: output of `uname -a` (UNIX), or version and 32 or 64-bit (Windows)
 If possible, please provide code that demonstrates the problem, keeping it as
 simple and free of external dependencies as you are able.
 -->
-* **Node Version**:
-* **CitGM Version**:
-* **Platform**:
+
+- **Node Version**:
+- **CitGM Version**:
+- **Platform**:
 
 <!-- Enter your issue details below this comment. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,9 +4,11 @@ the requirements below.
 -->
 
 ##### Checklist
+
 <!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
 
 - [ ] `npm test` passes
 - [ ] tests are included
 - [ ] documentation is changed or added
-- [ ] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
+- [ ] contribution guidelines followed
+      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ os:
   - linux
   - osx
 node_js:
-  - "11"
-  - "10"
-  - "8"
-  - "6"
-script: "npm run test-ci"
-after_script: "bash <(curl -s https://codecov.io/bash)"
+  - '11'
+  - '10'
+  - '8'
+  - '6'
+script: 'npm run test-ci'
+after_script: 'bash <(curl -s https://codecov.io/bash)'

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,4 +2,5 @@
 
 The [Node.js Code of Conduct][] applies to this repo.
 
-[Node.js Code of Conduct]: https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md
+[node.js code of conduct]:
+  https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md

--- a/COLLABORATORS.md
+++ b/COLLABORATORS.md
@@ -1,6 +1,9 @@
 # Collaboration Policy
 
-* All changes must come in a PR
-* All changes must be reviewed by another Collaborator or member of @nodejs/build
-  - Small changes to the lookup table can be made without following the above process
-* Changes can be landed in any way you prefer as long as it lands on the head of master with no merge commit
+- All changes must come in a PR
+- All changes must be reviewed by another Collaborator or member of
+  @nodejs/build
+  - Small changes to the lookup table can be made without following the above
+    process
+- Changes can be landed in any way you prefer as long as it lands on the head of
+  master with no merge commit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,29 +1,29 @@
 ## Making changes to CitGM
+
 #### There are a few basic requirements for making changes to CitGM
 
-* Consider creating an issue prior to submitting a PR as this can help speed up
-the process.
-* Include tests for your code wherever possible.
-* Include any documentation or man page changes where necessary.
-* Ensure that `npm test` passes before submitting the PR.
-* Squash each logical change into a single commit.
-* Follow the [commit guidelines](#commit-guidelines) below.
-
+- Consider creating an issue prior to submitting a PR as this can help speed up
+  the process.
+- Include tests for your code wherever possible.
+- Include any documentation or man page changes where necessary.
+- Ensure that `npm test` passes before submitting the PR.
+- Squash each logical change into a single commit.
+- Follow the [commit guidelines](#commit-guidelines) below.
 
 #### Commit Guidelines
 
-* The first line should be 50 characters or less and contain a short description
-of the change. All words in the description should be in lowercase with the
-exception of proper nouns, acronyms, and the ones that refer to code, like
-function/variable names. The description should be prefixed with the name of
-the changed subsystem and start with an imperative verb.
-Example: `lookup: add module to lookup.json`. Use `git log` for inspiration if
-you are unsure about what the subsystem should be.
-* Keep the second line blank.
-* Wrap all other lines at 72 columns.
-* Optionally you can include a `PR-URL:` line. (This can be useful when landing
-someone else's commits).
-* If the PR fixes an issue, please include a `Fixes:` or `Closes:` line.
+- The first line should be 50 characters or less and contain a short description
+  of the change. All words in the description should be in lowercase with the
+  exception of proper nouns, acronyms, and the ones that refer to code, like
+  function/variable names. The description should be prefixed with the name of
+  the changed subsystem and start with an imperative verb. Example:
+  `lookup: add module to lookup.json`. Use `git log` for inspiration if you are
+  unsure about what the subsystem should be.
+- Keep the second line blank.
+- Wrap all other lines at 72 columns.
+- Optionally you can include a `PR-URL:` line. (This can be useful when landing
+  someone else's commits).
+- If the PR fixes an issue, please include a `Fixes:` or `Closes:` line.
 
 A good commit log can look something like this:
 
@@ -49,37 +49,34 @@ This is for adding a module to be included in the default `citgm-all` runs.
 
 #### Hard Requirements
 
-* Module source code must be on Github.
-* Published versions must include a tag on Github
-* The test process must be executable with only the commands
-`npm install && npm test` or (`yarn install && yarn test`) using the tarball downloaded from the Github tag
-mentioned above
-* The tests pass on supported major release lines
-* The maintainers of the module remain responsive when there are problems
-* At least one module maintainer must be added to the lookup maintainers field
+- Module source code must be on Github.
+- Published versions must include a tag on Github
+- The test process must be executable with only the commands
+  `npm install && npm test` or (`yarn install && yarn test`) using the tarball
+  downloaded from the Github tag mentioned above
+- The tests pass on supported major release lines
+- The maintainers of the module remain responsive when there are problems
+- At least one module maintainer must be added to the lookup maintainers field
 
 #### Soft Requirements
 
 At least one of:
-* The module must be actively used by the community
-OR
-* The module must be heavily depended on
-OR
-* The module must cover unique portions of our API
-OR
-* The module fits into a key category (e.g. Testing, Streams, Monitoring, etc.)
-OR
-* The module is under the Node.js foundation Github org
-OR
-* The module is identified as an important module by a Node.js Working Group
+
+- The module must be actively used by the community OR
+- The module must be heavily depended on OR
+- The module must cover unique portions of our API OR
+- The module fits into a key category (e.g. Testing, Streams, Monitoring, etc.)
+  OR
+- The module is under the Node.js foundation Github org OR
+- The module is identified as an important module by a Node.js Working Group
 
 #### Procedure
 
-After making sure you adhere to the above requirements, do the
-following:
+After making sure you adhere to the above requirements, do the following:
 
 1. Add the module to
    [`lib/lookup.json`](https://github.com/nodejs/citgm/blob/master/lib/lookup.json)
 1. Run `npm link`
 1. Make sure the `citgm <module>` tests pass
-1. Commit your changes and open a PR. Please specify the hard and soft requirements the module fufills
+1. Commit your changes and open a PR. Please specify the hard and soft
+   requirements the module fufills

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,10 +1,8 @@
-The MIT License (MIT)
-=====================
+# The MIT License (MIT)
 
-Copyright (c) 2015 citgm contributors
---------------------------------------------------
+## Copyright (c) 2015 citgm contributors
 
-*citgm contributors listed at <https://github.com/nodejs/citgm/blob/master/AUTHORS>*
+_citgm contributors listed at <https://github.com/nodejs/citgm/blob/master/AUTHORS>_
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/ModerationPolicy.md
+++ b/ModerationPolicy.md
@@ -2,4 +2,5 @@
 
 The [Node.js Moderation Policy][] applies to this repo.
 
-[Node.js Moderation Policy]: https://github.com/nodejs/TSC/blob/master/Moderation-Policy.md
+[node.js moderation policy]:
+  https://github.com/nodejs/TSC/blob/master/Moderation-Policy.md

--- a/README.md
+++ b/README.md
@@ -1,19 +1,24 @@
 ## The Canary in the Goldmine
 
-citgm is a simple tool for pulling down an arbitrary module
-from npm and testing it using a specific version of the
-node runtime.
+citgm is a simple tool for pulling down an arbitrary module from npm and testing
+it using a specific version of the node runtime.
 
-[![Build Status](https://travis-ci.com/nodejs/citgm.svg?branch=master)](https://travis-ci.com/nodejs/citgm) [![dependencies Status](https://david-dm.org/nodejs/citgm/status.svg)](https://david-dm.org/nodejs/citgm) [![devDependencies Status](https://david-dm.org/nodejs/citgm/dev-status.svg)](https://david-dm.org/nodejs/citgm?type=dev)
+[![Build Status](https://travis-ci.com/nodejs/citgm.svg?branch=master)](https://travis-ci.com/nodejs/citgm)
+[![dependencies Status](https://david-dm.org/nodejs/citgm/status.svg)](https://david-dm.org/nodejs/citgm)
+[![devDependencies Status](https://david-dm.org/nodejs/citgm/dev-status.svg)](https://david-dm.org/nodejs/citgm?type=dev)
 
-The Node.js project uses citgm to smoke test our releases and controversial changes. The Jenkins job that utilizes citgm can be found [on our CI](https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/).
+The Node.js project uses citgm to smoke test our releases and controversial
+changes. The Jenkins job that utilizes citgm can be found
+[on our CI](https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/).
 
 ## Installation
+
 ```
 npm install -g citgm
 ```
 
 ## Usage
+
 ```
 citgm --help
 ```
@@ -48,39 +53,39 @@ Options:
 ```
 
 ### Examples:
-  Test the latest underscore module or a specific version:
-    `citgm underscore@latest` or `citgm underscore@1.3.0`
 
-  Test a local module:
-    `citgm ./my-module`
+Test the latest underscore module or a specific version:
+`citgm underscore@latest` or `citgm underscore@1.3.0`
 
-   Test using a tar.gz from Github:
-    `citgm http://github.com/jasnell/activitystrea.ms/archive/master.tar.gz`
+Test a local module: `citgm ./my-module`
+
+Test using a tar.gz from Github:
+`citgm http://github.com/jasnell/activitystrea.ms/archive/master.tar.gz`
 
 When using a JSON config file, the properties need to be the same as the
 longer-form CLI options. You can also use environment variables. For example,
 `CITGM_TEST_PATH=$HOME/bin` is the same as `--test-path $HOME/bin`.
 
-The tool requires online access to the npm registry to run. If you want to
-point to a private npm registry, then you'll need to set that up in your
-npm config separately before running citgm.
+The tool requires online access to the npm registry to run. If you want to point
+to a private npm registry, then you'll need to set that up in your npm config
+separately before running citgm.
 
-By default, the tool will prevent users from running as root unless the
-`-s` or `--su` CLI switch is set. If the tool is launched as root, it will
-attempt to silently and automatically downgrade permissions. If it cannot
-downgrade, it will print an error and exit the process.
+By default, the tool will prevent users from running as root unless the `-s` or
+`--su` CLI switch is set. If the tool is launched as root, it will attempt to
+silently and automatically downgrade permissions. If it cannot downgrade, it
+will print an error and exit the process.
 
 The tool will also automatically check npm to see if there are updates
-available. If a newer version has been published to npm, an info notice
-will appear in the verbose output. If the `-v` or `--verbose` flag is not
-set, the update notice will not be displayed.
+available. If a newer version has been published to npm, an info notice will
+appear in the verbose output. If the `-v` or `--verbose` flag is not set, the
+update notice will not be displayed.
 
 ## citgm-all
 
-If you want to run all the test suites for all modules found in a lookup
-table use citgm-all. It will automate the running of all tests and give
-itemized results at the end. It has all the same options as citgm except
-for the added markdown option which will print the results in markdown.
+If you want to run all the test suites for all modules found in a lookup table
+use citgm-all. It will automate the running of all tests and give itemized
+results at the end. It has all the same options as citgm except for the added
+markdown option which will print the results in markdown.
 
 ```
 Usage: citgm-all [options]
@@ -124,6 +129,7 @@ You can also test your own list of modules:
 ```
 citgm-all -l ./path/to/my_lookup.json
 ```
+
 For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
 
 ```
@@ -158,21 +164,23 @@ npm run test
 This will run both a linter and a tap based unit test suite.
 
 ## Requirements for inclusion in Node.js Citgm runs
-If you want to submit a module to be run in the Node.js CI, see the [requirements](./CONTRIBUTING.md#submitting-a-module-to-citgm).
+
+If you want to submit a module to be run in the Node.js CI, see the
+[requirements](./CONTRIBUTING.md#submitting-a-module-to-citgm).
 
 ## Notes
 
-You can identify the module to be tested using the same syntax supported by
-the `npm install` CLI command
+You can identify the module to be tested using the same syntax supported by the
+`npm install` CLI command
 
 ```
 citgm activitystrea.ms@latest
 citgm git+http://github.com/jasnell/activitystrea.ms
 ```
 
-Quite a few modules published to npm do not have their tests included, so
-we end up having to go directly to github. The most reliable approach is
-pulling down a tar ball for a specific branch from github:
+Quite a few modules published to npm do not have their tests included, so we end
+up having to go directly to github. The most reliable approach is pulling down a
+tar ball for a specific branch from github:
 
 ```
 citgm https://github.com/caolan/async/archive/master.tar.gz
@@ -181,16 +189,15 @@ citgm https://github.com/caolan/async/archive/master.tar.gz
 To simplify working with modules that we know need special handling, a lookup
 table mechanism is provided. This mechanism allows citgm to substitute certain
 known npm specs (lodash for instance) with their github tarball alternatives.
-The lookup mechanism is switched on using the `-l` or
-`--lookup` command line option.
+The lookup mechanism is switched on using the `-l` or `--lookup` command line
+option.
 
 ```
 citgm lodash@latest
 ```
 
 There is a built in lookup.json in the lib directory that will be used by
-default. If you want to use an alternative lookup.json file, pass in the
-path:
+default. If you want to use an alternative lookup.json file, pass in the path:
 
 ```
 citgm --lookup ../path/to/lookup.json lodash@latest
@@ -207,47 +214,58 @@ citgm --customTest path/to/customTestScript
 If you want to get code coverage results, your custom test script may look like:
 
 ```js
-"use strict";
+'use strict';
 
-const { spawnSync } = require("child_process");
-const path = require("path");
-const packageName = require(path.join(process.cwd(), "package.json")).name;
+const { spawnSync } = require('child_process');
+const path = require('path');
+const packageName = require(path.join(process.cwd(), 'package.json')).name;
 
-const coverageProcess = spawnSync("nyc", [
-  "--reporter=json-summary",
+const coverageProcess = spawnSync('nyc', [
+  '--reporter=json-summary',
   `--report-dir=${process.env.WORKSPACE}/${packageName}`,
-  "npm", "test"
+  'npm',
+  'test'
 ]);
 
-const coverageSummary = require(path.join(process.env.WORKSPACE, packageName, "coverage-summary.json"));
-console.log(packageName, "total coverage result(%)", coverageSummary.total.lines.pct);
+const coverageSummary = require(path.join(
+  process.env.WORKSPACE,
+  packageName,
+  'coverage-summary.json'
+));
+console.log(
+  packageName,
+  'total coverage result(%)',
+  coverageSummary.total.lines.pct
+);
 ```
 
-You will have to globally install dependencies from the `customTestScript`, in this case:
+You will have to globally install dependencies from the `customTestScript`, in
+this case:
+
 ```
 npm install -g nyc
 ```
 
 ### Additional Notes:
 
-* You may experience some wonkiness on Windows as the tool has not been fully
+- You may experience some wonkiness on Windows as the tool has not been fully
   tested on that platform.
 
-* The tool uses the npm and node in the PATH. To change which node and
-  npm the tool uses, change the PATH before launching citgm
+- The tool uses the npm and node in the PATH. To change which node and npm the
+  tool uses, change the PATH before launching citgm
 
-* Running the tool in verbose mode (CLI switch `-v silly`) outputs significantly
+- Running the tool in verbose mode (CLI switch `-v silly`) outputs significantly
   more detail (which is likely what we'll want in a fully automated run)
 
-* If you've taken a look at the dependencies for this tool, you'll note that
-  there are quite a few, some of which may not be strictly required. The
-  reason for the large number of dependencies is that this *is* a testing
-  tool, and many of the dependencies are broadly used. A large part of the
-  reason for using them is to test that they'll work properly using the
-  version of node being tested.
+- If you've taken a look at the dependencies for this tool, you'll note that
+  there are quite a few, some of which may not be strictly required. The reason
+  for the large number of dependencies is that this _is_ a testing tool, and
+  many of the dependencies are broadly used. A large part of the reason for
+  using them is to test that they'll work properly using the version of node
+  being tested.
 
-* PRs are welcome!
+- PRs are welcome!
 
 ## Contributors
 
-* as listed in <https://github.com/nodejs/citgm/blob/master/AUTHORS>
+- as listed in <https://github.com/nodejs/citgm/blob/master/AUTHORS>

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,8 @@
 # CITGM Release Process
 
-This document describes the technical aspects of the citgm release process. The intended audience is those who have been authorized to create official releases for citgm, hosted on npm.
+This document describes the technical aspects of the citgm release process. The
+intended audience is those who have been authorized to create official releases
+for citgm, hosted on npm.
 
 ## Who can make a release?
 

--- a/bin/citgm-all.js
+++ b/bin/citgm-all.js
@@ -39,11 +39,13 @@ const yargs = commonArgs(require('yargs'))
     type: 'array',
     description: 'Define which tags from the lookup to skip'
   })
-  .example('citgm-all -t /path/to/output.tap',
-           'Write test results as tap to file.')
+  .example(
+    'citgm-all -t /path/to/output.tap',
+    'Write test results as tap to file.'
+  )
   .example('citgm-all -l /path/to/lookup.json', 'Test a custom set of modules.')
   .example('citgm-all --includeTags express', 'Only test express.')
-  .example('citgm-all --excludeTags native', 'Don\'t test native modules.');
+  .example('citgm-all --excludeTags native', "Don't test native modules.");
 
 const app = yargs.argv;
 
@@ -55,8 +57,7 @@ const log = logger({
 update(log);
 
 if (!app.su) {
-  require('root-check')(); // Silently downgrade if running as root...
-                           // Unless --su is passed
+  require('root-check')(); // Silently downgrade if running as root... Unless --su is passed
 } else {
   log.warn('root', 'Running as root! Use caution!');
 }
@@ -76,13 +77,17 @@ const options = {
   excludeTags: app.excludeTags || []
 };
 
-if (options.includeTags.length){
-  log.info('includeTags', `Only running tests matching these tags: ${
-       app.includeTags}`);
+if (options.includeTags.length) {
+  log.info(
+    'includeTags',
+    `Only running tests matching these tags: ${app.includeTags}`
+  );
 }
-if (options.excludeTags.length){
-  log.info('excludeTags', `Not running tests matching these tags: ${
-      app.excludeTags}`);
+if (options.excludeTags.length) {
+  log.info(
+    'excludeTags',
+    `Not running tests matching these tags: ${app.excludeTags}`
+  );
 }
 
 const lookup = getLookup(options);
@@ -96,7 +101,7 @@ if (app.autoParallel || (app.parallel && app.parallel > cpus)) {
   app.parallel = cpus;
   log.info('cores', `running tests using ${app.parallel} cores`);
 }
-if (app.parallel && ((app.parallel + 1) > process.getMaxListeners())) {
+if (app.parallel && app.parallel + 1 > process.getMaxListeners()) {
   process.setMaxListeners(app.parallel + 1);
 }
 
@@ -115,7 +120,7 @@ if (!citgm.windows) {
 
 const modules = [];
 
-function runCitgm (mod, name, next) {
+function runCitgm(mod, name, next) {
   if (isMatch(mod.skip)) {
     modules.push({
       name,
@@ -145,30 +150,43 @@ function runCitgm (mod, name, next) {
   process.on('SIGHUP', cleanup);
   process.on('SIGBREAK', cleanup);
 
-  runner.on('start', (name) => {
-    log.info('starting', name);
-  }).on('fail', (err) => {
-    log.error('failure', err.message);
-  }).on('data', (type, key, message) => {
-    log[type](key, message);
-  }).on('end', (result) => {
-    result.duration = new Date() - start;
-    log.info('duration', `test duration: ${result.duration}ms`);
-    if (result.error) {
-      log.error(`${result.name} done`, `done - the test suite for ${
-          result.name} version ${result.version} failed`);
-    } else {
-      log.info(`${result.name} done`, `done - the test suite for ${result.name
-           } version ${result.version} passed.`);
-    }
-    modules.push(result);
-    if (!bailed) {
-      process.removeListener('SIGINT', cleanup);
-      process.removeListener('SIGHUP', cleanup);
-      process.removeListener('SIGBREAK', cleanup);
-    }
-    return next(bailed);
-  }).run();
+  runner
+    .on('start', (name) => {
+      log.info('starting', name);
+    })
+    .on('fail', (err) => {
+      log.error('failure', err.message);
+    })
+    .on('data', (type, key, message) => {
+      log[type](key, message);
+    })
+    .on('end', (result) => {
+      result.duration = new Date() - start;
+      log.info('duration', `test duration: ${result.duration}ms`);
+      if (result.error) {
+        log.error(
+          `${result.name} done`,
+          `done - the test suite for ${result.name} version ${
+            result.version
+          } failed`
+        );
+      } else {
+        log.info(
+          `${result.name} done`,
+          `done - the test suite for ${result.name} version ${
+            result.version
+          } passed.`
+        );
+      }
+      modules.push(result);
+      if (!bailed) {
+        process.removeListener('SIGINT', cleanup);
+        process.removeListener('SIGHUP', cleanup);
+        process.removeListener('SIGBREAK', cleanup);
+      }
+      return next(bailed);
+    })
+    .run();
 }
 
 function runTask(task, next) {
@@ -188,7 +206,7 @@ function launch() {
 
   const q = async.queue(runTask, app.parallel || 1);
   q.push(collection);
-  function done () {
+  function done() {
     q.drain = null;
     reporter.logger(log, modules);
 
@@ -201,12 +219,12 @@ function launch() {
       // If not use `log.bypass` which is currently process.stdout.write
       // TODO check that we can write to that path, perhaps require a flag to
       // Overwrite
-      const tap = (typeof app.tap === 'string') ? app.tap : log.bypass;
+      const tap = typeof app.tap === 'string' ? app.tap : log.bypass;
       reporter.tap(tap, modules, app.append);
     }
 
     if (app.junit) {
-      const junit = (typeof app.junit === 'string') ? app.junit : log.bypass;
+      const junit = typeof app.junit === 'string' ? app.junit : log.bypass;
       reporter.junit(junit, modules, app.append);
     }
 

--- a/bin/citgm.js
+++ b/bin/citgm.js
@@ -21,7 +21,7 @@ const app = yargs.argv;
 mod = app._[0];
 
 const log = logger({
-  level:app.verbose,
+  level: app.verbose,
   noColor: app.noColor
 });
 
@@ -29,7 +29,7 @@ update(log);
 
 if (!app.su) {
   require('root-check')(); // Silently downgrade if running as root...
-                           // Unless --su is passed
+  // Unless --su is passed
 } else {
   log.warn('root', 'Running as root! Use caution!');
 }
@@ -77,33 +77,38 @@ function launch(mod, options) {
   process.on('SIGHUP', cleanup);
   process.on('SIGBREAK', cleanup);
 
-  runner.on('start', (name) => {
-    log.info('starting', name);
-  }).on('fail', (err) => {
-    log.error('failure', err.message);
-  }).on('data', (type, key, message) => {
-    log[type](key, message);
-  }).on('end', (module) => {
-    module.duration = new Date() - start;
-    reporter.logger(log, module);
+  runner
+    .on('start', (name) => {
+      log.info('starting', name);
+    })
+    .on('fail', (err) => {
+      log.error('failure', err.message);
+    })
+    .on('data', (type, key, message) => {
+      log[type](key, message);
+    })
+    .on('end', (module) => {
+      module.duration = new Date() - start;
+      reporter.logger(log, module);
 
-    log.info('duration', `test duration: ${module.duration}ms`);
-    if (app.markdown) {
-      reporter.markdown(log.bypass, module);
-    }
-    if (app.tap) {
-      const tap = (typeof app.tap === 'string') ? app.tap : log.bypass;
-      reporter.tap(tap, module, app.append);
-    }
+      log.info('duration', `test duration: ${module.duration}ms`);
+      if (app.markdown) {
+        reporter.markdown(log.bypass, module);
+      }
+      if (app.tap) {
+        const tap = typeof app.tap === 'string' ? app.tap : log.bypass;
+        reporter.tap(tap, module, app.append);
+      }
 
-    if (app.junit) {
-      const junit = (typeof app.junit === 'string') ? app.junit : log.bypass;
-      reporter.junit(junit, module, app.append);
-    }
+      if (app.junit) {
+        const junit = typeof app.junit === 'string' ? app.junit : log.bypass;
+        reporter.junit(junit, module, app.append);
+      }
 
-    process.removeListener('SIGINT', cleanup);
-    process.removeListener('SIGHUP', cleanup);
-    process.removeListener('SIGBREAK', cleanup);
-    process.exit(module.error ? 1 : 0);
-  }).run();
+      process.removeListener('SIGINT', cleanup);
+      process.removeListener('SIGHUP', cleanup);
+      process.removeListener('SIGBREAK', cleanup);
+      process.exit(module.error ? 1 : 0);
+    })
+    .run();
 }

--- a/lib/check-tags.js
+++ b/lib/check-tags.js
@@ -18,16 +18,20 @@ function checkTags(options, mod, name, log) {
   let excludeTagMatches = _.intersection(options.excludeTags, mod.tags);
 
   if (excludeTagMatches.length) {
-    log.info(name,
-        `skipped as these excludeTags matched: ${excludeTagMatches}`);
+    log.info(
+      name,
+      `skipped as these excludeTags matched: ${excludeTagMatches}`
+    );
     return true; // We matched an excludeTag.
   }
 
   let includeTagMatches = _.intersection(options.includeTags, mod.tags);
 
   if (includeTagMatches.length) {
-    log.info(name,
-        `will run as these includeTags matched: ${includeTagMatches}`);
+    log.info(
+      name,
+      `will run as these includeTags matched: ${includeTagMatches}`
+    );
     return false; // We matched an includeTag.
   }
 
@@ -38,7 +42,6 @@ function checkTags(options, mod, name, log) {
     log.info(`${name} will run as no excludeTags matched`);
     return false; // We did not match an excludeTag.
   }
-
 }
 
 module.exports = checkTags;

--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -14,7 +14,7 @@ const packageManager = require('./package-manager');
 const tempDirectory = require('./temp-directory');
 const unpack = require('./unpack');
 
-const windows = (process.platform === 'win32');
+const windows = process.platform === 'win32';
 exports.windows = windows;
 
 /**
@@ -35,8 +35,12 @@ function findNode(context, next) {
       next(err);
       return;
     }
-    context.emit('data', 'verbose', `${context.module.name} using-node`,
-      resolved);
+    context.emit(
+      'data',
+      'verbose',
+      `${context.module.name} using-node`,
+      resolved
+    );
     next(null, context);
   });
 }
@@ -59,14 +63,26 @@ function init(context, next) {
   // Single module that citgm is testing.
   if (!windows) {
     if (context.options.uid)
-      context.emit('data', 'verbose', `${context.module.name} using-uid`,
-        context.options.uid);
+      context.emit(
+        'data',
+        'verbose',
+        `${context.module.name} using-uid`,
+        context.options.uid
+      );
     if (context.options.gid)
-      context.emit('data', 'verbose', `${context.module.name} using-gid`,
-        context.options.gid);
+      context.emit(
+        'data',
+        'verbose',
+        `${context.module.name} using-gid`,
+        context.options.gid
+      );
   }
-  context.emit('data', 'silly', `${context.module.name} init-detail`,
-    context.module);
+  context.emit(
+    'data',
+    'silly',
+    `${context.module.name} init-detail`,
+    context.module
+  );
   next(null, context); // Inject the context
 }
 
@@ -95,8 +111,7 @@ function extractDetail(mod) {
  **/
 
 function Tester(mod, options) {
-  if (!(this instanceof Tester))
-    return new Tester(mod, options);
+  if (!(this instanceof Tester)) return new Tester(mod, options);
   EventEmitter.call(this);
   this.module = extractDetail(mod);
   this.options = options;
@@ -110,44 +125,47 @@ util.inherits(Tester, EventEmitter);
 Tester.prototype.run = function() {
   this.emit('start', this.module.raw, this.options);
 
-  async.waterfall([
-    init.bind(null, this),
-    findNode,
-    findPackageManagers,
-    tempDirectory.create,
-    grabModuleData,
-    lookup,
-    grabProject,
-    unpack,
-    packageManager.install,
-    packageManager.test
-  ], (err) => {
-    if (!this.cleanexit) {
-      const payload = {
-        name: this.module.name || this.module.raw,
-        version: this.module.version,
-        flaky: this.module.flaky,
-        expectFail: this.module.expectFail
-      };
-      if (err && !payload.expectFail) {
-        this.emit('fail', err);
-        payload.error = err;
-      } else if (!err && payload.expectFail) {
-        this.emit('fail', 'this module should have failed');
-        payload.error = 'this module should have failed';
+  async.waterfall(
+    [
+      init.bind(null, this),
+      findNode,
+      findPackageManagers,
+      tempDirectory.create,
+      grabModuleData,
+      lookup,
+      grabProject,
+      unpack,
+      packageManager.install,
+      packageManager.test
+    ],
+    (err) => {
+      if (!this.cleanexit) {
+        const payload = {
+          name: this.module.name || this.module.raw,
+          version: this.module.version,
+          flaky: this.module.flaky,
+          expectFail: this.module.expectFail
+        };
+        if (err && !payload.expectFail) {
+          this.emit('fail', err);
+          payload.error = err;
+        } else if (!err && payload.expectFail) {
+          this.emit('fail', 'this module should have failed');
+          payload.error = 'this module should have failed';
+        }
+        if (this.testOutput !== '') {
+          payload.testOutput += `${this.testOutput.toString()}\n`;
+        }
+        if (this.testError !== '') {
+          payload.testOutput += `${this.testError.toString()}\n`;
+        }
+        tempDirectory.remove(this, () => {
+          this.emit('end', payload);
+          this.cleanexit = true;
+        });
       }
-      if (this.testOutput !== '') {
-        payload.testOutput += `${this.testOutput.toString()}\n`;
-      }
-      if (this.testError !== '') {
-        payload.testOutput += `${this.testError.toString()}\n`;
-      }
-      tempDirectory.remove(this, () => {
-        this.emit('end', payload);
-        this.cleanexit = true;
-      });
     }
-  });
+  );
 };
 
 Tester.prototype.cleanup = function() {

--- a/lib/common-args.js
+++ b/lib/common-args.js
@@ -1,100 +1,103 @@
 'use strict';
 const citgm = require('./citgm');
 
-module.exports = function commonArgs (app) {
+module.exports = function commonArgs(app) {
   app = app
-  .alias('help', 'h')
-  .config()
-  .env('CITGM')
-  .option('verbose', {
-    alias: ['v', 'loglevel'],
-    choices: ['silly', 'verbose', 'info', 'warn', 'error'],
-    default: 'info',
-    description: 'Verbose output'
-  })
-  .option('npm-loglevel', {
-    alias: 'q',
-    choices: ['silly', 'verbose', 'info', 'warn', 'error', 'http', 'silent'],
-    default: 'error',
-    description: 'Verbose output for npm'
-  })
-  .option('lookup', {
-    alias: 'l',
-    type: 'string',
-    description: 'Use the lookup table provided at <path>'
-  })
-  .option('nodedir', {
-    alias: 'd',
-    type: 'string',
-    description: 'Path to the node source to use when compiling native addons'
-  })
-  .option('tmpDir', {
-    type: 'string',
-    description: 'Directory to test modules in'
-  })
-  .option('test-path', {
-    alias: 'p',
-    type: 'string',
-    description: 'Path to prepend to $PATH when running tests'
-  })
-  .option('append', {
-    alias: 'a',
-    type: 'boolean',
-    description: 'Append results to file rather than replace'
-  })
-  .option('no-color', {
-    alias: 'n',
-    type: 'boolean',
-    description: 'Turns off colorized output'
-  })
-  .option('su', {
-    alias: 's',
-    type: 'boolean',
-    description: 'Allow running the tool as root.'
-  })
-  .option('markdown', {
-    alias: 'm',
-    type: 'boolean',
-    description: 'Output results in markdown'
-  })
-  .option('tap', {
-    alias: 't',
-    description: 'Output results in tap with optional file path'
-  })
-  .option('customTest', {
-    type: 'string',
-    description: 'Run a custom node test script instead of "npm test"'
-  })
-  .option('junit', {
-    alias: 'x',
-    description: 'Output results in junit xml with optional file path'
-  })
-  .option('timeout', {
-    alias: 'o',
-    type: 'number',
-    description: 'Set timeout for npm install',
-    default: 1000 * 60 * 10
-  })
-  .option('yarn', {
-    alias: 'y',
-    type: 'boolean',
-    description: 'Install and test the project using yarn instead of npm',
-    default: false
-  })
-  .example('citgm-all --customTest /path/to/customTest.js',
-    'Runs a custom node test script instead of "npm test"');
+    .alias('help', 'h')
+    .config()
+    .env('CITGM')
+    .option('verbose', {
+      alias: ['v', 'loglevel'],
+      choices: ['silly', 'verbose', 'info', 'warn', 'error'],
+      default: 'info',
+      description: 'Verbose output'
+    })
+    .option('npm-loglevel', {
+      alias: 'q',
+      choices: ['silly', 'verbose', 'info', 'warn', 'error', 'http', 'silent'],
+      default: 'error',
+      description: 'Verbose output for npm'
+    })
+    .option('lookup', {
+      alias: 'l',
+      type: 'string',
+      description: 'Use the lookup table provided at <path>'
+    })
+    .option('nodedir', {
+      alias: 'd',
+      type: 'string',
+      description: 'Path to the node source to use when compiling native addons'
+    })
+    .option('tmpDir', {
+      type: 'string',
+      description: 'Directory to test modules in'
+    })
+    .option('test-path', {
+      alias: 'p',
+      type: 'string',
+      description: 'Path to prepend to $PATH when running tests'
+    })
+    .option('append', {
+      alias: 'a',
+      type: 'boolean',
+      description: 'Append results to file rather than replace'
+    })
+    .option('no-color', {
+      alias: 'n',
+      type: 'boolean',
+      description: 'Turns off colorized output'
+    })
+    .option('su', {
+      alias: 's',
+      type: 'boolean',
+      description: 'Allow running the tool as root.'
+    })
+    .option('markdown', {
+      alias: 'm',
+      type: 'boolean',
+      description: 'Output results in markdown'
+    })
+    .option('tap', {
+      alias: 't',
+      description: 'Output results in tap with optional file path'
+    })
+    .option('customTest', {
+      type: 'string',
+      description: 'Run a custom node test script instead of "npm test"'
+    })
+    .option('junit', {
+      alias: 'x',
+      description: 'Output results in junit xml with optional file path'
+    })
+    .option('timeout', {
+      alias: 'o',
+      type: 'number',
+      description: 'Set timeout for npm install',
+      default: 1000 * 60 * 10
+    })
+    .option('yarn', {
+      alias: 'y',
+      type: 'boolean',
+      description: 'Install and test the project using yarn instead of npm',
+      default: false
+    })
+    .example(
+      'citgm-all --customTest /path/to/customTest.js',
+      'Runs a custom node test script instead of "npm test"'
+    );
 
   if (!citgm.windows) {
-    app = app.option('uid', {
-      alias: 'u',
-      type: 'number',
-      description: 'Set the uid (posix only)'
-    })
-    .option('gid', {
-      alias: 'g',
-      type: 'number',
-      description: 'Set the gid (posix only)'
-    });
+    app = app
+      .option('uid', {
+        alias: 'u',
+        type: 'number',
+        description: 'Set the uid (posix only)'
+      })
+      .option('gid', {
+        alias: 'g',
+        type: 'number',
+        description: 'Set the gid (posix only)'
+      });
   }
 
   return app;

--- a/lib/create-options.js
+++ b/lib/create-options.js
@@ -17,8 +17,12 @@ function createOptions(cwd, context) {
   if (context.options.nodedir) {
     const nodedir = path.resolve(process.cwd(), context.options.nodedir);
     options.env['npm_config_nodedir'] = nodedir;
-    context.emit('data', 'verbose', `${context.module.name} nodedir`,
-        `Using nodedir "${nodedir}"`);
+    context.emit(
+      'data',
+      'verbose',
+      `${context.module.name} nodedir`,
+      `Using nodedir "${nodedir}"`
+    );
   }
 
   if (context.module && context.module.envVar) {

--- a/lib/grab-module-data.js
+++ b/lib/grab-module-data.js
@@ -5,13 +5,11 @@ const spawn = require('./spawn');
 function grabModuleData(context, next) {
   // Launch npm info as a child process, using the tmp directory
   // As the working directory.
-  const proc =
-    spawn(
-      'npm',
-      ['view', '--json', context.module.raw],
-      createOptions(
-        context.path,
-        context));
+  const proc = spawn(
+    'npm',
+    ['view', '--json', context.module.raw],
+    createOptions(context.path, context)
+  );
   let data = '';
   proc.stdout.on('data', (chunk) => {
     data += chunk;
@@ -21,12 +19,18 @@ function grabModuleData(context, next) {
   });
   proc.on('close', (code) => {
     if (code > 0) {
-      context.emit('data', 'silly', `${context.module.name} npm-view`,
-          'No npm package information available');
-      if (context.module.type === 'git' &&
-          context.module.hosted.type === 'github') {
+      context.emit(
+        'data',
+        'silly',
+        `${context.module.name} npm-view`,
+        'No npm package information available'
+      );
+      if (
+        context.module.type === 'git' &&
+        context.module.hosted.type === 'github'
+      ) {
         context.meta = {
-          repository : {
+          repository: {
             type: 'git',
             url: context.module.hosted.git()
           }
@@ -35,8 +39,12 @@ function grabModuleData(context, next) {
       next(null, context);
       return;
     }
-    context.emit('data', 'silly', `${context.module.name} npm-view`,
-        'Data retrieved');
+    context.emit(
+      'data',
+      'silly',
+      `${context.module.name} npm-view`,
+      'Data retrieved'
+    );
     try {
       context.meta = JSON.parse(data);
     } catch (ex) {

--- a/lib/grab-project.js
+++ b/lib/grab-project.js
@@ -6,16 +6,24 @@ const spawn = require('./spawn');
 
 function grabProject(context, next) {
   if (context.meta)
-    context.emit('data', 'silly', `${context.module.name} package-meta`,
-        context.meta);
+    context.emit(
+      'data',
+      'silly',
+      `${context.module.name} package-meta`,
+      context.meta
+    );
   let packageName = context.module.raw;
   if (context.module.type === 'directory') {
     context.module.raw = context.module.name = path.basename(packageName);
     packageName = path.resolve(process.cwd(), packageName);
   }
   let bailed = false;
-  context.emit('data', 'info', `${context.module.name} npm:`,
-      `Downloading project: ${packageName}`);
+  context.emit(
+    'data',
+    'info',
+    `${context.module.name} npm:`,
+    `Downloading project: ${packageName}`
+  );
   let options = createOptions(context.path, context);
   options.stdio = ['ignore', 'pipe', 'ignore'];
   const proc = spawn('npm', ['pack', packageName], options);
@@ -23,14 +31,20 @@ function grabProject(context, next) {
   let filename = '';
 
   // Default timeout to 10 minutes if not provided
-  const timeout = setTimeout(cleanup, context.options.timeoutLength
-        || 1000 * 60 * 10);
+  const timeout = setTimeout(
+    cleanup,
+    context.options.timeoutLength || 1000 * 60 * 10
+  );
 
   function cleanup() {
     clearTimeout(timeout);
     bailed = true;
-    context.emit('data', 'error', `${context.module.name} npm:`,
-        'Download Timed Out');
+    context.emit(
+      'data',
+      'error',
+      `${context.module.name} npm:`,
+      'Download Timed Out'
+    );
     proc.kill();
     return next(Error('Download Timed Out'));
   }
@@ -59,12 +73,15 @@ function grabProject(context, next) {
     if (filename === '') {
       return next(Error('No project downloaded'));
     }
-    context.emit('data', 'info', `${context.module.name} npm:`,
-        `Project downloaded ${filename}`);
+    context.emit(
+      'data',
+      'info',
+      `${context.module.name} npm:`,
+      `Project downloaded ${filename}`
+    );
     context.unpack = path.join(context.path, filename);
     return next(null, context);
   });
-
 }
 
 module.exports = grabProject;

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -9,13 +9,13 @@ const isMatch = require('./match-conditions');
 // Construct the tarball url using the repo, spec and prefix config
 function makeUrl(repo, spec, tags, prefix, sha) {
   let version;
-  if (!spec) // Spec should already have defaulted to latest.
+  if (!spec)
+    // Spec should already have defaulted to latest.
     version = 'master';
-  else if (tags[spec])
-    version = tags[spec]; // Matches npm tags like 'latest' or 'next'.
-  else
-    // `spec` must match one of `meta.versions` as npm info call passed.
-    version = spec; // Matches npm versions like '1.0.0'
+  else if (tags[spec]) version = tags[spec];
+  // Matches npm tags like 'latest' or 'next'.
+  // `spec` must match one of `meta.versions` as npm info call passed.
+  else version = spec; // Matches npm versions like '1.0.0'
 
   prefix = prefix || '';
 
@@ -81,7 +81,7 @@ function resolve(context, next) {
     context.module.version = meta.version;
     if (rep) {
       context.emit('data', 'info', 'lookup-found', detail.name);
-      if (rep.envVar){
+      if (rep.envVar) {
         context.module.envVar = rep.envVar;
       }
       if (rep.stripAnsi) {
@@ -90,7 +90,7 @@ function resolve(context, next) {
       if (typeof rep.replace === 'boolean' && !rep.replace) {
         rep.npm = true;
       }
-      if (!rep.npm){
+      if (!rep.npm) {
         if (!rep.repo && !meta.repository) {
           next(new Error('no-repository-field in package.json'));
           return;
@@ -101,14 +101,23 @@ function resolve(context, next) {
           rep.master ? null : detail.fetchSpec,
           meta['dist-tags'],
           rep.master ? null : rep.prefix,
-          context.options.sha || rep.sha || gitHead);
-        context.emit('data', 'info', `${context.module.name
-            } lookup-replace`, url);
+          context.options.sha || rep.sha || gitHead
+        );
+        context.emit(
+          'data',
+          'info',
+          `${context.module.name} lookup-replace`,
+          url
+        );
         context.module.raw = url;
       }
       if (rep.install) {
-        context.emit('data', 'verbose', `${context.module.name
-            } lookup-install`, rep.install);
+        context.emit(
+          'data',
+          'verbose',
+          `${context.module.name} lookup-install`,
+          rep.install
+        );
         context.module.install = rep.install;
       }
       if (rep.tags) {
@@ -117,10 +126,12 @@ function resolve(context, next) {
       if (rep.yarn) {
         context.module.useYarn = true;
       }
-      context.module.flaky = context.options.failFlaky ?
-          false : isMatch(rep.flaky);
-      context.module.expectFail = context.options.expectFail ?
-          false : isMatch(rep.expectFail);
+      context.module.flaky = context.options.failFlaky
+        ? false
+        : isMatch(rep.flaky);
+      context.module.expectFail = context.options.expectFail
+        ? false
+        : isMatch(rep.expectFail);
     } else {
       context.emit('data', 'info', 'lookup-notfound', detail.name);
       if (meta.gitHead) {

--- a/lib/match-conditions.js
+++ b/lib/match-conditions.js
@@ -6,9 +6,9 @@ const semver = require('semver');
 
 // Mocked in tests
 let version = process.version;
-let semVersion = `${semver.major(process.version)}.${
-                 semver.minor(process.version)}.${
-                 semver.patch(process.version)}`;
+let semVersion = `${semver.major(process.version)}.${semver.minor(
+  process.version
+)}.${semver.patch(process.version)}`;
 let platform = process.platform;
 let arch = process.arch;
 let distro = '';
@@ -24,11 +24,11 @@ if (fs.existsSync('/etc/os-release')) {
   const osRelease = fs.readFileSync('/etc/os-release', 'utf8');
   distro = osRelease.match(/\n\s*ID="?(.*)"?/)[1] || '';
   const releaseMatch = osRelease.match(/\n\s*VERSION_ID="?(.*)"?/);
-  release = releaseMatch ? (releaseMatch[1] || '') : '';
+  release = releaseMatch ? releaseMatch[1] || '' : '';
 } else if (platform === 'darwin') {
   distro = 'macos';
   release = execSync('sw_vers -productVersion').toString() || '';
-} else if (platform === 'aix' ) {
+} else if (platform === 'aix') {
   release = execSync('oslevel').toString() || '';
   release = release.replace(/(\r\n|\n|\r)/gm, '') || '';
 }
@@ -38,8 +38,14 @@ const endian = process.config.variables.node_byteorder || '';
 function isStringMatch(conditions) {
   if (semver.validRange(conditions) && semver.satisfies(semVersion, conditions))
     return true;
-  const checks = [distro, release, version, [platform, arch].join('-'),
-    endian, fips];
+  const checks = [
+    distro,
+    release,
+    version,
+    [platform, arch].join('-'),
+    endian,
+    fips
+  ];
   return _.some(checks, (check) => {
     return check.search(conditions) !== -1;
   });

--- a/lib/out.js
+++ b/lib/out.js
@@ -6,7 +6,7 @@ let supportsColor = require('supports-color'); // Mocked in tests
 
 logger.remove(logger.transports.Console);
 logger.add(logger.transports.Console, {
-  prettyPrint:true,
+  prettyPrint: true,
   depth: 100
 });
 
@@ -16,17 +16,14 @@ function output(tag, message, dest) {
     obj = JSON.stringify(message, null, 2);
     message = '';
   }
-  const msg = columnify(
-    [{tag:tag, message:message}],
-    {
-      showHeaders: false,
-      maxLineWidth: 'auto',
-      minWidth: 20,
-      maxWidth: Infinity,
-      columnSplitter: '| ',
-      preserveNewLines: true
-    }
-  );
+  const msg = columnify([{ tag: tag, message: message }], {
+    showHeaders: false,
+    maxLineWidth: 'auto',
+    minWidth: 20,
+    maxWidth: Infinity,
+    columnSplitter: '| ',
+    preserveNewLines: true
+  });
   msg.split('\n').forEach((line) => {
     dest(line);
   });

--- a/lib/package-manager/get-executable.js
+++ b/lib/package-manager/get-executable.js
@@ -4,7 +4,7 @@ const path = require('path');
 const which = require('which');
 const npmWhich = require('npm-which')(__dirname);
 
-const windows = (process.platform === 'win32');
+const windows = process.platform === 'win32';
 
 module.exports = function getExecutable(binaryName, next) {
   if (binaryName === 'yarn') {
@@ -21,8 +21,13 @@ module.exports = function getExecutable(binaryName, next) {
     }
 
     if (windows) {
-      packageManagerBin = path.join(path.dirname(packageManagerBin),
-        'node_modules', 'npm', 'bin', 'npm-cli.js');
+      packageManagerBin = path.join(
+        path.dirname(packageManagerBin),
+        'node_modules',
+        'npm',
+        'bin',
+        'npm-cli.js'
+      );
     }
 
     next(null, packageManagerBin);

--- a/lib/package-manager/index.js
+++ b/lib/package-manager/index.js
@@ -23,17 +23,17 @@ function pkgTest(context, next) {
 }
 
 function getPackageManagers(next) {
-  async.parallel([
-    getExecutable.bind(null, 'npm'),
-    getExecutable.bind(null, 'yarn')
-  ], (err, res) => {
-    if (err) {
-      next(err);
-      return;
-    }
+  async.parallel(
+    [getExecutable.bind(null, 'npm'), getExecutable.bind(null, 'yarn')],
+    (err, res) => {
+      if (err) {
+        next(err);
+        return;
+      }
 
-    next(null, { npm: res[0], yarn: res[1] });
-  });
+      next(null, { npm: res[0], yarn: res[1] });
+    }
+  );
 }
 
 module.exports = {

--- a/lib/package-manager/install.js
+++ b/lib/package-manager/install.js
@@ -8,25 +8,31 @@ const spawn = require('../spawn');
 const timeout = require('../timeout');
 
 function install(packageManager, context, next) {
-  const options =
-    createOptions(
-      path.join(context.path, context.module.name), context);
+  const options = createOptions(
+    path.join(context.path, context.module.name),
+    context
+  );
   let args = ['install'];
-  context.emit('data', 'info', `${context.module.name} ${packageManager
-    }:`,
-    `${packageManager} install started`);
+  context.emit(
+    'data',
+    'info',
+    `${context.module.name} ${packageManager}:`,
+    `${packageManager} install started`
+  );
 
-  context.emit('data', 'verbose', `${context.module.name} ${packageManager
-    }:`,
-    `Using temp directory: "${options.env['npm_config_tmp']}"`);
+  context.emit(
+    'data',
+    'verbose',
+    `${context.module.name} ${packageManager}:`,
+    `Using temp directory: "${options.env['npm_config_tmp']}"`
+  );
 
   if (context.module.install) {
     args = args.concat(context.module.install);
   }
 
-  const packageManagerBin = packageManager === 'npm'
-    ? context.npmPath
-    : context.yarnPath;
+  const packageManagerBin =
+    packageManager === 'npm' ? context.npmPath : context.yarnPath;
 
   const binDirectory = path.dirname(packageManagerBin);
   options.env.PATH = `${binDirectory}:${process.env.PATH}`;
@@ -40,9 +46,12 @@ function install(packageManager, context, next) {
       chunk = stripAnsi(chunk.toString());
       chunk = chunk.replace(/\r/g, '\n');
     }
-    context.emit('data', 'warn', `${context.module.name
-      } ${packageManager}-install:`,
-      chunk.toString());
+    context.emit(
+      'data',
+      'warn',
+      `${context.module.name} ${packageManager}-install:`,
+      chunk.toString()
+    );
   });
 
   proc.stdout.on('data', (chunk) => {
@@ -51,9 +60,12 @@ function install(packageManager, context, next) {
       chunk = stripAnsi(chunk.toString());
       chunk = chunk.replace(/\r/g, '\n');
     }
-    context.emit('data', 'verbose', `${context.module.name
-      } ${packageManager}-install:`,
-      chunk.toString());
+    context.emit(
+      'data',
+      'verbose',
+      `${context.module.name} ${packageManager}-install:`,
+      chunk.toString()
+    );
   });
 
   proc.on('error', () => {
@@ -64,9 +76,12 @@ function install(packageManager, context, next) {
     if (code > 0) {
       return finish(Error('Install Failed'));
     }
-    context.emit('data', 'info', `${context.module.name} ${
-      packageManager}:`,
-      `${packageManager} install successfully completed`);
+    context.emit(
+      'data',
+      'info',
+      `${context.module.name} ${packageManager}:`,
+      `${packageManager} install successfully completed`
+    );
     return finish(null, context);
   });
 }

--- a/lib/package-manager/test.js
+++ b/lib/package-manager/test.js
@@ -22,19 +22,26 @@ function authorName(author) {
 
 function test(packageManager, context, next) {
   const wd = path.join(context.path, context.module.name);
-  context.emit('data', 'info', `${context.module.name} ${packageManager}:`,
-      'test suite started');
+  context.emit(
+    'data',
+    'info',
+    `${context.module.name} ${packageManager}:`,
+    'test suite started'
+  );
   readPackage(path.join(wd, 'package.json'), false, (err, data) => {
     if (err) {
       next(new Error('Package.json Could not be found'));
       return;
     }
-    if (data.scripts === undefined ||
-        data.scripts.test === undefined) {
+    if (data.scripts === undefined || data.scripts.test === undefined) {
       if (data.author) {
-        context.emit('data', 'warn', `${context.module.name} notice`,
-          `Please contact the module developer to request adding ${
-          packageManager}` + ` test support: ${authorName(data.author)}`);
+        context.emit(
+          'data',
+          'warn',
+          `${context.module.name} notice`,
+          `Please contact the module developer to request adding ${packageManager}` +
+            ` test support: ${authorName(data.author)}`
+        );
       }
       next(new Error(`Module does not support ${packageManager}-test!`));
       return;
@@ -44,21 +51,22 @@ function test(packageManager, context, next) {
     let nodeBin = 'node';
     if (context.options.testPath) {
       options.env.PATH = `${context.options.testPath}:${process.env.PATH}`;
-      nodeBin = which(nodeBinName, {path: options.env.PATH
-            || process.env.PATH});
+      nodeBin = which(nodeBinName, {
+        path: options.env.PATH || process.env.PATH
+      });
     }
 
-    const packageManagerBin = packageManager === 'npm'
-      ? context.npmPath
-      : context.yarnPath;
+    const packageManagerBin =
+      packageManager === 'npm' ? context.npmPath : context.yarnPath;
 
     const binDirectory = path.dirname(packageManagerBin);
     options.env.PATH = `${binDirectory}:${process.env.PATH}`;
 
     /* Run `npm/yarn test`, or `/path/to/customTest.js` if the customTest option
      was passed */
-    const args = context.options.customTest ?
-      [context.options.customTest] : [packageManagerBin, 'test'];
+    const args = context.options.customTest
+      ? [context.options.customTest]
+      : [packageManagerBin, 'test'];
 
     const proc = spawn(nodeBin, args, options);
     const finish = timeout(context, proc, next, 'Test');
@@ -69,13 +77,21 @@ function test(packageManager, context, next) {
         data = stripAnsi(data.toString());
         data = data.replace(/\r/g, '\n');
       }
-      context.emit('data', 'verbose', `${context.module.name} npm-test:`,
-          data.toString());
+      context.emit(
+        'data',
+        'verbose',
+        `${context.module.name} npm-test:`,
+        data.toString()
+      );
     });
     proc.stderr.on('data', (data) => {
       context.testError.append(data);
-      context.emit('data', 'verbose', `${context.module.name} npm-test:`,
-          data.toString());
+      context.emit(
+        'data',
+        'verbose',
+        `${context.module.name} npm-test:`,
+        data.toString()
+      );
     });
     proc.on('error', () => {
       finish(new Error('Tests Failed'));
@@ -86,7 +102,6 @@ function test(packageManager, context, next) {
       }
       return finish(null, context);
     });
-
   });
 }
 

--- a/lib/reporter/junit.js
+++ b/lib/reporter/junit.js
@@ -7,7 +7,7 @@ const builder = require('xmlbuilder');
 const util = require('./util');
 
 function generateTest(xml, mod) {
-  const output =util.sanitizeOutput(mod.testOutput, '', true);
+  const output = util.sanitizeOutput(mod.testOutput, '', true);
   const item = xml.ele('testcase');
   item.att('name', [mod.name, `v${mod.version}`].join('-'));
   item.att('time', mod.duration / 1000);
@@ -16,14 +16,17 @@ function generateTest(xml, mod) {
     item.ele('skipped');
   }
   if (mod.error) {
-    item.ele('failure', {'message': 'module test suite failed'}, [mod.error,
-      mod.testError].join(' '));
+    item.ele(
+      'failure',
+      { message: 'module test suite failed' },
+      [mod.error, mod.testError].join(' ')
+    );
   }
   return xml;
 }
 
 function generateJunit(modules) {
-  const xml = builder.create('testsuite', {headless: false});
+  const xml = builder.create('testsuite', { headless: false });
   xml.att('name', 'citgm');
   _.reduce(modules, generateTest, xml);
   xml.end({ pretty: true });
@@ -36,7 +39,7 @@ function junit(logger, modules, append) {
   }
   const payload = generateJunit(modules);
   if (typeof logger === 'string') {
-    if (append){
+    if (append) {
       fs.appendFileSync(logger, `${payload}\n`);
     } else {
       fs.writeFileSync(logger, `${payload}\n`);

--- a/lib/reporter/markdown.js
+++ b/lib/reporter/markdown.js
@@ -7,8 +7,7 @@ function printModulesMarkdown(logger, title, modules) {
   if (modules.length > 0) {
     logger(`### ${title} Modules`);
     _.each(modules, (mod) => {
-      logger(`  * ${mod.name} v${mod.version} duration:${
-          mod.duration}ms`);
+      logger(`  * ${mod.name} v${mod.version} duration:${mod.duration}ms`);
       if (mod.error) {
         logger(`    - ${mod.error.message}`);
       }

--- a/lib/reporter/tap.js
+++ b/lib/reporter/tap.js
@@ -6,17 +6,23 @@ const _ = require('lodash');
 const util = require('./util');
 
 function generateTest(mod, count) {
-  const result = (!mod.error || mod.flaky) ? 'ok' : 'not ok';
-  const directive = (mod.flaky && mod.error) ? ' # SKIP' : '';
+  const result = !mod.error || mod.flaky ? 'ok' : 'not ok';
+  const directive = mod.flaky && mod.error ? ' # SKIP' : '';
   if (mod.error && mod.error.message) {
     mod.error = mod.error.message;
   }
   const error = mod.error ? [directive, mod.error].join(' ') : '';
   const duration = `\n  duration_ms: ${mod.duration}`;
-  const output = mod.testOutput ? `\n${util.sanitizeOutput(mod.testOutput,
-        '  #')}` : '';
-  return [result, count + 1, '-', mod.name, `v${mod.version}${error
-      }\n  ---${output}${duration}\n  ...`].join(' ');
+  const output = mod.testOutput
+    ? `\n${util.sanitizeOutput(mod.testOutput, '  #')}`
+    : '';
+  return [
+    result,
+    count + 1,
+    '-',
+    mod.name,
+    `v${mod.version}${error}\n  ---${output}${duration}\n  ...`
+  ].join(' ');
 }
 
 function generateTap(modules) {
@@ -30,7 +36,7 @@ function tap(logger, modules, append) {
   }
   const payload = generateTap(modules);
   if (typeof logger === 'string') {
-    if (append){
+    if (append) {
       fs.appendFileSync(logger, `${payload}\n`);
     } else {
       fs.writeFileSync(logger, `${payload}\n`);

--- a/lib/reporter/util.js
+++ b/lib/reporter/util.js
@@ -16,25 +16,25 @@ function getSkipped(modules) {
 
 function getFlakyFails(modules) {
   return _.filter(modules, (mod) => {
-    return (mod.error && mod.flaky);
+    return mod.error && mod.flaky;
   });
 }
 
 function getExpectedFails(modules) {
   return _.filter(modules, (mod) => {
-    return (mod.expectFail && mod.error);
+    return mod.expectFail && mod.error;
   });
 }
 
 function getFails(modules) {
   return _.filter(modules, (mod) => {
-    return (mod.error && !mod.flaky && !mod.expectFail);
+    return mod.error && !mod.flaky && !mod.expectFail;
   });
 }
 
 function hasFailures(modules) {
   return _.some(modules, (mod) => {
-    return (mod.error && !mod.flaky);
+    return mod.error && !mod.flaky;
   });
 }
 
@@ -42,28 +42,36 @@ function sanitizeOutput(output, delimiter, xml) {
   if (!output || output === '') return '';
   /* eslint-disable no-control-regex */
   // ([valid-range])|. matches anything but only captures valid-range
-  const validUtf8 = new RegExp(`(${[
-    /[\x09\x0A\x0D\x20-\x7E]/, // ASCII
-    /[\xC2-\xDF][\x80-\xBF]/, // Non-overlong 2-byte
-    /\xE0[\xA0-\xBF][\x80-\xBF]/, // Excluding overlongs
-    /[\xE1-\xEC\xEE\xEF][\x80-\xBF]{2}/, // Straight 3-byte
-    /\xED[\x80-\x9F][\x80-\xBF]/, // Excluding surrogates
-    /\xF0[\x90-\xBF][\x80-\xBF]{2}/, // Planes 1-3
-    /[\xF1-\xF3][\x80-\xBF]{3}/, // Planes 4-15
-    /\xF4[\x80-\x8F][\x80-\xBF]{2}/ // Plane 16
-  ].map((r) => {
-    return r.source;
-  }).join('|')})|.`, 'g');
+  const validUtf8 = new RegExp(
+    `(${[
+      /[\x09\x0A\x0D\x20-\x7E]/, // ASCII
+      /[\xC2-\xDF][\x80-\xBF]/, // Non-overlong 2-byte
+      /\xE0[\xA0-\xBF][\x80-\xBF]/, // Excluding overlongs
+      /[\xE1-\xEC\xEE\xEF][\x80-\xBF]{2}/, // Straight 3-byte
+      /\xED[\x80-\x9F][\x80-\xBF]/, // Excluding surrogates
+      /\xF0[\x90-\xBF][\x80-\xBF]{2}/, // Planes 1-3
+      /[\xF1-\xF3][\x80-\xBF]{3}/, // Planes 4-15
+      /\xF4[\x80-\x8F][\x80-\xBF]{2}/ // Plane 16
+    ]
+      .map((r) => {
+        return r.source;
+      })
+      .join('|')})|.`,
+    'g'
+  );
   /* eslint-enable no-control-regex */
   // $1 matches the valid-range char if captured, or '' otherwise
   // So this removes all invalid UTF-8
-  return _(output.replace(validUtf8, '$1').split(/[\r\n]+/)).filter(
-  (item) => {
-    return item.length && item !== '\n' && item !== 'undefined';
-  }).map((item) => {
-    if (xml) item = xmlSanitizer(item);
-    return [delimiter, item].join(' ');
-  }).value().join('\n');
+  return _(output.replace(validUtf8, '$1').split(/[\r\n]+/))
+    .filter((item) => {
+      return item.length && item !== '\n' && item !== 'undefined';
+    })
+    .map((item) => {
+      if (xml) item = xmlSanitizer(item);
+      return [delimiter, item].join(' ');
+    })
+    .value()
+    .join('\n');
 }
 
 module.exports = {

--- a/lib/temp-directory.js
+++ b/lib/temp-directory.js
@@ -12,8 +12,12 @@ function create(context, next) {
   } else {
     context.path = path.join(osenv.tmpdir(), uuid.v4());
   }
-  context.emit('data', 'verbose', `${context.module.name} mk.tempdir`,
-      context.path);
+  context.emit(
+    'data',
+    'verbose',
+    `${context.module.name} mk.tempdir`,
+    context.path
+  );
 
   context.npmConfigTmp = path.join(context.path, 'npm_config_tmp');
 
@@ -29,8 +33,12 @@ function remove(context, next) {
   if (!context.path) {
     return next(null, context);
   }
-  context.emit('data', 'silly', `${context.module.name} rm.tempdir`,
-      context.path);
+  context.emit(
+    'data',
+    'silly',
+    `${context.module.name} rm.tempdir`,
+    context.path
+  );
   rimraf(context.path, (err) => {
     return next(err, context);
   });

--- a/lib/timeout.js
+++ b/lib/timeout.js
@@ -12,8 +12,12 @@ function timeout(context, proc, next, step) {
 
   function finish(err, ret, timedOut) {
     if (hasRun) {
-      context.emit('data', 'info', `${context.module.name} npm:`,
-        `${step} timeout.finish called more then once`);
+      context.emit(
+        'data',
+        'info',
+        `${context.module.name} npm:`,
+        `${step} timeout.finish called more then once`
+      );
       return;
     }
     hasRun = true;
@@ -21,8 +25,12 @@ function timeout(context, proc, next, step) {
     clearTimeout(timeout);
     if (timedOut) {
       context.module.flaky = true;
-      context.emit('data', 'error', `${context.module.name} npm:`,
-        `npm-${step.toLowerCase()} Timed Out`);
+      context.emit(
+        'data',
+        'error',
+        `${context.module.name} npm:`,
+        `npm-${step.toLowerCase()} Timed Out`
+      );
       proc.kill();
       err = new Error(`${step} Timed Out`);
       ret = null;

--- a/lib/unpack.js
+++ b/lib/unpack.js
@@ -15,8 +15,12 @@ function unpack(context, next) {
           if (err) {
             return next(err);
           }
-          context.emit('data', 'silly', `${context.module.name
-              } gzip-unpack-start`, context.unpack);
+          context.emit(
+            'data',
+            'silly',
+            `${context.module.name} gzip-unpack-start`,
+            context.unpack
+          );
           const gzip = zlib.createGunzip();
           const inp = fs.createReadStream(context.unpack);
           const out = tar.extract({
@@ -25,8 +29,12 @@ function unpack(context, next) {
           });
           const res = inp.pipe(gzip).pipe(out);
           res.on('close', () => {
-            context.emit('data', 'silly', `${context.module.name
-                } gzip-unpack-close`, context.unpack);
+            context.emit(
+              'data',
+              'silly',
+              `${context.module.name} gzip-unpack-close`,
+              context.unpack
+            );
             return next(null, context);
           });
           res.on('error', (err) => {

--- a/lib/update.js
+++ b/lib/update.js
@@ -16,7 +16,11 @@ module.exports = function(log) {
           'update-available',
           util.format(
             'v%s (current: v%s)\nnpm install -g %s',
-            update.latest, update.current, pkg.name));
+            update.latest,
+            update.current,
+            pkg.name
+          )
+        );
       }
     }
   });

--- a/package.json
+++ b/package.json
@@ -62,11 +62,28 @@
   },
   "devDependencies": {
     "eslint": "^5.7.0",
+    "eslint-config-prettier": "^3.3.0",
+    "eslint-plugin-prettier": "^3.0.0",
     "ncp": "^2.0.0",
+    "prettier": "1.15.2",
     "rewire": "^4.0.1",
     "string-to-stream": "^1.1.1",
     "tap": "^12.0.1",
     "tap-parser": "^7.0.0",
     "xml2js": "^0.4.19"
+  },
+  "prettier": {
+    "arrowParens": "always",
+    "endOfLine": "lf",
+    "proseWrap": "always",
+    "singleQuote": true,
+    "overrides": [
+      {
+        "files": "LICENSE.md",
+        "options": {
+          "proseWrap": "never"
+        }
+      }
+    ]
   }
 }

--- a/test/bin/test-citgm-all.js
+++ b/test/bin/test-citgm-all.js
@@ -7,8 +7,13 @@ const citgmAllPath = require.resolve('../../bin/citgm-all.js');
 
 test('citgm-all: /w markdown /w -j', (t) => {
   t.plan(1);
-  const proc = spawn(citgmAllPath, ['-l', 'test/fixtures/custom-lookup.json',
-    '-m', '-j', '1']);
+  const proc = spawn(citgmAllPath, [
+    '-l',
+    'test/fixtures/custom-lookup.json',
+    '-m',
+    '-j',
+    '1'
+  ]);
   proc.on('error', (err) => {
     t.error(err);
     t.fail('we should not get an error testing omg-i-pass');
@@ -20,34 +25,48 @@ test('citgm-all: /w markdown /w -j', (t) => {
 
 test('citgm-all: /w missing lookup.json', (t) => {
   t.plan(1);
-  const proc = spawn(citgmAllPath, ['-l',
-    'test/fixtures/this-does-not-exist-json']);
+  const proc = spawn(citgmAllPath, [
+    '-l',
+    'test/fixtures/this-does-not-exist-json'
+  ]);
   proc.on('error', (err) => {
     t.error(err);
   });
   proc.on('close', (code) => {
-    t.equals(code, 1,
-          'citgm-all should fail if the lookup.json does not exist');
+    t.equals(
+      code,
+      1,
+      'citgm-all should fail if the lookup.json does not exist'
+    );
   });
 });
 
 test('citgm-all: /w bad lookup.json', (t) => {
   t.plan(1);
-  const proc = spawn(citgmAllPath, ['-l',
-    'test/fixtures/custom-lookup-broken.json']);
+  const proc = spawn(citgmAllPath, [
+    '-l',
+    'test/fixtures/custom-lookup-broken.json'
+  ]);
   proc.on('error', (err) => {
     t.error(err);
   });
   proc.on('close', (code) => {
-    t.equals(code, 1,
-        'citgm-all should fail if the lookup.json contains errors');
+    t.equals(
+      code,
+      1,
+      'citgm-all should fail if the lookup.json contains errors'
+    );
   });
 });
 
 test('citgm-all: fail /w tap /w junit', (t) => {
   t.plan(1);
-  const proc = spawn(citgmAllPath, ['-l',
-    'test/fixtures/custom-lookup-fail.json', '-t', '-x']);
+  const proc = spawn(citgmAllPath, [
+    '-l',
+    'test/fixtures/custom-lookup-fail.json',
+    '-t',
+    '-x'
+  ]);
   proc.on('error', (err) => {
     t.error(err);
   });
@@ -58,8 +77,10 @@ test('citgm-all: fail /w tap /w junit', (t) => {
 
 test('citgm-all: flaky-fail', (t) => {
   t.plan(1);
-  const proc = spawn(citgmAllPath, ['-l',
-    'test/fixtures/custom-lookup-flaky.json']);
+  const proc = spawn(citgmAllPath, [
+    '-l',
+    'test/fixtures/custom-lookup-flaky.json'
+  ]);
   proc.on('error', (err) => {
     t.error(err);
   });
@@ -70,8 +91,10 @@ test('citgm-all: flaky-fail', (t) => {
 
 test('citgm-all: fail expectFail', (t) => {
   t.plan(1);
-  const proc = spawn(citgmAllPath, ['-l',
-    'test/fixtures/custom-lookup-expectFail.json']);
+  const proc = spawn(citgmAllPath, [
+    '-l',
+    'test/fixtures/custom-lookup-expectFail.json'
+  ]);
   proc.on('error', (err) => {
     t.error(err);
   });
@@ -82,8 +105,10 @@ test('citgm-all: fail expectFail', (t) => {
 
 test('citgm-all: pass expectFail', (t) => {
   t.plan(1);
-  const proc = spawn(citgmAllPath, ['-l',
-    'test/fixtures/custom-lookup-expectFail-fail.json']);
+  const proc = spawn(citgmAllPath, [
+    '-l',
+    'test/fixtures/custom-lookup-expectFail-fail.json'
+  ]);
   proc.on('error', (err) => {
     t.error(err);
   });
@@ -94,8 +119,10 @@ test('citgm-all: pass expectFail', (t) => {
 
 test('citgm-all: test with replace', (t) => {
   t.plan(1);
-  const proc = spawn(citgmAllPath, ['-l',
-    'test/fixtures/custom-lookup-backwards-compatibilty.json']);
+  const proc = spawn(citgmAllPath, [
+    '-l',
+    'test/fixtures/custom-lookup-backwards-compatibilty.json'
+  ]);
   proc.on('error', (err) => {
     t.error(err);
   });
@@ -106,8 +133,11 @@ test('citgm-all: test with replace', (t) => {
 
 test('citgm-all: flaky-fail ignoring flakyness', (t) => {
   t.plan(1);
-  const proc = spawn(citgmAllPath, ['-f', '-l',
-    'test/fixtures/custom-lookup-flaky.json']);
+  const proc = spawn(citgmAllPath, [
+    '-f',
+    '-l',
+    'test/fixtures/custom-lookup-flaky.json'
+  ]);
   proc.on('error', (err) => {
     t.error(err);
   });
@@ -118,8 +148,12 @@ test('citgm-all: flaky-fail ignoring flakyness', (t) => {
 
 test('citgm-all: includeTags', (t) => {
   t.plan(1);
-  const proc = spawn(citgmAllPath, ['--includeTags', 'tag1', '-l',
-    'test/fixtures/custom-lookup-tags.json']);
+  const proc = spawn(citgmAllPath, [
+    '--includeTags',
+    'tag1',
+    '-l',
+    'test/fixtures/custom-lookup-tags.json'
+  ]);
   proc.on('error', (err) => {
     t.error(err);
   });
@@ -130,8 +164,12 @@ test('citgm-all: includeTags', (t) => {
 
 test('citgm-all: excludeTags', (t) => {
   t.plan(1);
-  const proc = spawn(citgmAllPath, ['--excludeTags', 'tag2', '-l',
-    'test/fixtures/custom-lookup-tags.json']);
+  const proc = spawn(citgmAllPath, [
+    '--excludeTags',
+    'tag2',
+    '-l',
+    'test/fixtures/custom-lookup-tags.json'
+  ]);
   proc.on('error', (err) => {
     t.error(err);
   });
@@ -142,8 +180,12 @@ test('citgm-all: excludeTags', (t) => {
 
 test('citgm-all: includeTags multiple', (t) => {
   t.plan(1);
-  const proc = spawn(citgmAllPath, ['--includeTags', 'tag1 noTag1 NoTag2', '-l',
-    'test/fixtures/custom-lookup-tags.json']);
+  const proc = spawn(citgmAllPath, [
+    '--includeTags',
+    'tag1 noTag1 NoTag2',
+    '-l',
+    'test/fixtures/custom-lookup-tags.json'
+  ]);
   proc.on('error', (err) => {
     t.error(err);
   });
@@ -154,8 +196,12 @@ test('citgm-all: includeTags multiple', (t) => {
 
 test('citgm-all: excludeTags modulename', (t) => {
   t.plan(1);
-  const proc = spawn(citgmAllPath, ['--excludeTags', 'omg-i-fail', '-l',
-    'test/fixtures/custom-lookup-tags.json']);
+  const proc = spawn(citgmAllPath, [
+    '--excludeTags',
+    'omg-i-fail',
+    '-l',
+    'test/fixtures/custom-lookup-tags.json'
+  ]);
   proc.on('error', (err) => {
     t.error(err);
   });
@@ -166,8 +212,12 @@ test('citgm-all: excludeTags modulename', (t) => {
 
 test('citgm-all: includeTags modulename multiple', (t) => {
   t.plan(1);
-  const proc = spawn(citgmAllPath, ['--includeTags', 'omg-i-pass noTag1 NoTag2',
-    '-l', 'test/fixtures/custom-lookup-tags.json']);
+  const proc = spawn(citgmAllPath, [
+    '--includeTags',
+    'omg-i-pass noTag1 NoTag2',
+    '-l',
+    'test/fixtures/custom-lookup-tags.json'
+  ]);
   proc.on('error', (err) => {
     t.error(err);
   });
@@ -176,12 +226,18 @@ test('citgm-all: includeTags modulename multiple', (t) => {
   });
 });
 
-test('citgm-all: skip /w rootcheck /w tap to fs /w junit to fs /w append',
-(t) => {
+test('citgm-all: skip /w rootcheck /w tap to fs /w junit to fs /w append', (t) => {
   t.plan(1);
-  const proc = spawn(citgmAllPath, ['-l',
-    'test/fixtures/custom-lookup-skip.json', '-s', '--tap', '/dev/null',
-    '--junit', '/dev/null', '-a']);
+  const proc = spawn(citgmAllPath, [
+    '-l',
+    'test/fixtures/custom-lookup-skip.json',
+    '-s',
+    '--tap',
+    '/dev/null',
+    '--junit',
+    '/dev/null',
+    '-a'
+  ]);
   proc.on('error', (err) => {
     t.error(err);
   });
@@ -193,8 +249,11 @@ test('citgm-all: skip /w rootcheck /w tap to fs /w junit to fs /w append',
 test('bin: sigterm', (t) => {
   t.plan(1);
 
-  const proc = spawn(citgmAllPath, ['-l', 'test/fixtures/custom-lookup.json',
-    '-m']);
+  const proc = spawn(citgmAllPath, [
+    '-l',
+    'test/fixtures/custom-lookup.json',
+    '-m'
+  ]);
   proc.on('error', (err) => {
     t.error(err);
     t.fail('we should not get an error testing omg-i-pass');
@@ -209,9 +268,12 @@ test('bin: sigterm', (t) => {
 
 test('bin: test custom test', (t) => {
   t.plan(1);
-  const proc = spawn(citgmAllPath, ['-l',
+  const proc = spawn(citgmAllPath, [
+    '-l',
     'test/fixtures/custom-lookup-customTest.json',
-    '--customTest', `${process.cwd()}/test/fixtures/custom test script.js`]);
+    '--customTest',
+    `${process.cwd()}/test/fixtures/custom test script.js`
+  ]);
   proc.on('error', (err) => {
     t.error(err);
     t.fail('we should not get an error testing omg-i-fail');
@@ -223,9 +285,12 @@ test('bin: test custom test', (t) => {
 
 test('bin: test custom test', (t) => {
   t.plan(1);
-  const proc = spawn(citgmAllPath, ['-l',
+  const proc = spawn(citgmAllPath, [
+    '-l',
     'test/fixtures/custom-lookup-customTest.json',
-    '--customTest', `${process.cwd()}/test/fixtures/no such file.js`]);
+    '--customTest',
+    `${process.cwd()}/test/fixtures/no such file.js`
+  ]);
   proc.on('close', (code) => {
     t.ok(code !== 0, 'omg-i-fail should fail with a non-zero exit code');
   });

--- a/test/bin/test-citgm.js
+++ b/test/bin/test-citgm.js
@@ -8,8 +8,14 @@ const citgmPath = require.resolve('../../bin/citgm.js');
 
 test('bin: omg-i-pass /w tap to file /w junit to file /w append', (t) => {
   t.plan(1);
-  const proc = spawn(citgmPath, ['omg-i-pass', '--tap', '/dev/null', '--junit',
-    '/dev/null', '--append']);
+  const proc = spawn(citgmPath, [
+    'omg-i-pass',
+    '--tap',
+    '/dev/null',
+    '--junit',
+    '/dev/null',
+    '--append'
+  ]);
   proc.on('error', (err) => {
     t.error(err);
     t.fail('we should not get an error testing omg-i-pass');
@@ -19,11 +25,16 @@ test('bin: omg-i-pass /w tap to file /w junit to file /w append', (t) => {
   });
 });
 
-test('bin: omg-i-fail /w tap /w junit /w markdown output /w nodedir',
-(t) => {
+test('bin: omg-i-fail /w tap /w junit /w markdown output /w nodedir', (t) => {
   t.plan(1);
-  const proc = spawn(citgmPath, ['omg-i-fail', '-m', '-t', '-x', '-d',
-    '/dev/null']);
+  const proc = spawn(citgmPath, [
+    'omg-i-fail',
+    '-m',
+    '-t',
+    '-x',
+    '-d',
+    '/dev/null'
+  ]);
   proc.on('error', (err) => {
     t.error(err);
     t.fail('we should not get an error testing omg-i-pass');
@@ -75,8 +86,12 @@ test('bin: sigterm', (t) => {
 
 test('bin: install from sha', (t) => {
   t.plan(1);
-  const proc = spawn(citgmPath, ['omg-i-pass', '-t', '-c',
-    '37c34bad563599782c622baf3aaf55776fbc38a8']);
+  const proc = spawn(citgmPath, [
+    'omg-i-pass',
+    '-t',
+    '-c',
+    '37c34bad563599782c622baf3aaf55776fbc38a8'
+  ]);
   proc.on('error', (err) => {
     t.error(err);
     t.fail('we should not get an error testing omg-i-pass');
@@ -88,8 +103,11 @@ test('bin: install from sha', (t) => {
 
 test('bin: test custom test', (t) => {
   t.plan(1);
-  const proc = spawn(citgmPath, ['omg-i-fail', '--customTest',
-    `${process.cwd()}/test/fixtures/custom test script.js`]);
+  const proc = spawn(citgmPath, [
+    'omg-i-fail',
+    '--customTest',
+    `${process.cwd()}/test/fixtures/custom test script.js`
+  ]);
   proc.on('error', (err) => {
     t.error(err);
     t.fail('we should not get an error testing omg-i-fail');
@@ -101,8 +119,11 @@ test('bin: test custom test', (t) => {
 
 test('bin: test custom test', (t) => {
   t.plan(1);
-  const proc = spawn(citgmPath, ['omg-i-fail', '--customTest',
-    `${process.cwd()}/test/fixtures/no such file.js`]);
+  const proc = spawn(citgmPath, [
+    'omg-i-fail',
+    '--customTest',
+    `${process.cwd()}/test/fixtures/no such file.js`
+  ]);
   proc.on('close', (code) => {
     t.ok(code !== 0, 'omg-i-fail should fail with a non-zero exit code');
   });

--- a/test/fixtures/custom-lookup-no-repo.json
+++ b/test/fixtures/custom-lookup-no-repo.json
@@ -1,4 +1,3 @@
 {
-  "omg-i-pass": {
-  }
+  "omg-i-pass": {}
 }

--- a/test/fixtures/omg-i-pass-with-install-param/test_args.js
+++ b/test/fixtures/omg-i-pass-with-install-param/test_args.js
@@ -7,5 +7,4 @@
   extra parameters to env variables prefixed 'npm_config_'. In our example, npm
   will set 'npm_config_extra_param' to true.
 */
-if (!process.env['npm_config_extra_param'])
-  process.exit(1);
+if (!process.env['npm_config_extra_param']) process.exit(1);

--- a/test/fixtures/parsed-junit.json
+++ b/test/fixtures/parsed-junit.json
@@ -9,21 +9,15 @@
           "name": "iPass-v4.2.2",
           "time": "0.05"
         },
-        "system-out": [
-          "\n      \n    "
-        ]
+        "system-out": ["\n      \n    "]
       },
       {
         "$": {
           "name": "iFlakyFail-v3.3.3",
           "time": "0.05"
         },
-        "system-out": [
-          "\n       Thanks for testing!\n    "
-        ],
-        "skipped": [
-          ""
-        ],
+        "system-out": ["\n       Thanks for testing!\n    "],
+        "skipped": [""],
         "failure": [
           {
             "_": "[object Object] ",
@@ -38,9 +32,7 @@
           "name": "iFail-v3.0.1",
           "time": "0.05"
         },
-        "system-out": [
-          "\n       Thanks for testing!\n    "
-        ],
+        "system-out": ["\n       Thanks for testing!\n    "],
         "failure": [
           {
             "_": "[object Object] ",

--- a/test/fixtures/request-mock.js
+++ b/test/fixtures/request-mock.js
@@ -3,8 +3,7 @@ const EventEmitter = require('events').EventEmitter;
 const util = require('util');
 
 function RequestMock() {
-  if (!(this instanceof RequestMock))
-    return new RequestMock;
+  if (!(this instanceof RequestMock)) return new RequestMock();
   EventEmitter.call(this);
 }
 

--- a/test/npm/test-npm-author-name.js
+++ b/test/npm/test-npm-author-name.js
@@ -16,8 +16,11 @@ test('npm.test() authorName:', (t) => {
   };
   const authorExpected = 'Randy Savage <randy@wwe.rekt> (omg.html)';
   t.equals(authorName(name), name, 'it should return any string');
-  t.equals(authorName(author), authorExpected, 'it should return the expected'
-    + ' string when given an object');
+  t.equals(
+    authorName(author),
+    authorExpected,
+    'it should return the expected' + ' string when given an object'
+  );
   t.end();
 });
 
@@ -32,9 +35,15 @@ test('npm.test() authorName partial data:', (t) => {
   };
   const authorTwoExpected = '<thedude@abides.net>';
   t.equals(authorName(name), name, 'it should return any string');
-  t.equals(authorName(authorOne), authorOneExpected, 'it should return the'
-    + ' expected string when given an object');
-  t.equals(authorName(authorTwo), authorTwoExpected, 'it should return the'
-  + ' expected string when given an object');
+  t.equals(
+    authorName(authorOne),
+    authorOneExpected,
+    'it should return the' + ' expected string when given an object'
+  );
+  t.equals(
+    authorName(authorTwo),
+    authorTwoExpected,
+    'it should return the' + ' expected string when given an object'
+  );
   t.end();
 });

--- a/test/npm/test-npm-install.js
+++ b/test/npm/test-npm-install.js
@@ -47,10 +47,14 @@ test('npm-install: setup', (t) => {
 });
 
 test('npm-install: basic module', (t) => {
-  const context = makeContext.npmContext('omg-i-pass', packageManagers,
-    sandbox, {
+  const context = makeContext.npmContext(
+    'omg-i-pass',
+    packageManagers,
+    sandbox,
+    {
       npmLevel: 'silly'
-    });
+    }
+  );
   packageManagerInstall('npm', context, (err) => {
     t.error(err);
     t.end();
@@ -58,12 +62,17 @@ test('npm-install: basic module', (t) => {
 });
 
 test('npm-install: extra install parameters', (t) => {
-  const context = makeContext.npmContext({
-    name: 'omg-i-pass-with-install-param',
-    install: ['--extra-param']
-  }, packageManagers, sandbox, {
-    npmLevel: 'silly'
-  });
+  const context = makeContext.npmContext(
+    {
+      name: 'omg-i-pass-with-install-param',
+      install: ['--extra-param']
+    },
+    packageManagers,
+    sandbox,
+    {
+      npmLevel: 'silly'
+    }
+  );
   packageManagerInstall('npm', context, (err) => {
     t.error(err);
     t.notOk(context.module.flaky, 'Module passed and is not flaky');
@@ -72,10 +81,14 @@ test('npm-install: extra install parameters', (t) => {
 });
 
 test('npm-install: no package.json', (t) => {
-  const context = makeContext.npmContext('omg-i-fail', packageManagers,
-    sandbox, {
+  const context = makeContext.npmContext(
+    'omg-i-fail',
+    packageManagers,
+    sandbox,
+    {
       npmLevel: 'silly'
-    });
+    }
+  );
   packageManagerInstall('npm', context, (err) => {
     t.equals(err && err.message, 'Install Failed');
     t.notOk(context.module.flaky, 'Module failed but is not flaky');
@@ -84,11 +97,15 @@ test('npm-install: no package.json', (t) => {
 });
 
 test('npm-install: timeout', (t) => {
-  const context = makeContext.npmContext('omg-i-pass', packageManagers,
-    sandbox, {
+  const context = makeContext.npmContext(
+    'omg-i-pass',
+    packageManagers,
+    sandbox,
+    {
       npmLevel: 'silly',
       timeoutLength: 100
-    });
+    }
+  );
   packageManagerInstall('npm', context, (err) => {
     t.ok(context.module.flaky, 'Module is Flaky because install timed out');
     t.equals(err && err.message, 'Install Timed Out');
@@ -97,10 +114,14 @@ test('npm-install: timeout', (t) => {
 });
 
 test('npm-install: failed install', (t) => {
-  const context = makeContext.npmContext('omg-bad-tree', packageManagers,
-    sandbox, {
+  const context = makeContext.npmContext(
+    'omg-bad-tree',
+    packageManagers,
+    sandbox,
+    {
       npmLevel: 'http'
-    });
+    }
+  );
   const expected = {
     testOutput: /^$/,
     testError: /npm ERR! 404 Not [Ff]ound\s*: THIS-WILL-FAIL(@0\.0\.1)?/

--- a/test/npm/test-npm-test.js
+++ b/test/npm/test-npm-test.js
@@ -51,10 +51,14 @@ test('npm-test: setup', (t) => {
 });
 
 test('npm-test: basic module passing', (t) => {
-  const context = makeContext.npmContext('omg-i-pass', packageManagers,
-    sandbox, {
+  const context = makeContext.npmContext(
+    'omg-i-pass',
+    packageManagers,
+    sandbox,
+    {
       npmLevel: 'silly'
-    });
+    }
+  );
   packageManagerTest('npm', context, (err) => {
     t.error(err);
     t.end();
@@ -62,8 +66,11 @@ test('npm-test: basic module passing', (t) => {
 });
 
 test('npm-test: basic module failing', (t) => {
-  const context = makeContext.npmContext('omg-i-fail', packageManagers,
-    sandbox);
+  const context = makeContext.npmContext(
+    'omg-i-fail',
+    packageManagers,
+    sandbox
+  );
   packageManagerTest('npm', context, (err) => {
     t.equals(err && err.message, 'The canary is dead:');
     t.end();
@@ -71,9 +78,11 @@ test('npm-test: basic module failing', (t) => {
 });
 
 test('npm-test: basic module no test script', (t) => {
-  const context =
-    makeContext.npmContext('omg-i-do-not-support-testing', packageManagers,
-      sandbox);
+  const context = makeContext.npmContext(
+    'omg-i-do-not-support-testing',
+    packageManagers,
+    sandbox
+  );
   packageManagerTest('npm', context, (err) => {
     t.equals(err && err.message, 'Module does not support npm-test!');
     t.end();
@@ -81,8 +90,11 @@ test('npm-test: basic module no test script', (t) => {
 });
 
 test('npm-test: no package.json', (t) => {
-  const context = makeContext.npmContext('omg-i-dont-exist', packageManagers,
-    sandbox);
+  const context = makeContext.npmContext(
+    'omg-i-dont-exist',
+    packageManagers,
+    sandbox
+  );
   packageManagerTest('npm', context, (err) => {
     t.equals(err && err.message, 'Package.json Could not be found');
     t.end();
@@ -93,11 +105,15 @@ test('npm-test: alternative test-path', (t) => {
   // Same test as 'basic module passing', except with alt node bin which fails.
   const nodeBinName = packageManagerTest.__get__('nodeBinName');
   packageManagerTest.__set__('nodeBinName', 'fake-node');
-  const context = makeContext.npmContext('omg-i-pass', packageManagers,
-    sandbox, {
+  const context = makeContext.npmContext(
+    'omg-i-pass',
+    packageManagers,
+    sandbox,
+    {
       npmLevel: 'silly',
       testPath: path.resolve(__dirname, '..', 'fixtures', 'fakenodebin')
-    });
+    }
+  );
   packageManagerTest('npm', context, (err) => {
     packageManagerTest.__set__('nodeBinName', nodeBinName);
     t.equals(err && err.message, 'The canary is dead:');
@@ -106,11 +122,15 @@ test('npm-test: alternative test-path', (t) => {
 });
 
 test('npm-test: timeout', (t) => {
-  const context = makeContext.npmContext('omg-i-pass', packageManagers,
-    sandbox, {
+  const context = makeContext.npmContext(
+    'omg-i-pass',
+    packageManagers,
+    sandbox,
+    {
       npmLevel: 'silly',
       timeoutLength: 100
-    });
+    }
+  );
   packageManagerTest('npm', context, (err) => {
     t.ok(context.module.flaky, 'Module is Flaky because tests timed out');
     t.equals(err && err.message, 'Test Timed Out');

--- a/test/reporter/test-reporter-junit.js
+++ b/test/reporter/test-reporter-junit.js
@@ -19,24 +19,21 @@ const outputFileAppend = path.join(sandbox, 'test-append.xml');
 
 const appendStartFilePath = path.join(fixturesPath, 'appendTestFileStart.txt');
 
-const passingInput = [
-  fixtures.iPass,
-  fixtures.iFlakyPass
-];
+const passingInput = [fixtures.iPass, fixtures.iFlakyPass];
 
 const passingExpectedPath = path.join(fixturesPath, 'test-out-xml-passing.txt');
-const passingExpectedPathAppend = path.join(fixturesPath,
-      'test-out-xml-passing-append.txt');
+const passingExpectedPathAppend = path.join(
+  fixturesPath,
+  'test-out-xml-passing-append.txt'
+);
 
 const passingExpected = fs.readFileSync(passingExpectedPath, 'utf-8');
-const passingExpectedAppend = fs.readFileSync(passingExpectedPathAppend,
-      'utf-8');
+const passingExpectedAppend = fs.readFileSync(
+  passingExpectedPathAppend,
+  'utf-8'
+);
 
-const failingInput = [
-  fixtures.iPass,
-  fixtures.iFlakyFail,
-  fixtures.iFail
-];
+const failingInput = [fixtures.iPass, fixtures.iFlakyFail, fixtures.iFail];
 
 const junitParserExpected = require('../fixtures/parsed-junit.json');
 const failingExpectedPath = path.join(fixturesPath, 'test-out-xml-failing.txt');
@@ -62,8 +59,11 @@ test('reporter.junit(): passing', (t) => {
   }
 
   junit(logger, passingInput);
-  t.equals(output, passingExpected, 'we should get expected output when all'
-  + ' modules pass');
+  t.equals(
+    output,
+    passingExpected,
+    'we should get expected output when all' + ' modules pass'
+  );
   t.end();
 });
 
@@ -99,8 +99,8 @@ test('reporter.junit(): failing', (t) => {
   }
 
   junit(logger, failingInput);
-  t.equals(output, failingExpected), 'we should get the expected output when a'
-  + ' module fails';
+  t.equals(output, failingExpected),
+    'we should get the expected output when a' + ' module fails';
   t.end();
 });
 
@@ -113,8 +113,8 @@ test('reporter.junit(): parser', (t) => {
 
   junit(logger, failingInput);
   parseString(output, (err, result) => {
-    t.deepEquals(result, junitParserExpected), 'we should get the expected'
-    + ' output when a module fails';
+    t.deepEquals(result, junitParserExpected),
+      'we should get the expected' + ' output when a module fails';
     t.end();
   });
 });
@@ -122,8 +122,8 @@ test('reporter.junit(): parser', (t) => {
 test('reporter.junit(): write to disk', (t) => {
   junit(outputFile, passingInput);
   const expected = fs.readFileSync(outputFile, 'utf8');
-  t.equals(expected, passingExpected), 'the file on disk should match the'
-  + ' expected output';
+  t.equals(expected, passingExpected),
+    'the file on disk should match the' + ' expected output';
   t.end();
 });
 
@@ -132,8 +132,8 @@ test('reporter.junit(): append to disk', (t) => {
   fs.writeFileSync(outputFileAppend, appendStartFile);
   junit(outputFileAppend, passingInput, true);
   const expected = fs.readFileSync(outputFileAppend, 'utf-8');
-  t.equals(expected, passingExpectedAppend), 'the file on disk should match the'
-  + ' expected output';
+  t.equals(expected, passingExpectedAppend),
+    'the file on disk should match the' + ' expected output';
   t.end();
 });
 

--- a/test/reporter/test-reporter-logger.js
+++ b/test/reporter/test-reporter-logger.js
@@ -58,8 +58,11 @@ test('multiple modules passing, with a flaky module that fails:', (t) => {
   expected += 'done';
   expected += 'The smoke test has passed.';
   output = '';
-  loggerReporter(logger, [fixtures.iPass, fixtures.iFlakyPass,
-    fixtures.iFlakyFail]);
+  loggerReporter(logger, [
+    fixtures.iPass,
+    fixtures.iFlakyPass,
+    fixtures.iFlakyFail
+  ]);
   t.equals(output, expected, 'we should have the expected logged output');
   t.end();
 });

--- a/test/reporter/test-reporter-markdown.js
+++ b/test/reporter/test-reporter-markdown.js
@@ -32,9 +32,12 @@ test('single failing module:', (t) => {
 
 test('multiple modules passing, with a flaky module that fails:', (t) => {
   let output = '';
-  markdown((data) => {
-    output += data;
-  }, [fixtures.iPass, fixtures.iFlakyPass, fixtures.iFlakyFail]);
+  markdown(
+    (data) => {
+      output += data;
+    },
+    [fixtures.iPass, fixtures.iFlakyPass, fixtures.iFlakyFail]
+  );
   let expected = '## 🎉🎉 CITGM Passed 🎉🎉';
   expected += '## 📛 But with Flaky Failures 📛';
   expected += '### Passing Modules';

--- a/test/reporter/test-reporter-tap.js
+++ b/test/reporter/test-reporter-tap.js
@@ -21,25 +21,22 @@ const outputFileAppendBlank = path.join(sandbox, 'test-append-blank.tap');
 
 const appendStartFilePath = path.join(fixturesPath, 'appendTestFileStart.txt');
 
-const passingInput = [
-  fixtures.iPass,
-  fixtures.iFlakyPass
-];
+const passingInput = [fixtures.iPass, fixtures.iFlakyPass];
 
 const passingExpectedPath = path.join(fixturesPath, 'test-out-tap-passing.txt');
-const passingExpectedPathAppend = path.join(fixturesPath,
-    'test-out-tap-passing-append.txt');
+const passingExpectedPathAppend = path.join(
+  fixturesPath,
+  'test-out-tap-passing-append.txt'
+);
 
 const tapParserExpected = require('../fixtures/parsed-tap.json');
 const passingExpected = fs.readFileSync(passingExpectedPath, 'utf-8');
-const passingExpectedAppend = fs.readFileSync(passingExpectedPathAppend,
-  'utf-8');
+const passingExpectedAppend = fs.readFileSync(
+  passingExpectedPathAppend,
+  'utf-8'
+);
 
-const failingInput = [
-  fixtures.iPass,
-  fixtures.iFlakyFail,
-  fixtures.iFail
-];
+const failingInput = [fixtures.iPass, fixtures.iFlakyFail, fixtures.iFail];
 
 const failingExpectedPath = path.join(fixturesPath, 'test-out-tap-failing.txt');
 const failingExpected = fs.readFileSync(failingExpectedPath, 'utf-8');
@@ -59,8 +56,11 @@ test('reporter.tap(): passing', (t) => {
   }
 
   tap(logger, passingInput);
-  t.equals(output, passingExpected, 'we should get expected output when all'
-  + ' modules pass');
+  t.equals(
+    output,
+    passingExpected,
+    'we should get expected output when all' + ' modules pass'
+  );
   t.end();
 });
 
@@ -72,8 +72,8 @@ test('reporter.tap(): failing', (t) => {
   }
 
   tap(logger, failingInput);
-  t.equals(output, failingExpected), 'we should get the expected output when a'
-  + ' module fails';
+  t.equals(output, failingExpected),
+    'we should get the expected output when a' + ' module fails';
   t.end();
 });
 
@@ -84,19 +84,19 @@ test('reporter.tap(): parser', (t) => {
   }
 
   tap(logger, failingInput);
-  const p = new Parser(((results) => {
-    t.deepEquals(results, tapParserExpected), 'the tap parser should correctly'
-    + ' parse the tap file';
+  const p = new Parser((results) => {
+    t.deepEquals(results, tapParserExpected),
+      'the tap parser should correctly' + ' parse the tap file';
     t.end();
-  }));
+  });
   str(output).pipe(p);
 });
 
 test('reporter.tap(): write to disk', (t) => {
   tap(outputFile, passingInput);
   const expected = fs.readFileSync(outputFile, 'utf8');
-  t.equals(expected, passingExpected), 'the file on disk should match the'
-  + ' expected output';
+  t.equals(expected, passingExpected),
+    'the file on disk should match the' + ' expected output';
   t.end();
 });
 
@@ -105,16 +105,16 @@ test('reporter.tap(): append to disk', (t) => {
   fs.writeFileSync(outputFileAppend, appendStartFile);
   tap(outputFileAppend, passingInput, true);
   const expected = fs.readFileSync(outputFileAppend, 'utf8');
-  t.equals(expected, passingExpectedAppend), 'the file on disk should match the'
-  + ' expected output';
+  t.equals(expected, passingExpectedAppend),
+    'the file on disk should match the' + ' expected output';
   t.end();
 });
 
 test('reporter.tap(): append to disk when file does not exist', (t) => {
   tap(outputFileAppendBlank, passingInput, true);
   const expected = fs.readFileSync(outputFileAppendBlank, 'utf8');
-  t.equals(expected, passingExpected), 'the file on disk should match the'
-  + ' expected output';
+  t.equals(expected, passingExpected),
+    'the file on disk should match the' + ' expected output';
   t.end();
 });
 

--- a/test/reporter/test-reporter-util.js
+++ b/test/reporter/test-reporter-util.js
@@ -46,60 +46,113 @@ const flakeCityUsa = [
 ];
 
 test('getPassing:', (t) => {
-  t.equals(util.getPassing(noPassing).length, 0,
-      'there should be no passing modules in the noPassing list');
-  t.equals(util.getPassing(somePassing).length, 2,
-      'there should be two passing modules in the somePassing list');
-  t.equals(util.getPassing(allPassing).length, 3,
-      'there should be three passing modules in the allPassing list');
-  t.equals(util.getPassing(flakeCityUsa).length, 3,
-      'there should be two passing modules in the flakeCityUsa list');
+  t.equals(
+    util.getPassing(noPassing).length,
+    0,
+    'there should be no passing modules in the noPassing list'
+  );
+  t.equals(
+    util.getPassing(somePassing).length,
+    2,
+    'there should be two passing modules in the somePassing list'
+  );
+  t.equals(
+    util.getPassing(allPassing).length,
+    3,
+    'there should be three passing modules in the allPassing list'
+  );
+  t.equals(
+    util.getPassing(flakeCityUsa).length,
+    3,
+    'there should be two passing modules in the flakeCityUsa list'
+  );
   t.end();
 });
 
 test('getSkipped:', (t) => {
-  t.equals(util.getSkipped(noPassing).length, 1,
-      'there should be one skipped module in the noPassing list');
-  t.equals(util.getSkipped(somePassing).length, 1,
-      'there should be one skipped module  in the somePassing list');
-  t.equals(util.getSkipped(allPassing).length, 1,
-      'there should be one skipped module  in the allPassing list');
+  t.equals(
+    util.getSkipped(noPassing).length,
+    1,
+    'there should be one skipped module in the noPassing list'
+  );
+  t.equals(
+    util.getSkipped(somePassing).length,
+    1,
+    'there should be one skipped module  in the somePassing list'
+  );
+  t.equals(
+    util.getSkipped(allPassing).length,
+    1,
+    'there should be one skipped module  in the allPassing list'
+  );
   t.end();
 });
 
 test('getFlakyFails:', (t) => {
-  t.equals(util.getFlakyFails(noPassing).length, 4,
-      'there should be two flaky failing modules in the noPassing list');
-  t.equals(util.getFlakyFails(somePassing).length, 1,
-      'there should be one flaky failing modules in the somePassing list');
-  t.equals(util.getFlakyFails(allPassing).length, 0,
-      'there should be no flaky failing modules in the allPassing list');
-  t.equals(util.getFlakyFails(flakeCityUsa).length, 2,
-      'there should be two flaky failing modules in the flakeCityUsa list');
+  t.equals(
+    util.getFlakyFails(noPassing).length,
+    4,
+    'there should be two flaky failing modules in the noPassing list'
+  );
+  t.equals(
+    util.getFlakyFails(somePassing).length,
+    1,
+    'there should be one flaky failing modules in the somePassing list'
+  );
+  t.equals(
+    util.getFlakyFails(allPassing).length,
+    0,
+    'there should be no flaky failing modules in the allPassing list'
+  );
+  t.equals(
+    util.getFlakyFails(flakeCityUsa).length,
+    2,
+    'there should be two flaky failing modules in the flakeCityUsa list'
+  );
   t.end();
 });
 
 test('getFails:', (t) => {
-  t.equals(util.getFails(noPassing).length, 3,
-      'there should be three failing modules in the noPassing list');
-  t.equals(util.getFails(somePassing).length, 1,
-      'there should be one failing modules in the somePassing list');
-  t.equals(util.getFails(allPassing).length, 0,
-      'there should be no failing modules in the allPassing list');
-  t.equals(util.getFails(flakeCityUsa).length, 0,
-      'there should be no failing modules in the flakeCityUsa list');
+  t.equals(
+    util.getFails(noPassing).length,
+    3,
+    'there should be three failing modules in the noPassing list'
+  );
+  t.equals(
+    util.getFails(somePassing).length,
+    1,
+    'there should be one failing modules in the somePassing list'
+  );
+  t.equals(
+    util.getFails(allPassing).length,
+    0,
+    'there should be no failing modules in the allPassing list'
+  );
+  t.equals(
+    util.getFails(flakeCityUsa).length,
+    0,
+    'there should be no failing modules in the flakeCityUsa list'
+  );
   t.end();
 });
 
 test('hasFailures:', (t) => {
-  t.ok(util.hasFailures(noPassing),
-      'there should be failures in the noPassing list');
-  t.ok(util.hasFailures(somePassing),
-      'there should be failures in the somePassing list');
-  t.notok(util.hasFailures(allPassing),
-      'there should be no failures in the allPassing list');
-  t.notok(util.hasFailures(flakeCityUsa),
-      'there should be no failures in the flakeCityUsa list');
+  t.ok(
+    util.hasFailures(noPassing),
+    'there should be failures in the noPassing list'
+  );
+  t.ok(
+    util.hasFailures(somePassing),
+    'there should be failures in the somePassing list'
+  );
+  t.notok(
+    util.hasFailures(allPassing),
+    'there should be no failures in the allPassing list'
+  );
+  t.notok(
+    util.hasFailures(flakeCityUsa),
+    'there should be no failures in the flakeCityUsa list'
+  );
   t.end();
 });
 
@@ -109,7 +162,10 @@ test('util.sanitizeOutput', (t) => {
   const expected = fs.readFileSync(carriageReturnExpectedPath, 'utf-8');
   let result = util.sanitizeOutput(raw, '#');
   result += '\n';
-  t.equals(result, expected, 'there should be a # on every line & escape char' +
-  'should be removed');
+  t.equals(
+    result,
+    expected,
+    'there should be a # on every line & escape char' + 'should be removed'
+  );
   t.end();
 });

--- a/test/test-check-tags.js
+++ b/test/test-check-tags.js
@@ -258,8 +258,7 @@ test('test excludeTags, includeTags and no matching tags', (t) => {
     excludeTags: ['b'],
     includeTags: ['a']
   };
-  const mod = {
-  };
+  const mod = {};
   t.plan(1);
   const result = checkTags(options, mod, 'test', log);
   t.true(result, 'should return true');
@@ -325,7 +324,8 @@ test('test module name can be used in includeTags/excludeTags', (t) => {
       { excludeTags: [], includeTags: ['test'] },
       { tags: 'b' },
       'test',
-      log),
+      log
+    ),
     false
   );
 
@@ -334,30 +334,32 @@ test('test module name can be used in includeTags/excludeTags', (t) => {
       { excludeTags: ['test'], includeTags: [] },
       { tags: 'b' },
       'test',
-      log),
+      log
+    ),
     true
   );
 });
 
-test('test tags matching module name with includeTags/excludeTags',
-    (t) => {
-      t.plan(2);
+test('test tags matching module name with includeTags/excludeTags', (t) => {
+  t.plan(2);
 
-      t.equal(
-        checkTags(
-          { excludeTags: [], includeTags: ['test'] },
-          { tags: 'test' },
-          'test',
-          log),
-        false
-      );
+  t.equal(
+    checkTags(
+      { excludeTags: [], includeTags: ['test'] },
+      { tags: 'test' },
+      'test',
+      log
+    ),
+    false
+  );
 
-      t.equal(
-        checkTags(
-          { excludeTags: ['test'], includeTags: [] },
-          { tags: 'test' },
-          'test',
-          log),
-        true
-      );
-    });
+  t.equal(
+    checkTags(
+      { excludeTags: ['test'], includeTags: [] },
+      { tags: 'test' },
+      'test',
+      log
+    ),
+    true
+  );
+});

--- a/test/test-citgm.js
+++ b/test/test-citgm.js
@@ -15,15 +15,19 @@ test('citgm: omg-i-pass', (t) => {
 
   const mod = 'omg-i-pass';
 
-  citgm.Tester(mod, options)
-  .on('start', (name) => {
-    t.equals(name, mod, 'it should be omg-i-pass');
-  }).on('fail', (err) => {
-    t.error(err);
-  }).on('end', () => {
-    t.notOk(process.exitCode, 'it should not exit');
-    t.end();
-  }).run();
+  citgm
+    .Tester(mod, options)
+    .on('start', (name) => {
+      t.equals(name, mod, 'it should be omg-i-pass');
+    })
+    .on('fail', (err) => {
+      t.error(err);
+    })
+    .on('end', () => {
+      t.notOk(process.exitCode, 'it should not exit');
+      t.end();
+    })
+    .run();
 });
 
 test('citgm: omg-i-pass from git url', (t) => {
@@ -36,13 +40,17 @@ test('citgm: omg-i-pass from git url', (t) => {
 
   const mod = 'git+https://github.com/MylesBorins/omg-i-pass';
 
-  citgm.Tester(mod, options)
-  .on('start', (name) => {
-    t.equals(name, mod, 'it should be omg-i-pass');
-  }).on('fail', (err) => {
-    t.error(err);
-  }).on('end', () => {
-    t.notOk(process.exitCode, 'it should not exit');
-    t.end();
-  }).run();
+  citgm
+    .Tester(mod, options)
+    .on('start', (name) => {
+      t.equals(name, mod, 'it should be omg-i-pass');
+    })
+    .on('fail', (err) => {
+      t.error(err);
+    })
+    .on('end', () => {
+      t.notOk(process.exitCode, 'it should not exit');
+      t.end();
+    })
+    .run();
 });

--- a/test/test-create-options.js
+++ b/test/test-create-options.js
@@ -10,11 +10,11 @@ test('create-options:', (t) => {
   const context = {
     options: {
       nodedir: nodePath,
-      npmLevel: 'warning',
+      npmLevel: 'warning'
     },
     emit: function() {},
     npmConfigTmp: 'npm_config_tmp',
-    module: {envVar: {testenvVar: 'thisisatest'}}
+    module: { envVar: { testenvVar: 'thisisatest' } }
   };
 
   const env = Object.create(process.env);
@@ -28,8 +28,12 @@ test('create-options:', (t) => {
   t.equals(typeof options, 'object', 'We should get back an object');
   t.notOk(options.uid, 'There should not be a uid in the options');
   t.notOk(options.gid, 'There should not be a gid in the options');
-  t.deepequal(options.env, env, 'The created env should be a clone of'
-  + ' process.env with the added npm_loglevel and nodedir');
+  t.deepequal(
+    options.env,
+    env,
+    'The created env should be a clone of' +
+      ' process.env with the added npm_loglevel and nodedir'
+  );
   t.end();
 });
 

--- a/test/test-grab-module-data.js
+++ b/test/test-grab-module-data.js
@@ -16,15 +16,18 @@ test('grab-module-data: lodash', (t) => {
         type: null
       }
     },
-    emit: function () {},
+    emit: function() {},
     options: {}
   };
 
   grabModuleData(context, (err, result) => {
     t.error(err);
     t.ok(result.meta, 'There should be a result.meta');
-    t.equals(result.meta.name, 'lodash',
-        'The name of the results should be lodash');
+    t.equals(
+      result.meta.name,
+      'lodash',
+      'The name of the results should be lodash'
+    );
     t.ok(result.meta.dist, 'It should have a dist object');
     t.ok(result.meta.dist.shasum, 'The dist should have a shasum');
     t.ok(result.meta.dist.tarball, 'The dist should have a tarball');
@@ -42,7 +45,7 @@ test('grab-module-data: does not exist', (t) => {
         type: null
       }
     },
-    emit: function () {},
+    emit: function() {},
     options: {}
   };
 
@@ -64,7 +67,7 @@ test('grab-module-data: hosted', (t) => {
         git: () => 'git://nope@nope:~/nope.git'
       }
     },
-    emit: function () {},
+    emit: function() {},
     options: {}
   };
 
@@ -77,8 +80,12 @@ test('grab-module-data: hosted', (t) => {
 
   grabModuleData(context, (err, result) => {
     t.error(err);
-    t.deepequals(result.meta, expected, 'The returned meta object should'
-    + ' include a type of git and the supplied url');
+    t.deepequals(
+      result.meta,
+      expected,
+      'The returned meta object should' +
+        ' include a type of git and the supplied url'
+    );
     t.end();
   });
 });

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -25,23 +25,35 @@ test('lookup: makeUrl', (t) => {
 
   expected = `${repo}/archive/${tags.latest}.tar.gz`;
   url = makeUrl(repo, 'latest', tags);
-  t.equal(url, expected,
-        'if given a spec and tags it should give a link to associated version');
+  t.equal(
+    url,
+    expected,
+    'if given a spec and tags it should give a link to associated version'
+  );
 
   expected = `${repo}/archive/` + '1.0.0' + '.tar.gz';
   url = makeUrl(repo, '1.0.0', tags);
-  t.equal(url, expected,
-        'given a spec which is not an npm tag we should assume a Github tag');
+  t.equal(
+    url,
+    expected,
+    'given a spec which is not an npm tag we should assume a Github tag'
+  );
 
   expected = `${repo}/archive/${prefix}${tags.latest}.tar.gz`;
   url = makeUrl(repo, 'latest', tags, prefix);
-  t.equal(url, expected,
-        'if given a prefix it should be included in the filename');
+  t.equal(
+    url,
+    expected,
+    'if given a prefix it should be included in the filename'
+  );
 
   expected = `${repo}/archive/${sha}.tar.gz`;
   url = makeUrl(repo, 'latest', tags, prefix, sha);
-  t.equal(url, expected,
-        'if given sha, it should be used to create download URL');
+  t.equal(
+    url,
+    expected,
+    'if given sha, it should be used to create download URL'
+  );
 
   t.end();
 });
@@ -57,8 +69,10 @@ test('lookup[getLookupTable]:', (t) => {
   }
   t.ok(table, 'table should exist');
   t.ok(table.lodash, 'lodash should be in the table');
-  t.ok(table.underscore.maintainers,
-      'underscore should contain a maintainers parameter');
+  t.ok(
+    table.underscore.maintainers,
+    'underscore should contain a maintainers parameter'
+  );
   t.end();
 });
 
@@ -72,15 +86,19 @@ test('lookup[getLookupTable]: custom table', (t) => {
     t.error(e);
   }
 
-  t.deepEquals(table, {
-    'omg-i-pass': {
-      npm: true
+  t.deepEquals(
+    table,
+    {
+      'omg-i-pass': {
+        npm: true
+      },
+      'omg-i-pass-too': {
+        prefix: 'v',
+        stripAnsi: true
+      }
     },
-    'omg-i-pass-too': {
-      prefix: 'v',
-      stripAnsi: true
-    }
-  }, 'we should receive the expected lookup table from the fixtures folder');
+    'we should receive the expected lookup table from the fixtures folder'
+  );
   t.end();
 });
 
@@ -105,19 +123,17 @@ test('lookup: module not in table', (t) => {
       name: 'omg-i-pass',
       raw: null
     },
-    meta: {
-
-    },
-    options: {
-
-    },
-    emit: function () {}
+    meta: {},
+    options: {},
+    emit: function() {}
   };
 
   lookup(context, (err) => {
     t.error(err);
-    t.notOk(context.module.raw,
-          'raw should remain falsey if module is not in lookup');
+    t.notOk(
+      context.module.raw,
+      'raw should remain falsey if module is not in lookup'
+    );
     t.end();
   });
 });
@@ -135,17 +151,17 @@ test('lookup: module not in table with gitHead', (t) => {
       },
       gitHead: 'abc123'
     },
-    options: {
-
-    },
-    emit: function () {}
+    options: {},
+    emit: function() {}
   };
 
   lookup(context, (err) => {
     t.error(err);
-    t.equals(context.module.raw,
-             'https://github.com/nodejs/omg-i-pass/archive/abc123.tar.gz',
-             'raw should use commit SHA if package has gitHead');
+    t.equals(
+      context.module.raw,
+      'https://github.com/nodejs/omg-i-pass/archive/abc123.tar.gz',
+      'raw should use commit SHA if package has gitHead'
+    );
     t.end();
   });
 });
@@ -162,17 +178,17 @@ test('lookup: module in table', (t) => {
         url: 'https://github.com/lodash/lodash'
       }
     },
-    options: {
-
-    },
-    emit: function () {}
+    options: {},
+    emit: function() {}
   };
 
   lookup(context, (err) => {
     t.error(err);
-    t.equals(context.module.raw,
-          'https://github.com/lodash/lodash/archive/master.tar.gz',
-              'raw should be truthy if the module was in the list');
+    t.equals(
+      context.module.raw,
+      'https://github.com/lodash/lodash/archive/master.tar.gz',
+      'raw should be truthy if the module was in the list'
+    );
     t.end();
   });
 });
@@ -190,17 +206,17 @@ test('lookup: module in table with gitHead', (t) => {
       },
       gitHead: 'abc123'
     },
-    options: {
-
-    },
-    emit: function () {}
+    options: {},
+    emit: function() {}
   };
 
   lookup(context, (err) => {
     t.error(err);
-    t.equals(context.module.raw,
-             'https://github.com/lodash/lodash/archive/abc123.tar.gz',
-             'raw should use commit SHA if package has gitHead');
+    t.equals(
+      context.module.raw,
+      'https://github.com/lodash/lodash/archive/abc123.tar.gz',
+      'raw should use commit SHA if package has gitHead'
+    );
     t.end();
   });
 });
@@ -231,7 +247,7 @@ test('lookup: replace with no repo', (t) => {
     options: {
       lookup: 'test/fixtures/custom-lookup-no-repo.json'
     },
-    emit: function () {}
+    emit: function() {}
   };
 
   lookup(context, (err) => {
@@ -255,7 +271,7 @@ test('lookup: --fail-flaky', (t) => {
     options: {
       failFlaky: true
     },
-    emit: function () {}
+    emit: function() {}
   };
 
   lookup(context, (err) => {
@@ -289,7 +305,7 @@ test('lookup: lookup with install', (t) => {
     options: {
       lookup: 'test/fixtures/custom-lookup-install.json'
     },
-    emit: function () {}
+    emit: function() {}
   };
   const expected = {
     install: [/--extra-param/]
@@ -306,12 +322,16 @@ test('lookup: logging', (t) => {
   const expectedLogMsgs = [
     { type: 'info', key: 'lookup', msg: 'omg-i-pass' },
     { type: 'info', key: 'lookup-found', msg: 'omg-i-pass' },
-    { type: 'info',
+    {
+      type: 'info',
       key: 'omg-i-pass lookup-replace',
-      msg: 'https://github.com/nodejs/citgm/archive/master.tar.gz' },
-    { type: 'verbose',
+      msg: 'https://github.com/nodejs/citgm/archive/master.tar.gz'
+    },
+    {
+      type: 'verbose',
       key: 'omg-i-pass lookup-install',
-      msg: ['--extra-param']}
+      msg: ['--extra-param']
+    }
   ];
   const EventEmitter = require('events').EventEmitter;
   const context = new EventEmitter();

--- a/test/test-match-conditions.js
+++ b/test/test-match-conditions.js
@@ -23,7 +23,7 @@ const notMatch = {
 };
 
 const invalid = {
-  'v5': [123, false, false]
+  v5: [123, false, false]
 };
 
 function shim() {
@@ -45,23 +45,33 @@ function revertShim() {
 }
 
 function testVersions(t, testFunction) {
-  t.ok(testFunction(process.version),
-      'the current version is what it is matched against');
+  t.ok(
+    testFunction(process.version),
+    'the current version is what it is matched against'
+  );
   shim();
   t.ok(testFunction('v5'), 'the module is matched on the current platform');
-  t.ok(testFunction('> 5.0.0'),
-      'the module is matched on the current platform');
+  t.ok(
+    testFunction('> 5.0.0'),
+    'the module is matched on the current platform'
+  );
   t.ok(testFunction('macos'), 'the distro is correct');
-  t.notok(testFunction('v2'),
-      'the module is not matched on the current platform');
-  t.notok(testFunction('<=v2.0.0'),
-      'the module is not matched on the current platform');
+  t.notok(
+    testFunction('v2'),
+    'the module is not matched on the current platform'
+  );
+  t.notok(
+    testFunction('<=v2.0.0'),
+    'the module is not matched on the current platform'
+  );
   revertShim();
 }
 
 function testPlatforms(t, testFunction) {
-  t.ok(testFunction(process.platform),
-      'the current platform is what it is matched against');
+  t.ok(
+    testFunction(process.platform),
+    'the current platform is what it is matched against'
+  );
   shim();
   t.ok(testFunction('darwin'), 'darwin is matched');
   t.ok(testFunction('x64'), 'x64 is matched');
@@ -75,37 +85,20 @@ function testPlatforms(t, testFunction) {
 
 function testArrays(t, testFunction) {
   shim();
-  t.ok(testFunction([
-    match,
-    match,
-    notMatch,
-    invalid
-  ]), 'matched array of object');
-  t.notok(testFunction([
-    notMatch,
-    notMatch,
-    notMatch,
-    invalid
-  ]), 'not matched array of objects');
+  t.ok(
+    testFunction([match, match, notMatch, invalid]),
+    'matched array of object'
+  );
+  t.notok(
+    testFunction([notMatch, notMatch, notMatch, invalid]),
+    'not matched array of objects'
+  );
 
-  t.ok(testFunction([
-    'hurd',
-    'x86',
-    'v4',
-    'darwin'
-  ]), 'matchy array of string');
+  t.ok(testFunction(['hurd', 'x86', 'v4', 'darwin']), 'matchy array of string');
 
-  t.notok(testFunction([
-    'hurd',
-    'x86',
-    'v4'
-  ]), 'not matchy array of string');
+  t.notok(testFunction(['hurd', 'x86', 'v4']), 'not matchy array of string');
 
-  t.notok(testFunction([
-    true,
-    false,
-    123
-  ]), 'not matched invalid input');
+  t.notok(testFunction([true, false, 123]), 'not matched invalid input');
 
   revertShim();
 }
@@ -114,12 +107,17 @@ function testObjects(t, testFunction) {
   shim();
   t.ok(testFunction(match), 'it should be matched');
   t.notok(testFunction(notMatch), 'it should not be matched');
-  t.notok(testFunction(invalid),
-      'invalid input should not give a false positive');
-  t.notok(testFunction({
-    a: 123,
-    v5: false
-  }), 'another invalid input that should not give a false positive');
+  t.notok(
+    testFunction(invalid),
+    'invalid input should not give a false positive'
+  );
+  t.notok(
+    testFunction({
+      a: 123,
+      v5: false
+    }),
+    'another invalid input that should not give a false positive'
+  );
   revertShim();
 }
 

--- a/test/test-out.js
+++ b/test/test-out.js
@@ -17,24 +17,36 @@ test('out: no color', (t) => {
 test('out: with color', (t) => {
   const supportsColor = Logger.__get__('supportsColor');
   Logger.__set__('supportsColor', () => {
-    return {stdout: true, stderr: true};
+    return { stdout: true, stderr: true };
   });
   const output = Logger.__get__('output');
   Logger.__set__('output', () => {
     return true;
   });
   const log = Logger();
-  t.notok(log.silly(), 'there should be a silly logging level that is a'
-  + ' function with no return');
-  t.notok(log.verbose(),
-      'there should be a verbose logging level that is a function with no'
-      + ' return');
-  t.notok(log.info(),
-      'there should be a info logging level that is a function with no return');
-  t.notok(log.warn(),
-      'there should be a warn logging level that is a function with no return');
-  t.notok(log.error(), 'there should be a error logging level that is a'
-  + ' function with no return');
+  t.notok(
+    log.silly(),
+    'there should be a silly logging level that is a' +
+      ' function with no return'
+  );
+  t.notok(
+    log.verbose(),
+    'there should be a verbose logging level that is a function with no' +
+      ' return'
+  );
+  t.notok(
+    log.info(),
+    'there should be a info logging level that is a function with no return'
+  );
+  t.notok(
+    log.warn(),
+    'there should be a warn logging level that is a function with no return'
+  );
+  t.notok(
+    log.error(),
+    'there should be a error logging level that is a' +
+      ' function with no return'
+  );
   Logger.__set__('supportsColor', supportsColor);
   Logger.__set__('output', output);
   t.end();

--- a/test/test-spawn.js
+++ b/test/test-spawn.js
@@ -16,8 +16,11 @@ test('spawn:', (t) => {
   });
 
   child.on('close', () => {
-    t.equals(message,
-        'Hello world.\n', 'we should receive "Hello world." on stdout');
+    t.equals(
+      message,
+      'Hello world.\n',
+      'we should receive "Hello world." on stdout'
+    );
     t.equals(error, '', 'there should be no data on stderr');
     t.end();
   });
@@ -33,7 +36,7 @@ test('spawn: windows mock', (t) => {
     value: 'win32'
   });
 
-  child.spawn = function (cmd, args, options) {
+  child.spawn = function(cmd, args, options) {
     return {
       cmd: cmd,
       args: args,
@@ -44,11 +47,7 @@ test('spawn: windows mock', (t) => {
   const result = spawn('echo', ['Hello world.']);
   const expected = {
     cmd: 'cmd',
-    args: [
-      '/c',
-      'echo',
-      'Hello world.'
-    ],
+    args: ['/c', 'echo', 'Hello world.'],
     options: undefined
   };
 
@@ -57,7 +56,10 @@ test('spawn: windows mock', (t) => {
     value: platform
   });
 
-  t.deepEqual(result, expected,
-        'we should have the expected options for win32');
+  t.deepEqual(
+    result,
+    expected,
+    'we should have the expected options for win32'
+  );
   t.end();
 });

--- a/test/test-temp-directory.js
+++ b/test/test-temp-directory.js
@@ -10,7 +10,7 @@ const tempDirectory = rewire('../lib/temp-directory');
 
 const context = {
   path: null,
-  emit: function () {},
+  emit: function() {},
   module: {
     name: 'test-module'
   }
@@ -21,7 +21,7 @@ const contextTmpDir = {
     tmpDir: '.thisisatest'
   },
   path: null,
-  emit: function () {},
+  emit: function() {},
   module: {
     name: 'test-module'
   }
@@ -29,7 +29,7 @@ const contextTmpDir = {
 
 const badContext = {
   path: null,
-  emit: function () {},
+  emit: function() {},
   module: {
     name: 'test-module-bad'
   }
@@ -51,13 +51,14 @@ test('tempDirectory.create:', (t) => {
 test('tempDirectory.create --tmpDir:', (t) => {
   tempDirectory.create(contextTmpDir, (e, ctx) => {
     t.error(e);
-    t.ok(ctx.path.match(/thisisatest\/.*-.*-.*-.*-.*/),
-        'the path should match --tmpDir');
+    t.ok(
+      ctx.path.match(/thisisatest\/.*-.*-.*-.*-.*/),
+      'the path should match --tmpDir'
+    );
     fs.stat(ctx.path, (err, stats) => {
       t.error(err);
       t.ok(stats.isDirectory(), 'the path should exist and be a folder');
-      rimraf('./.thisisatest', () => {
-      });
+      rimraf('./.thisisatest', () => {});
       t.end();
     });
   });
@@ -66,14 +67,17 @@ test('tempDirectory.create --tmpDir:', (t) => {
 test('tempDirectory.create: bad path', (t) => {
   const path = tempDirectory.__get__('path');
   tempDirectory.__set__('path', {
-    join: function () {
+    join: function() {
       return '/dev/null';
     }
   });
   t.notOk(badContext.path, 'badContext should not have a path');
   tempDirectory.create(badContext, (e) => {
-    t.notEquals(e.message.search(/\/dev\/null/), -1,
-        'the message should include the path /dev/null');
+    t.notEquals(
+      e.message.search(/\/dev\/null/),
+      -1,
+      'the message should include the path /dev/null'
+    );
     tempDirectory.__set__('path', path);
     t.end();
   });
@@ -94,8 +98,11 @@ test('tempDirectory.remove:', (t) => {
 test('tempDirectory.remove: bad path', (t) => {
   t.ok(badContext, 'badContext should have a path');
   tempDirectory.remove(badContext, (e) => {
-    t.notEquals(e.message.search(/\/dev\/null/), -1,
-        'the message should include the path /dev/null');
+    t.notEquals(
+      e.message.search(/\/dev\/null/),
+      -1,
+      'the message should include the path /dev/null'
+    );
     t.end();
   });
 });

--- a/test/test-timeout.js
+++ b/test/test-timeout.js
@@ -21,11 +21,15 @@ test('timeout: setup', (t) => {
 });
 
 test('timeout:', (t) => {
-  const context = makeContext.npmContext('omg-i-pass', packageManagers,
-    sandbox, {
+  const context = makeContext.npmContext(
+    'omg-i-pass',
+    packageManagers,
+    sandbox,
+    {
       npmLevel: 'silly',
       timeoutLength: 100
-    });
+    }
+  );
   const proc = {
     kill() {
       this.killed++;
@@ -50,15 +54,18 @@ test('timeout:', (t) => {
     t.equals(proc.killed, 1);
     t.end();
   }, 200);
-
 });
 
 test('timeout:', (t) => {
-  const context = makeContext.npmContext('omg-i-pass', packageManagers,
-    sandbox, {
+  const context = makeContext.npmContext(
+    'omg-i-pass',
+    packageManagers,
+    sandbox,
+    {
       npmLevel: 'silly',
       timeoutLength: 100
-    });
+    }
+  );
   const proc = {
     kill() {
       this.killed++;

--- a/test/test-unpack.js
+++ b/test/test-unpack.js
@@ -11,12 +11,15 @@ const unpack = require('../lib/unpack');
 test('unpack: context.unpack = null', (t) => {
   const context = {
     unpack: null,
-    emit: function () {}
+    emit: function() {}
   };
 
   unpack(context, (err) => {
-    t.deepEquals(err, new Error('Nothing to unpack... Ending'),
-        'it should error out');
+    t.deepEquals(
+      err,
+      new Error('Nothing to unpack... Ending'),
+      'it should error out'
+    );
     t.end();
   });
 });
@@ -24,12 +27,15 @@ test('unpack: context.unpack = null', (t) => {
 test('unpack: context.unpack is invalid path', (t) => {
   const context = {
     unpack: path.join(__dirname, '..', 'fixtures', 'do-not-exist.tar.gz'),
-    emit: function () {}
+    emit: function() {}
   };
 
   unpack(context, (err) => {
-    t.deepEquals(err, new Error('Nothing to unpack... Ending'),
-        'it should error out');
+    t.deepEquals(
+      err,
+      new Error('Nothing to unpack... Ending'),
+      'it should error out'
+    );
     t.end();
   });
 });
@@ -40,7 +46,7 @@ test('unpack: valid unpack', (t) => {
       name: 'omg-i-pass'
     },
     unpack: './test/fixtures/omg-i-pass.tgz',
-    emit: function () {}
+    emit: function() {}
   };
 
   // FIXME I am not super convinced that the correct tar ball is being deflated

--- a/test/test-update.js
+++ b/test/test-update.js
@@ -10,7 +10,7 @@ pkg.version = '0.0.0';
 
 test('update: /w callback', (t) => {
   const log = {
-    warn: function (data) {
+    warn: function(data) {
       t.equals(data, 'update-available');
       t.end();
     }

--- a/test/yarn/test-yarn-install.js
+++ b/test/yarn/test-yarn-install.js
@@ -47,8 +47,11 @@ test('yarn-install: setup', (t) => {
 });
 
 test('yarn-install: basic module', (t) => {
-  const context = makeContext.npmContext('omg-i-pass', packageManagers,
-    sandbox);
+  const context = makeContext.npmContext(
+    'omg-i-pass',
+    packageManagers,
+    sandbox
+  );
   packageManagerInstall('yarn', context, (err) => {
     context.testOutput = context.testOutput.toString();
     context.testError = context.testError.toString();
@@ -58,8 +61,11 @@ test('yarn-install: basic module', (t) => {
 });
 
 test('yarn-install: no package.json', (t) => {
-  const context = makeContext.npmContext('omg-i-fail', packageManagers,
-    sandbox);
+  const context = makeContext.npmContext(
+    'omg-i-fail',
+    packageManagers,
+    sandbox
+  );
   packageManagerInstall('yarn', context, (err) => {
     context.testOutput = context.testOutput.toString();
     context.testError = context.testError.toString();
@@ -70,10 +76,14 @@ test('yarn-install: no package.json', (t) => {
 });
 
 test('yarn-install: timeout', (t) => {
-  const context = makeContext.npmContext('omg-i-pass', packageManagers,
-    sandbox, {
+  const context = makeContext.npmContext(
+    'omg-i-pass',
+    packageManagers,
+    sandbox,
+    {
       timeoutLength: 100
-    });
+    }
+  );
   packageManagerInstall('yarn', context, (err) => {
     context.testOutput = context.testOutput.toString();
     context.testError = context.testError.toString();
@@ -84,8 +94,11 @@ test('yarn-install: timeout', (t) => {
 });
 
 test('yarn-install: failed install', (t) => {
-  const context = makeContext.npmContext('omg-bad-tree', packageManagers,
-    sandbox);
+  const context = makeContext.npmContext(
+    'omg-bad-tree',
+    packageManagers,
+    sandbox
+  );
   const expected = {
     testError: /\/THIS-WILL-FAIL: Not found/
   };

--- a/test/yarn/test-yarn-test.js
+++ b/test/yarn/test-yarn-test.js
@@ -51,8 +51,11 @@ test('yarn-test: setup', (t) => {
 });
 
 test('yarn-test: basic module passing', (t) => {
-  const context = makeContext.npmContext('omg-i-pass',
-    packageManagers, sandbox);
+  const context = makeContext.npmContext(
+    'omg-i-pass',
+    packageManagers,
+    sandbox
+  );
   packageManagerTest('yarn', context, (err) => {
     t.error(err);
     t.end();
@@ -60,8 +63,11 @@ test('yarn-test: basic module passing', (t) => {
 });
 
 test('yarn-test: basic module failing', (t) => {
-  const context = makeContext.npmContext('omg-i-fail',
-    packageManagers, sandbox);
+  const context = makeContext.npmContext(
+    'omg-i-fail',
+    packageManagers,
+    sandbox
+  );
   packageManagerTest('yarn', context, (err) => {
     t.equals(err && err.message, 'The canary is dead:');
     t.end();
@@ -69,9 +75,11 @@ test('yarn-test: basic module failing', (t) => {
 });
 
 test('yarn-test: basic module no test script', (t) => {
-  const context =
-    makeContext.npmContext('omg-i-do-not-support-testing',
-      packageManagers, sandbox);
+  const context = makeContext.npmContext(
+    'omg-i-do-not-support-testing',
+    packageManagers,
+    sandbox
+  );
   packageManagerTest('yarn', context, (err) => {
     t.equals(err && err.message, 'Module does not support yarn-test!');
     t.end();
@@ -79,8 +87,11 @@ test('yarn-test: basic module no test script', (t) => {
 });
 
 test('yarn-test: no package.json', (t) => {
-  const context = makeContext.npmContext('omg-i-dont-exist',
-    packageManagers, sandbox);
+  const context = makeContext.npmContext(
+    'omg-i-dont-exist',
+    packageManagers,
+    sandbox
+  );
   packageManagerTest('yarn', context, (err) => {
     t.equals(err && err.message, 'Package.json Could not be found');
     t.end();
@@ -91,10 +102,14 @@ test('yarn-test: alternative test-path', (t) => {
   // Same test as 'basic module passing', except with alt node bin which fails.
   const nodeBinName = packageManagerTest.__get__('nodeBinName');
   packageManagerTest.__set__('nodeBinName', 'fake-node');
-  const context = makeContext.npmContext('omg-i-pass', packageManagers,
-    sandbox, {
+  const context = makeContext.npmContext(
+    'omg-i-pass',
+    packageManagers,
+    sandbox,
+    {
       testPath: path.resolve(__dirname, '..', 'fixtures', 'fakenodebin')
-    });
+    }
+  );
   packageManagerTest('yarn', context, (err) => {
     packageManagerTest.__set__('nodeBinName', nodeBinName);
     t.equals(err && err.message, 'The canary is dead:');
@@ -103,10 +118,14 @@ test('yarn-test: alternative test-path', (t) => {
 });
 
 test('yarn-test: timeout', (t) => {
-  const context = makeContext.npmContext('omg-i-pass', packageManagers,
-    sandbox, {
+  const context = makeContext.npmContext(
+    'omg-i-pass',
+    packageManagers,
+    sandbox,
+    {
       timeoutLength: 100
-    });
+    }
+  );
   packageManagerTest('yarn', context, (err) => {
     t.ok(context.module.flaky, 'Module is Flaky because tests timed out');
     t.equals(err && err.message, 'Test Timed Out');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

The code base is currently pretty inconsistent about spacing, indentation. I really love prettier, so I threw together this quick PR which uses it, and disables all styling rules from eslint itself.

(Separate PR from #611 in case you don't want this)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
