### PR TITLE
remove electron-prebuilt

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -386,12 +386,6 @@
     "tags": "native",
     "maintainers": "bnoordhuis"
   },
-  "electron-prebuilt": {
-    "prefix": "v",
-    "flaky": "s390",
-    "skip": "ppc",
-    "maintainers": "maxogden"
-  },
   "libxmljs": {
     "prefix": "v",
     "flaky": ["aix", "sles", "rhel", "darwin"],


### PR DESCRIPTION
`electron-prebuilt` is deprecated and has not had a version published in a couple years. It's flaky in CITGM, so let's remove it.

Would be great to get `electron` in there, but I'm guessing that's a lot of work?

/ping @codebytere 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
