### PR TITLE
lookup: skip bson

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -355,7 +355,7 @@
   "bson": {
     "prefix": "V",
     "maintainers": "christkv",
-    "skip": ">=10"
+    "skip": true
   },
   "ember-cli": {
     "prefix": "v",


### PR DESCRIPTION
It currently requires headless chrome