### PR TITLE
lookup: add got

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -184,6 +184,11 @@
     "expectFail": "fips",
     "maintainers": "isaacs"
   },
+  "got": {
+    "maintainers": ["sindresorhus"],
+    "prefix": "v",
+    "skip": ["<8", ">=11"]
+  },
   "graceful-fs": {
     "prefix": "v",
     "maintainers": "isaacs"


### PR DESCRIPTION
Hard Requirements:
- [x] Module source code must be on Github.
- [x] Published versions must include a tag on Github
- [x] The test process must be executable with only the commands npm install && npm test or (yarn install && yarn test) using the tarball downloaded from the Github tag mentioned above
- [x] The tests pass on supported major release lines (8 and 10)
- [x] The maintainers of the module remain responsive when there are problems
- [x] At least one module maintainer must be added to the lookup maintainers field

Soft Requirements:

- [x] The module must be actively used by the community OR
- [x] The module must be heavily depended on OR

Skipping Node 11 for now because a test uses `process.binding('timer_wrap')` (removed in 11).

/cc @sindresorhus