### PR TITLE
lookup: add babel

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -1,4 +1,11 @@
 {
+  "@babel/core": {
+    "maintainers": ["nicolo-ribaudo", "JLHwung", "liuxingbaoyu"],
+    "prefix": "v",
+    "yarn": true,
+    "scripts": ["build", "test-only"],
+    "skip": ["aix", "ppc", "s390", "win32"]
+  },
   "@clinic/bubbleprof": {
     "maintainers": ["mcollina", "rafaelgss"],
     "prefix": "v",


### PR DESCRIPTION
Work in progress because babel is still not compatible with citgm. This is what you have to do now to test it:

```
make bootstrap
make test
```