### PR TITLE
lookup: mark flaky on OSX

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -89,7 +89,7 @@
   },
   "jquery": {
     "skip": "win32",
-    "flaky": ["linux", "aix"],
+    "flaky": ["linux", "aix", "darwin"],
     "maintainers": "jeresig",
     "ignoreGitHead": true
   },


### PR DESCRIPTION
hey @jresig and @timmywil jQuery has been consistently flaky on OSX 10.10 and
10.11 in our CITM (smoke tests for node.js). Marking as flaky for now so it
doesn't cause our CI runs to be red.

Refs: https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/1655/nodes=osx1010/testReport/(root)/citgm/jquery_v3_3_1/
Refs: https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/1655/nodes=osx1011/testReport/(root)/citgm/jquery_v3_3_1/


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)