### PR TITLE
win: fix spawning npm

### DIFF
--- a/lib/package-manager/install.js
+++ b/lib/package-manager/install.js
@@ -2,6 +2,7 @@
 const path = require('path');
 
 const stripAnsi = require('strip-ansi');
+const which = require('which').sync;
 
 const createOptions = require('../create-options');
 const spawn = require('../spawn');
@@ -12,7 +13,7 @@ function install(packageManager, context, next) {
     path.join(context.path, context.module.name),
     context
   );
-  let args = ['install'];
+
   context.emit(
     'data',
     'info',
@@ -27,17 +28,26 @@ function install(packageManager, context, next) {
     `Using temp directory: "${options.env['npm_config_tmp']}"`
   );
 
-  if (context.module.install) {
-    args = args.concat(context.module.install);
+  let nodeBin = 'node';
+  if (context.options.testPath) {
+    options.env.PATH = `${context.options.testPath}:${process.env.PATH}`;
+    nodeBin = which('node', {
+      path: options.env.PATH || process.env.PATH
+    });
   }
 
   const packageManagerBin =
     packageManager === 'npm' ? context.npmPath : context.yarnPath;
 
+  let args = [packageManagerBin, 'install'];
+  if (context.module.install) {
+    args = args.concat(context.module.install);
+  }
+
   const binDirectory = path.dirname(packageManagerBin);
   options.env.PATH = `${binDirectory}:${process.env.PATH}`;
 
-  const proc = spawn(packageManagerBin, args, options);
+  const proc = spawn(nodeBin, args, options);
   const finish = timeout(context, proc, next, 'Install');
 
   proc.stderr.on('data', (chunk) => {


### PR DESCRIPTION
Fixes spawning npm under Windows. CITGM would try to spawn `npm-cli.js` directly, causing Windows Script Host to get used to run the npm code.

Fixes: https://github.com/nodejs/citgm/issues/634

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes (linter passes, tests are broken on Windows)
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
