### PR TITLE
win: fix PATH env variable generation

### DIFF
--- a/lib/package-manager/install.js
+++ b/lib/package-manager/install.js
@@ -7,6 +7,8 @@ const createOptions = require('../create-options');
 const spawn = require('../spawn');
 const timeout = require('../timeout');
 
+const envSeparator = process.platform === 'win32' ? ';' : ':';
+
 function install(packageManager, context, next) {
   const options = createOptions(
     path.join(context.path, context.module.name),
@@ -35,7 +37,7 @@ function install(packageManager, context, next) {
     packageManager === 'npm' ? context.npmPath : context.yarnPath;
 
   const binDirectory = path.dirname(packageManagerBin);
-  options.env.PATH = `${binDirectory}:${process.env.PATH}`;
+  options.env.PATH = `${binDirectory}${envSeparator}${process.env.PATH}`;
 
   const proc = spawn(packageManagerBin, args, options);
   const finish = timeout(context, proc, next, 'Install');

--- a/lib/package-manager/test.js
+++ b/lib/package-manager/test.js
@@ -11,6 +11,8 @@ const timeout = require('../timeout');
 
 let nodeBinName = 'node'; // Mocked in tests
 
+const envSeparator = process.platform === 'win32' ? ';' : ':';
+
 function authorName(author) {
   if (typeof author === 'string') return author;
   let parts = [];
@@ -50,7 +52,7 @@ function test(packageManager, context, next) {
     const options = createOptions(wd, context);
     let nodeBin = 'node';
     if (context.options.testPath) {
-      options.env.PATH = `${context.options.testPath}:${process.env.PATH}`;
+      options.env.PATH = `${context.options.testPath}${envSeparator}${process.env.PATH}`;
       nodeBin = which(nodeBinName, {
         path: options.env.PATH || process.env.PATH
       });
@@ -60,7 +62,7 @@ function test(packageManager, context, next) {
       packageManager === 'npm' ? context.npmPath : context.yarnPath;
 
     const binDirectory = path.dirname(packageManagerBin);
-    options.env.PATH = `${binDirectory}:${process.env.PATH}`;
+    options.env.PATH = `${binDirectory}${envSeparator}${process.env.PATH}`;
 
     /* Run `npm/yarn test`, or `/path/to/customTest.js` if the customTest option
      was passed */


### PR DESCRIPTION
On Windows use ';' as separator in PATH environment variable.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
