### PR TITLE
lib: do not resolve npm-cli.js on Windows

### DIFF
--- a/lib/package-manager/get-executable.js
+++ b/lib/package-manager/get-executable.js
@@ -1,35 +1,13 @@
 'use strict';
 
-const path = require('path');
-const which = require('which');
 const npmWhich = require('npm-which')(__dirname);
-
-const windows = process.platform === 'win32';
+const which = require('which');
 
 module.exports = function getExecutable(binaryName, next) {
   if (binaryName === 'yarn') {
-    // Use `npm-which` for yarn to get the locally version
+    // Use `npm-which` for yarn to get the local version
     npmWhich(binaryName, next);
-
-    return;
+  } else {
+    which(binaryName, next);
   }
-
-  which(binaryName, (err, packageManagerBin) => {
-    if (err) {
-      next(err);
-      return;
-    }
-
-    if (windows) {
-      packageManagerBin = path.join(
-        path.dirname(packageManagerBin),
-        'node_modules',
-        'npm',
-        'bin',
-        'npm-cli.js'
-      );
-    }
-
-    next(null, packageManagerBin);
-  });
 };


### PR DESCRIPTION
It was breaking execution of npm sub-scripts because the
node_modules/npm/bin directory contains a npm.cmd file that would be
resolved from the PATH generated to run tests. However, npm doesn't
support being run from this directory.

Fixes: https://github.com/nodejs/citgm/issues/648
