### PR TITLE
Two --sha fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Options:
   --customTest <path>         Run a custom node test script instead of "npm test"
   -x, --junit [path]          Output results in junit xml with optional file path
   -o, --timeout <length>      Set timeout for npm install
-  -c, --sha <commit-sha>      Install module from commit-sha
+  -c, --sha <commit-sha>      Install module from commit-sha, branch or tag
   -u, --uid <uid>             Set the uid (posix only)
   -g, --gid <uid>             Set the gid (posix only)
   -a, --append                Turns on append results to file mode rather than replace

--- a/bin/citgm.js
+++ b/bin/citgm.js
@@ -16,7 +16,7 @@ const yargs = commonArgs(require('yargs'))
   .option('sha', {
     alias: 'c',
     type: 'string',
-    description: 'Install module from commit-sha'
+    description: 'Install module from commit-sha, branch or tag'
   });
 
 const app = yargs.argv;

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -176,7 +176,7 @@ function resolve(context) {
           null,
           null,
           null,
-          meta.gitHead
+          context.options.sha || meta.gitHead
         );
         context.emit('data', 'info', 'lookup-githead', url);
         context.module.raw = url;

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -304,6 +304,33 @@ test('lookup: replace with no repo', (t) => {
   }
 });
 
+test('lookup: not found in lookup.json with --sha', (t) => {
+  t.plan(1);
+  const context = {
+    lookup: null,
+    module: {
+      name: 'test'
+    },
+    meta: {
+      gitHead: 'metaGitHead',
+      repository: {
+        url: 'https://github.com/test-org/test-repo'
+      }
+    },
+    options: {
+      sha: 'customsha'
+    },
+    emit: function() {}
+  };
+
+  lookup(context);
+  t.equals(
+    context.module.raw,
+    'https://github.com/test-org/test-repo/archive/customsha.tar.gz'
+  );
+  t.end();
+});
+
 test('lookup: --fail-flaky', (t) => {
   t.plan(1);
   const context = {


### PR DESCRIPTION
First commit: also use --sha in case the module is not in the lookup table

Second commit: clarify that --sha can also be a branch or tag
For example to test the master branch of a module:
citgm moduleName --sha=master