### PR TITLE
lookup: skip stylus on >=11

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -420,7 +420,8 @@
   },
   "stylus": {
     "flaky": ["win32", "aix"],
-    "maintainers": "tj"
+    "maintainers": "tj",
+    "skip": ">=11"
   },
   "tape": {
     "prefix": "v",


### PR DESCRIPTION
Waiting for a new release that works on current Node.js version.

Refs: https://github.com/stylus/stylus/issues/2436