### PR TITLE
lookup: skip time on >=11

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -446,7 +446,8 @@
     "flaky": ["linux-ia32", "s390"],
     "skip": ["win32", "aix"],
     "tags": "native",
-    "maintainers": "TooTallNate"
+    "maintainers": "TooTallNate",
+    "skip": ">=11"
   },
   "torrent-stream": {
     "prefix": "v",


### PR DESCRIPTION
Waiting for the fix to land and be in a release.

Refs: https://github.com/TooTallNate/node-time/pull/76