### PR TITLE
lookup: skip uglify-js on v12

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -456,7 +456,8 @@
   "uglify-js": {
     "prefix": "v",
     "flaky": ["ppc", "darwin"],
-    "maintainers": "mishoo"
+    "maintainers": "mishoo",
+    "skip": "12"
   },
   "underscore": {
     "flaky": ["aix", "s390"],


### PR DESCRIPTION
Some tests are broken by changes in the output of `console.log`. It's
not clear yet if this should be fixed in Node core or in the module's
tests.

Refs: https://github.com/nodejs/node/pull/23162#issuecomment-446716098