### PR TITLE
lookup: skip bluebird on PPC and S390X

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -57,7 +57,8 @@
   },
   "bluebird": {
     "prefix": "v",
-    "maintainers": "petkaantonov"
+    "maintainers": "petkaantonov",
+    "skip": ["ppc", "s390"]
   },
   "body-parser": {
     "flaky": "aix",


### PR DESCRIPTION
Consistently fails on those platforms.