### PR TITLE
lookup: fix and enable pug

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -315,9 +315,10 @@
     "maintainers": "blakeembrey"
   },
   "pug": {
-    "flaky": "ppc",
-    "skip": true,
-    "maintainers": ["tj", "ForbesLindesay"]
+    "prefix": "pug@",
+    "yarn": true,
+    "maintainers": ["tj", "ForbesLindesay"],
+    "skip": ["6", "win32"]
   },
   "pumpify": {
     "prefix": "v",


### PR DESCRIPTION
Closes: https://github.com/nodejs/citgm/issues/524

Skipped on Windows because it the test scripts uses `sh`.