### PR TITLE
logger: if !module.testOutput set to empty string

### DIFF
--- a/lib/reporter/logger.js
+++ b/lib/reporter/logger.js
@@ -12,6 +12,7 @@ function logModule(log, logType, module) {
     log[logType](chalk.yellow('version:'), module.version);
   }
   if (module.error) {
+    if (!module.testOutput) module.testOutput = '';
     log[logType]('error:', module.error.message);
     // If the output is not too big, just print it.
     if (module.testOutput.length < outChunkSize) {


### PR DESCRIPTION
This was currently breaking cntrl-c

Fixes: #663