### PR TITLE
lookup: skip eslint

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -135,7 +135,7 @@
   "eslint": {
     "prefix": "v",
     "flaky": ["s390", "ubuntu"],
-    "skip": [">=8", "ppc"],
+    "skip": [true, "ppc"],
     "expectFail": "fips",
     "maintainers": ["nzakas", "mysticatea", "not-an-aardvark"]
   },


### PR DESCRIPTION
We are currently skipping on >=8.x. Expanding to include 6.x as it
has been broken on the last two releases. We should dig in and see
if we can get this passing.

/cc @nzakas, @mysticatea, @not-an-aardvark