### PR TITLE
lookup: skip ava on ia32

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -30,7 +30,7 @@
   },
   "ava": {
     "prefix": "v",
-    "skip": ["ppc", "win32", "x86", "rhel", "aix", "10"],
+    "skip": ["ppc", "win32", "x86", "rhel", "aix", "ia32", "10"],
     "flaky": "<8",
     "maintainers": ["sindresorhus", "novemberborn"]
   },
@@ -135,7 +135,7 @@
   "eslint": {
     "prefix": "v",
     "flaky": ["s390", "ubuntu"],
-    "skip": [true, "ppc"],
+    "skip": [truez, "ppc"],
     "expectFail": "fips",
     "maintainers": ["nzakas", "mysticatea", "not-an-aardvark"]
   },


### PR DESCRIPTION
it is an unsupported platform