### PR TITLE
lookup: unflake node-report on Windows

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -310,7 +310,6 @@
   },
   "node-report": {
     "prefix": "v",
-    "flaky": "win32",
     "tags": "native",
     "maintainers": ["rnchamberlain", "richardlau"],
     "skip": "12"


### PR DESCRIPTION
[node-report@2.2.2](https://github.com/nodejs/node-report/releases/tag/v2.2.2) fixes compilation on Windows.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
