### PR TITLE
lib: allow booleans in arrays for match conditions

### DIFF
--- a/lib/match-conditions.js
+++ b/lib/match-conditions.js
@@ -54,6 +54,7 @@ function isStringMatch(conditions) {
 
 function isArrayMatch(arr) {
   return _.some(arr, (item) => {
+    if (typeof item === 'boolean' && item) return true;
     if (typeof item === 'string') return isStringMatch(item);
     if (typeof item === 'object') return isObjectMatch(item);
     return false;

--- a/lib/match-conditions.js
+++ b/lib/match-conditions.js
@@ -54,7 +54,7 @@ function isStringMatch(conditions) {
 
 function isArrayMatch(arr) {
   return _.some(arr, (item) => {
-    if (typeof item === 'boolean' && item) return true;
+    if (typeof item === 'boolean') return item;
     if (typeof item === 'string') return isStringMatch(item);
     if (typeof item === 'object') return isObjectMatch(item);
     return false;

--- a/test/test-match-conditions.js
+++ b/test/test-match-conditions.js
@@ -98,7 +98,9 @@ function testArrays(t, testFunction) {
 
   t.notok(testFunction(['hurd', 'x86', 'v4']), 'not matchy array of string');
 
-  t.notok(testFunction([true, false, 123]), 'not matched invalid input');
+  t.ok(testFunction([true, false, 123]), 'True evaluates to true');
+
+  t.notok(testFunction([false, 123]), 'No truthy results evaluate to false');
 
   revertShim();
 }


### PR DESCRIPTION
This is a decent pattern to use when we need to temporarily skip a
module but don't want to lose the existing skip data for specific
platforms