### PR TITLE
test: fix test-npm-install for npm 6.7.0

### DIFF
--- a/test/npm/test-npm-install.js
+++ b/test/npm/test-npm-install.js
@@ -125,7 +125,7 @@ test('npm-install: failed install', (t) => {
   );
   const expected = {
     testOutput: /^$/,
-    testError: /npm ERR! 404 Not [Ff]ound\s*: THIS-WILL-FAIL(@0\.0\.1)?/
+    testError: /npm ERR! 404 Not [Ff]ound\s*(:)? .*THIS-WILL-FAIL(@0\.0\.1)?/
   };
   packageManagerInstall('npm', context, (err) => {
     t.notOk(context.module.flaky, 'Module failed is not flaky');


### PR DESCRIPTION
The checked error message differs between the version of npm included
in Node.js 11.10.0 compared to previous versions.

Fixes: https://github.com/nodejs/citgm/issues/680

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
