### PR TITLE
Remove ref

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -361,7 +361,7 @@
     "flaky": "aix",
     "tags": "native",
     "maintainers": "TooTallNate",
-    "skip": ["12", "win32"]
+    "skip": true
   },
   "request": {
     "prefix": "v",


### PR DESCRIPTION
This removes ref for now as it will fail on all citgm runs currently
due to the testing framework not being compatible anymore. There are
two open PRs to fix this and as soon as either is merged, I'll open
a new PR to add `ref` back.

Refs: https://github.com/TooTallNate/ref/pull/111

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
