### PR TITLE
feat: add useGitClone option to lookup table

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
 "install": ["--param1", "--param2"] - Array of extra command line parameters passed to 'npm install'
 "maintainers": ["user1", "user2"] - List of module maintainers to be contacted with issues
 "tags": ["tag1", "tag2"]     Specify which tags apply to the module
+"useGitClone" true           Use a shallow git clone instead of downloading the module
 "ignoreGitHead":             Ignore the gitHead field if it exists and fallback to using github tags
 "yarn":                      Install and test the project using yarn instead of npm
 ```

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
 "install": ["--param1", "--param2"] - Array of extra command line parameters passed to 'npm install'
 "maintainers": ["user1", "user2"] - List of module maintainers to be contacted with issues
 "tags": ["tag1", "tag2"]     Specify which tags apply to the module
-"useGitClone" true           Use a shallow git clone instead of downloading the module
+"useGitClone": true          Use a shallow git clone instead of downloading the module
 "ignoreGitHead":             Ignore the gitHead field if it exists and fallback to using github tags
 "yarn":                      Install and test the project using yarn instead of npm
 ```

--- a/lib/git-clone.js
+++ b/lib/git-clone.js
@@ -26,7 +26,9 @@ function gitClone(context, next) {
     execGit(['init']);
     execGit(['remote', 'add', 'origin', gitUrl]);
     execGit(['fetch', '--depth=1', 'origin', gitRef]);
-    execGit(['checkout', '--recurse-submodules', 'FETCH_HEAD']);
+    execGit(['checkout', 'FETCH_HEAD']);
+    execGit(['submodule', 'init']);
+    execGit(['submodule', 'update']);
   } catch (e) {
     return next(e);
   }

--- a/lib/git-clone.js
+++ b/lib/git-clone.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const child = require('child_process');
+const path = require('path');
+
+const mkdirp = require('mkdirp');
+
+function getExecGit(path) {
+  return function execGit(args) {
+    child.execFileSync('git', args, {
+      cwd: path,
+      stdio: 'ignore'
+    });
+  };
+}
+
+function gitClone(context, next) {
+  const gitUrl = context.module.raw;
+  const gitRef = context.module.ref;
+
+  const modulePath = path.join(context.path, context.module.name);
+  mkdirp.sync(modulePath);
+  const execGit = getExecGit(modulePath);
+
+  try {
+    execGit(['init']);
+    execGit(['remote', 'add', 'origin', gitUrl]);
+    execGit(['fetch', '--depth=1', 'origin', gitRef]);
+    execGit(['checkout', 'FETCH_HEAD']);
+    execGit(['submodule', 'init']);
+    execGit(['submodule', 'update']);
+  } catch (e) {
+    return next(e);
+  }
+
+  context.unpack = false;
+
+  next(null, context);
+}
+
+module.exports = gitClone;

--- a/lib/git-clone.js
+++ b/lib/git-clone.js
@@ -26,9 +26,7 @@ function gitClone(context, next) {
     execGit(['init']);
     execGit(['remote', 'add', 'origin', gitUrl]);
     execGit(['fetch', '--depth=1', 'origin', gitRef]);
-    execGit(['checkout', 'FETCH_HEAD']);
-    execGit(['submodule', 'init']);
-    execGit(['submodule', 'update']);
+    execGit(['checkout', '--recurse-submodules', 'FETCH_HEAD']);
   } catch (e) {
     return next(e);
   }

--- a/lib/grab-project.js
+++ b/lib/grab-project.js
@@ -3,6 +3,7 @@
 const path = require('path');
 
 const createOptions = require('./create-options');
+const gitClone = require('./git-clone');
 const spawn = require('./spawn');
 
 function grabProject(context, next) {
@@ -13,6 +14,10 @@ function grabProject(context, next) {
       `${context.module.name} package-meta`,
       context.meta
     );
+  if (context.module.type === 'git') {
+    gitClone(context, next);
+    return;
+  }
   let packageName = context.module.raw;
   if (context.module.type === 'directory') {
     context.module.raw = context.module.name = path.basename(packageName);

--- a/lib/grab-project.js
+++ b/lib/grab-project.js
@@ -14,7 +14,7 @@ function grabProject(context, next) {
       `${context.module.name} package-meta`,
       context.meta
     );
-  if (context.module.type === 'git') {
+  if (context.module.useGitClone) {
     gitClone(context, next);
     return;
   }

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -28,6 +28,16 @@ function makeUrl(repo, spec, tags, prefix, sha) {
   return util.format('%s/archive/%s%s.tar.gz', repo, prefix, version);
 }
 
+function makeClone(repo, spec, tags, prefix) {
+  let version;
+  if (!spec) version = 'master';
+  else version = (prefix || '') + tags[spec];
+  return {
+    url: `${repo}.git`,
+    ref: version
+  };
+}
+
 // Pull the repository url either from the lookup table
 // Or the npm metadata. remove the .git suffix from the url
 // If necessary, and replace the git:// prefx with https://
@@ -96,21 +106,39 @@ function resolve(context, next) {
           next(new Error('no-repository-field in package.json'));
           return;
         }
-        const gitHead = rep.master || rep.ignoreGitHead ? null : meta.gitHead;
-        const url = makeUrl(
-          getRepo(rep.repo, meta),
-          rep.master ? null : detail.fetchSpec,
-          meta['dist-tags'],
-          rep.master ? null : rep.prefix,
-          context.options.sha || rep.sha || gitHead
-        );
-        context.emit(
-          'data',
-          'info',
-          `${context.module.name} lookup-replace`,
-          url
-        );
-        context.module.raw = url;
+        if (rep.useGitClone) {
+          const { url, ref } = makeClone(
+            getRepo(rep.repo, meta),
+            rep.master ? null : detail.fetchSpec,
+            meta['dist-tags'],
+            rep.prefix
+          );
+          context.emit(
+            'data',
+            'info',
+            `${context.module.name} lookup-replace`,
+            url
+          );
+          context.module.type = 'git';
+          context.module.raw = url;
+          context.module.ref = ref;
+        } else {
+          const gitHead = rep.master || rep.ignoreGitHead ? null : meta.gitHead;
+          const url = makeUrl(
+            getRepo(rep.repo, meta),
+            rep.master ? null : detail.fetchSpec,
+            meta['dist-tags'],
+            rep.master ? null : rep.prefix,
+            context.options.sha || rep.sha || gitHead
+          );
+          context.emit(
+            'data',
+            'info',
+            `${context.module.name} lookup-replace`,
+            url
+          );
+          context.module.raw = url;
+        }
       }
       if (rep.install) {
         context.emit(

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -119,7 +119,7 @@ function resolve(context, next) {
             `${context.module.name} lookup-replace`,
             url
           );
-          context.module.type = 'git';
+          context.module.useGitClone = true;
           context.module.raw = url;
           context.module.ref = ref;
         } else {

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -88,7 +88,7 @@
   "clinic": {
     "maintainers": "mcollina",
     "prefix": "v",
-	"skip": "<=6"
+    "skip": "<=6"
   },
   "coffeescript": {
     "maintainers": ["jashkenas", "GeoffreyBooth"]
@@ -146,7 +146,7 @@
     "prefix": "v",
     "maintainers": "SimenB",
     "yarn": true,
-    "envVar": {"YARN_IGNORE_ENGINES": true},
+    "envVar": { "YARN_IGNORE_ENGINES": true },
     "skip": ["aix"]
   },
   "esprima": {
@@ -259,6 +259,7 @@
   },
   "leveldown": {
     "prefix": "v",
+    "useGitClone": true,
     "flaky": ["ppc", "s390"],
     "tags": "native",
     "maintainers": "rvagg"

--- a/lib/unpack.js
+++ b/lib/unpack.js
@@ -46,6 +46,8 @@ function unpack(context, next) {
         return next(Error('Nothing to unpack... Ending'));
       }
     });
+  } else if (context.unpack === false) {
+    return next(null, context);
   } else {
     return next(Error('Nothing to unpack... Ending'));
   }

--- a/test/fixtures/custom-lookup-useGitClone.json
+++ b/test/fixtures/custom-lookup-useGitClone.json
@@ -1,0 +1,6 @@
+{
+  "lodash": {
+    "prefix": "v",
+    "useGitClone": true
+  }
+}

--- a/test/test-grab-project.js
+++ b/test/test-grab-project.js
@@ -121,6 +121,51 @@ test('grab-project: module does not exist', (t) => {
   });
 });
 
+test('grab-project: use git clone', (t) => {
+  const context = {
+    emit: function() {},
+    path: sandbox,
+    module: {
+      name: 'omg-i-pass',
+      type: 'git',
+      raw: 'https://github.com/MylesBorins/omg-i-pass.git',
+      ref: 'v3.0.0'
+    },
+    options: {}
+  };
+  grabProject(context, (err) => {
+    t.error(err);
+    fs.stat(
+      path.join(context.path, 'omg-i-pass/package.json'),
+      (err, stats) => {
+        t.error(err);
+        t.ok(stats.isFile(), 'The project must be cloned locally');
+        t.end();
+      }
+    );
+  });
+});
+
+test('grab-project: fail with bad ref', (t) => {
+  const context = {
+    emit: function() {},
+    path: sandbox,
+    module: {
+      name: 'omg-i-pass',
+      type: 'git',
+      raw: 'https://github.com/MylesBorins/omg-i-pass.git',
+      ref: 'bad-git-ref'
+    },
+    options: {}
+  };
+  grabProject(context, (err) => {
+    t.equals(
+      err && err.message,
+      'Command failed: git fetch --depth=1 origin v1.42.42'
+    );
+  });
+});
+
 test('grab-project: timeout', (t) => {
   const context = {
     emit: function() {},

--- a/test/test-grab-project.js
+++ b/test/test-grab-project.js
@@ -126,8 +126,8 @@ test('grab-project: use git clone', (t) => {
     emit: function() {},
     path: path.join(sandbox, 'git-clone'),
     module: {
+      useGitClone: true,
       name: 'omg-i-pass',
-      type: 'git',
       raw: 'https://github.com/MylesBorins/omg-i-pass.git',
       ref: 'v3.0.0'
     },
@@ -151,8 +151,8 @@ test('grab-project: fail with bad ref', (t) => {
     emit: function() {},
     path: path.join(sandbox, 'git-bad-ref'),
     module: {
+      useGitClone: true,
       name: 'omg-i-pass',
-      type: 'git',
       raw: 'https://github.com/MylesBorins/omg-i-pass.git',
       ref: 'bad-git-ref'
     },

--- a/test/test-grab-project.js
+++ b/test/test-grab-project.js
@@ -124,7 +124,7 @@ test('grab-project: module does not exist', (t) => {
 test('grab-project: use git clone', (t) => {
   const context = {
     emit: function() {},
-    path: sandbox,
+    path: path.join(sandbox, 'git-clone'),
     module: {
       name: 'omg-i-pass',
       type: 'git',
@@ -149,7 +149,7 @@ test('grab-project: use git clone', (t) => {
 test('grab-project: fail with bad ref', (t) => {
   const context = {
     emit: function() {},
-    path: sandbox,
+    path: path.join(sandbox, 'git-bad-ref'),
     module: {
       name: 'omg-i-pass',
       type: 'git',
@@ -161,8 +161,9 @@ test('grab-project: fail with bad ref', (t) => {
   grabProject(context, (err) => {
     t.equals(
       err && err.message,
-      'Command failed: git fetch --depth=1 origin v1.42.42'
+      'Command failed: git fetch --depth=1 origin bad-git-ref'
     );
+    t.end();
   });
 });
 

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -221,6 +221,38 @@ test('lookup: module in table with gitHead', (t) => {
   });
 });
 
+test('lookup: module in table with useGitClone', (t) => {
+  const context = {
+    lookup: null,
+    module: {
+      fetchSpec: 'latest',
+      name: 'lodash',
+      raw: null
+    },
+    meta: {
+      'dist-tags': { latest: '1.2.3' },
+      repository: {
+        url: 'https://github.com/lodash/lodash'
+      }
+    },
+    options: {
+      lookup: 'test/fixtures/custom-lookup-useGitClone.json'
+    },
+    emit: function() {}
+  };
+
+  lookup(context, (err) => {
+    t.error(err);
+    t.equals(
+      context.module.raw,
+      'https://github.com/lodash/lodash.git',
+      'raw should be a git URL if useGitClone is true'
+    );
+    t.equals(context.module.ref, 'v1.2.3');
+    t.end();
+  });
+});
+
 test('lookup: no table', (t) => {
   const context = {
     options: {

--- a/test/test-unpack.js
+++ b/test/test-unpack.js
@@ -67,3 +67,15 @@ test('unpack: valid unpack', (t) => {
     });
   });
 });
+
+test('unpack: context.unpack = false', (t) => {
+  const context = {
+    unpack: false,
+    emit: function() {}
+  };
+
+  unpack(context, (err) => {
+    t.error(err);
+    t.end();
+  });
+});


### PR DESCRIPTION
If "useGitClone" is set to "true", a shallow clone of the
repository will be used instead of downloading the tarball.

Fixes: https://github.com/nodejs/citgm/issues/694