### PR TITLE
feat: add scripts option to lookup table

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
 "envVar"                     Pass an environment variable before running
 "install": ["--param1", "--param2"] - Array of extra command line parameters passed to 'npm install'
 "maintainers": ["user1", "user2"] - List of module maintainers to be contacted with issues
+"scripts": ["script1", "script2"] - List of scripts from package.json to run instead of 'test'
 "tags": ["tag1", "tag2"]     Specify which tags apply to the module
 "useGitClone": true          Use a shallow git clone instead of downloading the module
 "ignoreGitHead":             Ignore the gitHead field if it exists and fallback to using github tags

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -149,6 +149,15 @@ function resolve(context, next) {
         );
         context.module.install = rep.install;
       }
+      if (rep.scripts) {
+        context.emit(
+          'data',
+          'silly',
+          `${context.module.name} lookup-scripts`,
+          rep.scripts
+        );
+        context.module.scripts = rep.scripts;
+      }
       if (rep.tags) {
         context.module.tags = rep.tags;
       }

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -308,6 +308,12 @@
     "skip": "win32",
     "maintainers": "linusu"
   },
+  "nan": {
+    "maintainers": ["nodejs/addon-api"],
+    "prefix": "v",
+    "scripts": ["rebuild-tests", "test"],
+    "tags": "native"
+  },
   "node-gyp": {
     "prefix": "v",
     "tags": "native",

--- a/lib/package-manager/test.js
+++ b/lib/package-manager/test.js
@@ -66,44 +66,79 @@ function test(packageManager, context, next) {
 
     /* Run `npm/yarn test`, or `/path/to/customTest.js` if the customTest option
      was passed */
-    const args = context.options.customTest
-      ? [context.options.customTest]
-      : [packageManagerBin, 'test'];
-
-    const proc = spawn(bin, args, options);
-    const finish = timeout(context, proc, next, 'Test');
-
-    proc.stdout.on('data', (data) => {
-      context.testOutput.append(data);
-      if (context.module.stripAnsi) {
-        data = stripAnsi(data.toString());
-        data = data.replace(/\r/g, '\n');
+    let scripts;
+    if (context.options.customTest) {
+      scripts = [[context.options.customTest]];
+    } else if (context.module.scripts) {
+      scripts = context.module.scripts.map((script) => [
+        packageManagerBin,
+        'run',
+        script
+      ]);
+    } else {
+      scripts = [[packageManagerBin, 'test']];
+    }
+    context.emit(
+      'data',
+      'silly',
+      `${context.module.name} npm-test:`,
+      `Scripts to execute: ${JSON.stringify(scripts)}.`
+    );
+    context.scripts = scripts;
+    context.scriptsIter = scripts.keys();
+    const runScript = (err, context) => {
+      if (err) {
+        return next(err, context);
       }
+      const scriptIndex = context.scriptsIter.next();
+      if (scriptIndex.done) {
+        return next(err, context);
+      }
+      const args = context.scripts[scriptIndex.value];
       context.emit(
         'data',
-        'verbose',
+        'silly',
         `${context.module.name} npm-test:`,
-        data.toString()
+        `Running script ${JSON.stringify(args)}.`
       );
-    });
-    proc.stderr.on('data', (data) => {
-      context.testError.append(data);
-      context.emit(
-        'data',
-        'verbose',
-        `${context.module.name} npm-test:`,
-        data.toString()
-      );
-    });
-    proc.on('error', () => {
-      finish(new Error('Tests Failed'));
-    });
-    proc.on('close', (code) => {
-      if (code > 0) {
-        return finish(new Error('The canary is dead:'));
-      }
-      return finish(null, context);
-    });
+
+      const proc = spawn(bin, args, options);
+      const finish = timeout(context, proc, runScript, 'Test');
+
+      proc.stdout.on('data', (data) => {
+        context.testOutput.append(data);
+        if (context.module.stripAnsi) {
+          data = stripAnsi(data.toString());
+          data = data.replace(/\r/g, '\n');
+        }
+        context.emit(
+          'data',
+          'verbose',
+          `${context.module.name} npm-test:`,
+          data.toString()
+        );
+      });
+      proc.stderr.on('data', (data) => {
+        context.testError.append(data);
+        context.emit(
+          'data',
+          'verbose',
+          `${context.module.name} npm-test:`,
+          data.toString()
+        );
+      });
+      proc.on('error', () => {
+        finish(new Error('Tests Failed'));
+      });
+      proc.on('close', (code) => {
+        if (code > 0) {
+          return finish(new Error('The canary is dead:'));
+        }
+        return finish(null, context);
+      });
+    };
+
+    runScript(null, context);
   });
 }
 

--- a/test/fixtures/custom-lookup-scripts.json
+++ b/test/fixtures/custom-lookup-scripts.json
@@ -1,0 +1,6 @@
+{
+  "omg-i-pass-with-scripts": {
+    "prefix": "v",
+    "scripts": ["test-build", "test"]
+  }
+}

--- a/test/fixtures/omg-i-pass-with-scripts/build.js
+++ b/test/fixtures/omg-i-pass-with-scripts/build.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const { writeFileSync } = require('fs');
+const { join } = require('path');
+
+writeFileSync(join(__dirname, '.testbuilt'), 'test-build ran');

--- a/test/fixtures/omg-i-pass-with-scripts/package.json
+++ b/test/fixtures/omg-i-pass-with-scripts/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "omg-i-pass-with-scripts",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "test-build": "node build.js",
+    "test": "node test.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nodejs/citgm"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/test/fixtures/omg-i-pass-with-scripts/test.js
+++ b/test/fixtures/omg-i-pass-with-scripts/test.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const assert = require('assert');
+const { existsSync } = require('fs');
+const { join } = require('path');
+
+assert(existsSync(join(__dirname, '.testbuilt')));

--- a/test/npm/test-npm-test.js
+++ b/test/npm/test-npm-test.js
@@ -25,10 +25,13 @@ const failTemp = path.join(sandbox, 'omg-i-fail');
 const badFixtures = path.join(fixtures, 'omg-i-do-not-support-testing');
 const badTemp = path.join(sandbox, 'omg-i-do-not-support-testing');
 
+const scriptsFixtures = path.join(fixtures, 'omg-i-pass-with-scripts');
+const scriptsTemp = path.join(sandbox, 'omg-i-pass-with-scripts');
+
 let packageManagers;
 
 test('npm-test: setup', (t) => {
-  t.plan(8);
+  t.plan(13);
   packageManager.getPackageManagers((e, res) => {
     packageManagers = res;
     t.error(e);
@@ -46,6 +49,13 @@ test('npm-test: setup', (t) => {
     ncp(badFixtures, badTemp, (e) => {
       t.error(e);
       t.ok(fs.existsSync(path.join(badTemp, 'package.json')));
+    });
+    ncp(scriptsFixtures, scriptsTemp, (e) => {
+      t.error(e);
+      t.ok(!fs.existsSync(path.join(scriptsTemp, '.testbuilt')));
+      t.ok(fs.existsSync(path.join(scriptsTemp, 'build.js')));
+      t.ok(fs.existsSync(path.join(scriptsTemp, 'package.json')));
+      t.ok(fs.existsSync(path.join(scriptsTemp, 'test.js')));
     });
   });
 });
@@ -131,6 +141,24 @@ test('npm-test: timeout', (t) => {
   packageManagerTest('npm', context, (err) => {
     t.ok(context.module.flaky, 'Module is Flaky because tests timed out');
     t.equals(err && err.message, 'Test Timed Out');
+    t.end();
+  });
+});
+
+test('npm-test: module with scripts passing', (t) => {
+  const context = makeContext.npmContext(
+    {
+      name: 'omg-i-pass-with-scripts',
+      scripts: ['test-build', 'test']
+    },
+    packageManagers,
+    sandbox,
+    {
+      npmLevel: 'silly'
+    }
+  );
+  packageManagerTest('npm', context, (err) => {
+    t.error(err);
     t.end();
   });
 });

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -221,6 +221,35 @@ test('lookup: module in table with gitHead', (t) => {
   });
 });
 
+test('lookup: module in table with scripts', (t) => {
+  const context = {
+    module: {
+      name: 'omg-i-pass-with-scripts',
+      raw: null
+    },
+    meta: {
+      repository: {
+        url: 'git+https://github.com/nodejs/citgm'
+      },
+      version: '1.0.0'
+    },
+    options: {
+      lookup: 'test/fixtures/custom-lookup-scripts.json'
+    },
+    emit: function() {}
+  };
+
+  lookup(context, (err) => {
+    t.error(err);
+    t.strictSame(
+      context.module.scripts,
+      ['test-build', 'test'],
+      'lookup should read scripts'
+    );
+    t.end();
+  });
+});
+
 test('lookup: module in table with useGitClone', (t) => {
   const context = {
     lookup: null,

--- a/test/yarn/test-yarn-test.js
+++ b/test/yarn/test-yarn-test.js
@@ -25,10 +25,13 @@ const failTemp = path.join(sandbox, 'omg-i-fail');
 const badFixtures = path.join(fixtures, 'omg-i-do-not-support-testing');
 const badTemp = path.join(sandbox, 'omg-i-do-not-support-testing');
 
+const scriptsFixtures = path.join(fixtures, 'omg-i-pass-with-scripts');
+const scriptsTemp = path.join(sandbox, 'omg-i-pass-with-scripts');
+
 let packageManagers;
 
 test('yarn-test: setup', (t) => {
-  t.plan(8);
+  t.plan(13);
   packageManager.getPackageManagers((e, res) => {
     packageManagers = res;
     t.error(e);
@@ -46,6 +49,13 @@ test('yarn-test: setup', (t) => {
     ncp(badFixtures, badTemp, (e) => {
       t.error(e);
       t.ok(fs.existsSync(path.join(badTemp, 'package.json')));
+    });
+    ncp(scriptsFixtures, scriptsTemp, (e) => {
+      t.error(e);
+      t.ok(!fs.existsSync(path.join(scriptsTemp, '.testbuilt')));
+      t.ok(fs.existsSync(path.join(scriptsTemp, 'build.js')));
+      t.ok(fs.existsSync(path.join(scriptsTemp, 'package.json')));
+      t.ok(fs.existsSync(path.join(scriptsTemp, 'test.js')));
     });
   });
 });
@@ -126,6 +136,24 @@ test('yarn-test: timeout', (t) => {
   packageManagerTest('yarn', context, (err) => {
     t.ok(context.module.flaky, 'Module is Flaky because tests timed out');
     t.equals(err && err.message, 'Test Timed Out');
+    t.end();
+  });
+});
+
+test('yarn-test: module with scripts passing', (t) => {
+  const context = makeContext.npmContext(
+    {
+      name: 'omg-i-pass-with-scripts',
+      scripts: ['test-build', 'test']
+    },
+    packageManagers,
+    sandbox,
+    {
+      npmLevel: 'silly'
+    }
+  );
+  packageManagerTest('yarn', context, (err) => {
+    t.error(err);
     t.end();
   });
 });


### PR DESCRIPTION
If set, "scripts" specifies the scripts from the module's package.json
to run instead of the default "test".

Allows `nan` to be added (second commit).
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
