### PR TITLE
lookup: skip ref

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -367,7 +367,7 @@
     "flaky": "aix",
     "tags": "native",
     "maintainers": "TooTallNate",
-    "skip": ["12", "win32"]
+    "skip": [true, "12", "win32"]
   },
   "request": {
     "prefix": "v",


### PR DESCRIPTION
ref is now unreliable on all versions of node

It appears it relies on `"mocha": *` which might explain what is going
on, but I am unable to reliable get the suite passing on 6, 8, or 10