### PR TITLE
Revert "lookup: don't skip bcrypt for v12 (#685)"

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -37,7 +37,8 @@
   "bcrypt": {
     "prefix": "v",
     "tags": "native",
-    "maintainers": "ncb000gt"
+    "maintainers": "ncb000gt",
+    "skip": "12"
   },
   "binary-split": {
     "prefix": "v",


### PR DESCRIPTION
This reverts commit 37452aa0a5d4f7e5b09842f2c0dd4997d76e8e14.

Seems like something is failing again @agathver 

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
