### PR TITLE
reporter: fix junit skip reporting

### DIFF
--- a/lib/reporter/junit.js
+++ b/lib/reporter/junit.js
@@ -10,10 +10,14 @@ const util = require('./util');
 function generateTest(xml, mod) {
   const output = util.sanitizeOutput(mod.testOutput, '', true);
   const item = xml.ele('testcase');
-  item.att('name', [mod.name, `v${mod.version}`].join('-'));
+  let name = mod.name;
+  if (mod.version) {
+    name = [name, `v${mod.version}`].join('-');
+  }
+  item.att('name', name);
   item.att('time', mod.duration / 1000);
   item.ele('system-out').dat(output);
-  if (mod.skip || (mod.flaky && mod.error)) {
+  if (mod.skipped || (mod.flaky && mod.error)) {
     item.ele('skipped');
   }
   if (mod.error) {

--- a/test/fixtures/parsed-junit.json
+++ b/test/fixtures/parsed-junit.json
@@ -41,6 +41,14 @@
             }
           }
         ]
+      },
+      {
+        "$": {
+          "name": "iSkipped",
+          "time": "NaN"
+        },
+        "system-out": ["\n      \n    "],
+        "skipped": [""]
       }
     ]
   }

--- a/test/fixtures/reporter-fixtures.json
+++ b/test/fixtures/reporter-fixtures.json
@@ -6,7 +6,6 @@
   },
   "iSkipped": {
     "name": "iSkipped",
-    "version": "4.2.2",
     "skipped": true
   },
   "iFail": {

--- a/test/fixtures/test-out-xml-failing.txt
+++ b/test/fixtures/test-out-xml-failing.txt
@@ -17,5 +17,11 @@
     </system-out>
     <failure message="module test suite failed">[object Object] </failure>
   </testcase>
+  <testcase name="iSkipped" time="NaN">
+    <system-out>
+      <![CDATA[]]>
+    </system-out>
+    <skipped/>
+  </testcase>
 </testsuite>
 

--- a/test/reporter/test-reporter-junit.js
+++ b/test/reporter/test-reporter-junit.js
@@ -34,7 +34,12 @@ const passingExpectedAppend = fs.readFileSync(
   'utf-8'
 );
 
-const failingInput = [fixtures.iPass, fixtures.iFlakyFail, fixtures.iFail];
+const failingInput = [
+  fixtures.iPass,
+  fixtures.iFlakyFail,
+  fixtures.iFail,
+  fixtures.iSkipped
+];
 
 const junitParserExpected = require('../fixtures/parsed-junit.json');
 const failingExpectedPath = path.join(fixturesPath, 'test-out-xml-failing.txt');


### PR DESCRIPTION
Fixes reporting of skipped modules for the junit reporter.

Also tidy up the name for skipped modules, which do not have
`version` metadata.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
