### PR TITLE
lib: redirect tmpdir for modules being tested

### DIFF
--- a/lib/create-options.js
+++ b/lib/create-options.js
@@ -14,6 +14,9 @@ function createOptions(cwd, context) {
   options.env = Object.create(process.env);
   options.env['npm_loglevel'] = context.options.npmLevel;
   options.env['npm_config_tmp'] = context.npmConfigTmp;
+  options.env['TEMP'] = context.npmConfigTmp;
+  options.env['TMP'] = context.npmConfigTmp;
+  options.env['TMPDIR'] = context.npmConfigTmp;
 
   if (context.options.nodedir) {
     const nodedir = path.resolve(process.cwd(), context.options.nodedir);

--- a/test/fixtures/omg-i-write-to-tmpdir/package.json
+++ b/test/fixtures/omg-i-write-to-tmpdir/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "omg-i-write-to-tmpdir",
+  "version": "1.0.0",
+  "description": "Test suite writes to tmpdir",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nodejs/citgm.git"
+  },
+  "main": "index.js",
+  "scripts": {
+    "test": "node test.js",
+    "install": "exit 0"
+  },
+  "keywords": [
+    "always",
+    "passes"
+  ],
+  "license": "MIT"
+}

--- a/test/fixtures/omg-i-write-to-tmpdir/test.js
+++ b/test/fixtures/omg-i-write-to-tmpdir/test.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const { join } = require('path');
+const { tmpdir } = require('os');
+const { writeFileSync } = require('fs');
+
+writeFileSync(join(tmpdir(), 'omg-i-write-to-tmpdir-testfile'));

--- a/test/npm/test-npm-test.js
+++ b/test/npm/test-npm-test.js
@@ -28,10 +28,13 @@ const badTemp = path.join(sandbox, 'omg-i-do-not-support-testing');
 const scriptsFixtures = path.join(fixtures, 'omg-i-pass-with-scripts');
 const scriptsTemp = path.join(sandbox, 'omg-i-pass-with-scripts');
 
+const writeTmpdirFixtures = path.join(fixtures, 'omg-i-write-to-tmpdir');
+const writeTmpdirTemp = path.join(sandbox, 'omg-i-write-to-tmpdir');
+
 let packageManagers;
 
 test('npm-test: setup', (t) => {
-  t.plan(13);
+  t.plan(16);
   packageManager.getPackageManagers((e, res) => {
     packageManagers = res;
     t.error(e);
@@ -56,6 +59,11 @@ test('npm-test: setup', (t) => {
       t.ok(fs.existsSync(path.join(scriptsTemp, 'build.js')));
       t.ok(fs.existsSync(path.join(scriptsTemp, 'package.json')));
       t.ok(fs.existsSync(path.join(scriptsTemp, 'test.js')));
+    });
+    ncp(writeTmpdirFixtures, writeTmpdirTemp, (e) => {
+      t.error(e);
+      t.ok(fs.existsSync(path.join(writeTmpdirTemp, 'package.json')));
+      t.ok(fs.existsSync(path.join(writeTmpdirTemp, 'test.js')));
     });
   });
 });
@@ -159,6 +167,28 @@ test('npm-test: module with scripts passing', (t) => {
   );
   packageManagerTest('npm', context, (err) => {
     t.error(err);
+    t.end();
+  });
+});
+
+test('npm-test: tmpdir is redirected', (t) => {
+  const context = makeContext.npmContext(
+    'omg-i-write-to-tmpdir',
+    packageManagers,
+    sandbox,
+    {
+      npmLevel: 'silly'
+    }
+  );
+  context.npmConfigTmp = writeTmpdirTemp;
+  packageManagerTest('npm', context, (err) => {
+    t.error(err);
+    t.ok(
+      fs.existsSync(
+        path.join(writeTmpdirTemp, 'omg-i-write-to-tmpdir-testfile')
+      ),
+      'Temporary file is written into the redirected temporary directory'
+    );
     t.end();
   });
 });

--- a/test/test-create-options.js
+++ b/test/test-create-options.js
@@ -28,6 +28,9 @@ test('create-options:', (t) => {
   env['npm_loglevel'] = 'warning';
   env['npm_config_tmp'] = 'npm_config_tmp';
   env['testenvVar'] = 'thisisatest';
+  env['TEMP'] = 'npm_config_tmp';
+  env['TMP'] = 'npm_config_tmp';
+  env['TMPDIR'] = 'npm_config_tmp';
   // Set dynamically to support Windows.
   env['npm_config_nodedir'] = path.resolve(process.cwd(), nodePath);
 

--- a/test/yarn/test-yarn-test.js
+++ b/test/yarn/test-yarn-test.js
@@ -28,10 +28,13 @@ const badTemp = path.join(sandbox, 'omg-i-do-not-support-testing');
 const scriptsFixtures = path.join(fixtures, 'omg-i-pass-with-scripts');
 const scriptsTemp = path.join(sandbox, 'omg-i-pass-with-scripts');
 
+const writeTmpdirFixtures = path.join(fixtures, 'omg-i-write-to-tmpdir');
+const writeTmpdirTemp = path.join(sandbox, 'omg-i-write-to-tmpdir');
+
 let packageManagers;
 
 test('yarn-test: setup', (t) => {
-  t.plan(13);
+  t.plan(16);
   packageManager.getPackageManagers((e, res) => {
     packageManagers = res;
     t.error(e);
@@ -56,6 +59,11 @@ test('yarn-test: setup', (t) => {
       t.ok(fs.existsSync(path.join(scriptsTemp, 'build.js')));
       t.ok(fs.existsSync(path.join(scriptsTemp, 'package.json')));
       t.ok(fs.existsSync(path.join(scriptsTemp, 'test.js')));
+    });
+    ncp(writeTmpdirFixtures, writeTmpdirTemp, (e) => {
+      t.error(e);
+      t.ok(fs.existsSync(path.join(writeTmpdirTemp, 'package.json')));
+      t.ok(fs.existsSync(path.join(writeTmpdirTemp, 'test.js')));
     });
   });
 });
@@ -154,6 +162,28 @@ test('yarn-test: module with scripts passing', (t) => {
   );
   packageManagerTest('yarn', context, (err) => {
     t.error(err);
+    t.end();
+  });
+});
+
+test('yarn-test: tmpdir is redirected', (t) => {
+  const context = makeContext.npmContext(
+    'omg-i-write-to-tmpdir',
+    packageManagers,
+    sandbox,
+    {
+      npmLevel: 'silly'
+    }
+  );
+  context.npmConfigTmp = writeTmpdirTemp;
+  packageManagerTest('npm', context, (err) => {
+    t.error(err);
+    t.ok(
+      fs.existsSync(
+        path.join(writeTmpdirTemp, 'omg-i-write-to-tmpdir-testfile')
+      ),
+      'Temporary file is written into the redirected temporary directory'
+    );
     t.end();
   });
 });


### PR DESCRIPTION
The test for some modules write into `os.tmpdir()` and do not always
clean up afterwards which can fill the temporary directory on our CI.
Redirect the temporary directory for modules being tested into CITGM's
`tmpDir` which gets removed at the end of the run.

Refs: https://github.com/nodejs/build/issues/1757

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
