### PR TITLE
Revert "lookup: skip cheerio"

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -83,8 +83,7 @@
   },
   "cheerio": {
     "skip": "win32",
-    "maintainers": ["matthewmueller", "jugglinmike"],
-    "skip": true
+    "maintainers": ["matthewmueller", "jugglinmike"]
   },
   "clinic": {
     "maintainers": "mcollina",


### PR DESCRIPTION
cheerio test failures have been fixed in cheerio@1.0.0-rc.3.

Fixes: https://github.com/nodejs/citgm/issues/699

This reverts commit 36d8dd28503f1b64f3eddcd2996178b2496d773e.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
