### PR TITLE
package: update yargs to 13.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "winston": "^2.4.4",
     "xml-sanitizer": "^1.1.6",
     "xmlbuilder": "^10.1.1",
-    "yargs": "^12.0.5",
+    "yargs": "^13.2.2",
     "yarn": "^1.15.2"
   },
   "devDependencies": {


### PR DESCRIPTION
I didn't include this in the batch update because I thought they stopped supporting Node 6, but that's apparently [not the case](https://github.com/yargs/yargs/blob/master/CHANGELOG.md#1300-2019-02-02)