### PR TITLE
lib: fix logging in lib/check-tags.js

### DIFF
--- a/lib/check-tags.js
+++ b/lib/check-tags.js
@@ -37,10 +37,10 @@ function checkTags(options, mod, name, log) {
   }
 
   if (options.includeTags.length) {
-    log.info(`${name} skipped as no includeTags matched`);
+    log.info(name, 'skipped as no includeTags matched');
     return true; // We did not match an includeTag.
   } else {
-    log.info(`${name} will run as no excludeTags matched`);
+    log.info(name, 'will run as no excludeTags matched');
     return false; // We did not match an excludeTag.
   }
 }


### PR DESCRIPTION
The log functions take two parameters: tag and message. Fix instances
of calling `log.info` with only one parameter (which is treated as tag).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
