### PR TITLE
lib: fix npm loglevel environment variable name

### DIFF
--- a/lib/create-options.js
+++ b/lib/create-options.js
@@ -12,7 +12,7 @@ function createOptions(cwd, context) {
     if (context.options.gid) options.gid = context.options.gid;
   }
   options.env = Object.create(process.env);
-  options.env['npm_loglevel'] = context.options.npmLevel;
+  options.env['npm_config_loglevel'] = context.options.npmLevel;
   options.env['npm_config_tmp'] = context.npmConfigTmp;
   options.env['TEMP'] = context.npmConfigTmp;
   options.env['TMP'] = context.npmConfigTmp;

--- a/test/test-create-options.js
+++ b/test/test-create-options.js
@@ -25,7 +25,7 @@ test('create-options:', (t) => {
   // Create a copy of process.env to set the properties added by createOptions
   // for the deepequal test.
   const env = Object.create(process.env);
-  env['npm_loglevel'] = 'warning';
+  env['npm_config_loglevel'] = 'warning';
   env['npm_config_tmp'] = 'npm_config_tmp';
   env['testenvVar'] = 'thisisatest';
   env['TEMP'] = 'npm_config_tmp';
@@ -41,7 +41,7 @@ test('create-options:', (t) => {
     options.env,
     env,
     'The created env should be a clone of' +
-      ' process.env with the added npm_loglevel and nodedir'
+      ' process.env with the added npm_config_loglevel and nodedir'
   );
   t.end();
 });


### PR DESCRIPTION
npm environment variables are prefixed with `npm_config_`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
