### PR TITLE
chore: cleanup citgm.js

### DIFF
--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -17,18 +17,6 @@ const unpack = require('./unpack');
 const windows = process.platform === 'win32';
 exports.windows = windows;
 
-/**
- * The process here is straightforward:
- * 1. We pull down information about the module from npm
- * 2. We create a temporary working directory and pull down the
- *    module using the git repo shown in the npm metadata or,
- *    if the repo is not specified, by pulling the code from
- *    npm itself
- * 3. If npm-test is implemented, invoke to run the tests. Otherwise,
- * 4. Filter the output of 4 through the Reporter script (details TBD)
- * 5. Output the results.
- **/
-
 function findNode(context, next) {
   which('node', (err, resolved) => {
     if (err) {
@@ -60,7 +48,6 @@ function findPackageManagers(context, next) {
 }
 
 function init(context, next) {
-  // Single module that citgm is testing.
   if (!windows) {
     if (context.options.uid)
       context.emit(
@@ -94,22 +81,18 @@ function sha1(mod) {
 }
 
 function extractDetail(mod) {
-  const detail = npa(mod); // Will throw on failure
-  detail.name = detail.name || sha1(mod);
+  const detail = npa(mod); // Will throw if mod is invalid
+  detail.name = detail.name || `noname-${sha1(mod)}`;
   return detail;
 }
 
 /**
- * Setup the test
- *  - module = the name of the npm module to check out
- *
  * The Tester will emit specific events once it is run:
  *  - end = emitted when the test is complete
  *  - fail = emitted if the test fails for any reason
  *  - info = informational events (for debugging)
  *  - start = emitted when run is started
  **/
-
 class Tester extends EventEmitter {
   constructor(mod, options) {
     super();
@@ -121,7 +104,7 @@ class Tester extends EventEmitter {
   }
 
   run() {
-    this.emit('start', this.module.raw, this.options);
+    this.emit('start', this.module.raw);
 
     async.waterfall(
       [

--- a/test/test-citgm.js
+++ b/test/test-citgm.js
@@ -30,6 +30,8 @@ test('citgm: omg-i-pass', (t) => {
 });
 
 test('citgm: omg-i-pass from git url', (t) => {
+  t.plan(3);
+
   const options = {
     hmac: null,
     lookup: null,
@@ -39,9 +41,14 @@ test('citgm: omg-i-pass from git url', (t) => {
 
   const mod = 'git+https://github.com/MylesBorins/omg-i-pass';
 
-  new citgm.Tester(mod, options)
+  const tester = new citgm.Tester(mod, options);
+  tester
     .on('start', (name) => {
-      t.equals(name, mod, 'it should be omg-i-pass');
+      t.equals(name, mod, 'it should be the raw URL');
+      t.equals(
+        tester.module.name,
+        `noname-44e9e903ceed542df23ff575629965f65eeaa51a`
+      );
     })
     .on('fail', (err) => {
       t.error(err);


### PR DESCRIPTION
* Remove outdated / wrong comments
* Add a "noname-" prefix if the module's name is a hash
* Stop emitting this.options. It is never used.
