### PR TITLE
lookup: unskip bcrypt for Node.js 12

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -37,8 +37,7 @@
   "bcrypt": {
     "prefix": "v",
     "tags": "native",
-    "maintainers": "ncb000gt",
-    "skip": "12"
+    "maintainers": "ncb000gt"
   },
   "binary-split": {
     "prefix": "v",


### PR DESCRIPTION
bcrypt v3.0.6 has been updated to use nan v2.13.2.

Refs: https://github.com/kelektiv/node.bcrypt.js/issues/715#issuecomment-484132851
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
