### PR TITLE
chore: enable node 12 and win32 for serialport

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -413,7 +413,7 @@
     "flaky": "ppc",
     "tags": "native",
     "maintainers": "reconbot",
-    "skip": ["12", "win32"]
+    "skip": ["win32"]
   },
   "shot": {
     "prefix": "v",


### PR DESCRIPTION
`serialport` now supports node 12. It has always supported windows32 (and it tested against it) so I’ve brought that back. I couldn’t find issues that explained why it was removed. The commit suggested that maybe it was flakey? If so I’d like to know more as we don’t see that in our tests.

Closes: https://github.com/node-serialport/node-serialport/issues/1742

##### Checklist

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
