### PR TITLE
chore(travis): stop supporting Node.js 6, add Node.js 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ os:
   - osx
   - windows
 node_js:
+  - '12'
   - '11'
   - '10'
   - '8'
-  - '6'
 script: 'npm run test-ci'
 after_script: 'bash <(curl -s https://codecov.io/bash)'


### PR DESCRIPTION
Needed to land https://github.com/nodejs/citgm/pull/709