### PR TITLE
lookup: remove ftp

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -187,11 +187,6 @@
     "expectFail": "fips",
     "maintainers": "jprichardson"
   },
-  "ftp": {
-    "prefix": "v",
-    "skip": true,
-    "maintainers": "mscdex"
-  },
   "full-icu-test": {
     "prefix": "v",
     "maintainers": "srl295"


### PR DESCRIPTION
The module is dead.
Previous attempt to fix its tests: https://github.com/mscdex/node-ftp/pull/191