### PR TITLE
lookup: add jsdom

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
 "useGitClone": true          Use a shallow git clone instead of downloading the module
 "ignoreGitHead":             Ignore the gitHead field if it exists and fallback to using github tags
 "yarn":                      Install and test the project using yarn instead of npm
+"timeoutLength":             Number of milliseconds before timeout
 ```
 
 If you want to pass options to npm, eg `--registry`, you can usually define an

--- a/lib/common-args.js
+++ b/lib/common-args.js
@@ -73,8 +73,7 @@ module.exports = function commonArgs(app) {
     .option('timeout', {
       alias: 'o',
       type: 'number',
-      description: 'Set timeout for npm install',
-      default: 1000 * 60 * 10
+      description: 'Set timeout for npm install'
     })
     .option('yarn', {
       alias: 'y',

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -162,6 +162,9 @@ function resolve(context) {
       if (rep.yarn) {
         context.module.useYarn = true;
       }
+      if (rep.timeoutLength) {
+        context.module.timeoutLength = rep.timeoutLength;
+      }
       context.module.flaky = context.options.failFlaky
         ? false
         : isMatch(rep.flaky);

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -237,6 +237,12 @@
     "maintainers": "jeresig",
     "ignoreGitHead": true
   },
+  "jsdom": {
+    "maintainers": ["domenic", "Zirro"],
+    "timeoutLength": 1200000,
+    "useGitClone": true,
+    "yarn": true
+  },
   "koa": {
     "flaky": "ubuntu",
     "maintainers": "tj"

--- a/lib/package-manager/test.js
+++ b/lib/package-manager/test.js
@@ -106,7 +106,13 @@ async function test(packageManager, context) {
       );
 
       const proc = spawn(bin, args, options);
-      const finish = timeout(context, proc, runScript, 'Test');
+      const finish = timeout(
+        context,
+        proc,
+        runScript,
+        'Test',
+        context.module.timeoutLength
+      );
 
       proc.stdout.on('data', (data) => {
         context.testOutput.append(data);

--- a/lib/timeout.js
+++ b/lib/timeout.js
@@ -3,9 +3,10 @@
 // Default timeout to 10 minutes if not provided
 const kDefaultTimeout = 1000 * 60 * 10;
 
-function timeout(context, proc, next, step) {
+function timeout(context, proc, next, step, moduleConfigTimeout) {
   let hasRun = false;
-  const delay = context.options.timeoutLength || kDefaultTimeout;
+  const delay =
+    context.options.timeoutLength || moduleConfigTimeout || kDefaultTimeout;
   // Third arg === `true` is the way to signal `finish` that this is a timeout.
   // Otherwise it acts like a "regular" callback, i.e. `(err, ret) => {}`.
   // `if (timedOut)` will overwrite `err` & `ret`, so first 2 args are ignored.


### PR DESCRIPTION
[jsdom](https://github.com/jsdom/jsdom) is a JavaScript implementation of the DOM and HTML standards, commonly used for testing and scraping websites while behaving much like a regular web browser.

It fulfills all the hard requirements of citgm (after the tests-in-tarball requirement was relaxed in https://github.com/nodejs/citgm/pull/695) and several soft requirements given its widespread usage within testing frameworks. The code makes frequent use of less common APIs such as `vm`, and is currently covered by around ~4500 tests that have revealed [unusual bugs](https://github.com/nodejs/node/issues/20978) in the past.

The tests usually take between 10-12 minutes to complete, so I've built on @SimenB's WIP to add the timeoutLength option in https://github.com/nodejs/citgm/pull/728 with a few more changes in order for it to work.