### PR TITLE
lookup: unskip bluebird on ppc and s390

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -56,8 +56,7 @@
   },
   "bluebird": {
     "prefix": "v",
-    "maintainers": "petkaantonov",
-    "skip": ["ppc", "s390"]
+    "maintainers": "petkaantonov"
   },
   "body-parser": {
     "flaky": "aix",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->
Bluebird v3.5.5 seems to pass on ppc and s390 for me locally and in ci 
https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker-nobuild/641/nodes=rhel72-s390x/console
https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker-nobuild/642/console
cc: @richardlau 

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
