### PR TITLE
lookup: fix pug

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -329,7 +329,8 @@
     "prefix": "pug@",
     "yarn": true,
     "maintainers": ["tj", "ForbesLindesay"],
-    "skip": ["win32"]
+    "skip": ["win32"],
+    "repo": "https://github.com/pugjs/pug"
   },
   "pumpify": {
     "prefix": "v",


### PR DESCRIPTION
pug metadata on npm points to a URL we can't use. Override in
lookup.json.

Fixes: https://github.com/nodejs/citgm/issues/744

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
