### PR TITLE
lookup: use master branch for ember-cli

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -127,6 +127,7 @@
   "ember-cli": {
     "prefix": "v",
     "flaky": ["win32", "rhel", "sles"],
+    "master": true,
     "expectFail": "fips",
     "maintainers": ["stefanpenner", "rwjblue", "Turbo87", "kellyselden"]
   },


### PR DESCRIPTION
ember-cli@3.11.0 has failing tests. This means that CITGM fails across
all platforms for ember-cli. The issue is fixed in the ember-cli master
branch. It should be safe to use the master branch, as ember-cli
releases approximately every 6 weeks (coinciding with ember releases)
and is very conservative about changes that would require a semver bump
(again, as is ember--they share the same version number).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
