### PR TITLE
lookup: fix serialport

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -402,6 +402,7 @@
   "serialport": {
     "prefix": "serialport@",
     "flaky": "ppc",
+    "master": true,
     "tags": "native",
     "maintainers": "reconbot",
     "skip": ["win32"]


### PR DESCRIPTION
The serialport fails across all platforms on which it is run during
CITGM runs against the current Node.js master branch. The fix for the
problem is (probably)
https://github.com/serialport/node-serialport/commit/13c542b891a69888573de2d7f0f2d6b64b7e7335
which hasn't made it into a release yet. Run tests against the master
branch of serialport instead of the current release.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
