### PR TITLE
lookup: koa & fastify master

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -162,8 +162,7 @@
   },
   "fastify": {
     "maintainers": ["mcollina", "delvedor"],
-    "prefix": "v",
-    "master": true
+    "prefix": "v"
   },
   "ffi": {
     "flaky": ["ppc", "aix", "s390", "ubuntu"],

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -162,7 +162,8 @@
   },
   "fastify": {
     "maintainers": ["mcollina", "delvedor"],
-    "prefix": "v"
+    "prefix": "v",
+    "master": true
   },
   "ffi": {
     "flaky": ["ppc", "aix", "s390", "ubuntu"],
@@ -239,7 +240,8 @@
   },
   "koa": {
     "flaky": "ubuntu",
-    "maintainers": "tj"
+    "maintainers": "tj",
+    "master": true
   },
   "level": {
     "prefix": "v",


### PR DESCRIPTION
koa & fastify master includes fixes to tests. This PR should be
reverted once koa and/or fastify does another release.

I will make new PR's when koa and/or fastify  make a new release.

Since it makes no sense to make new release for just test fixes these two can block https://github.com/nodejs/node/pull/27984 for quite a while without this PR.
