### PR TITLE
add end-of-stream and pump

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -131,6 +131,11 @@
     "expectFail": "fips",
     "maintainers": ["stefanpenner", "rwjblue", "Turbo87", "kellyselden"]
   },
+   "end-of-stream": {
+    "prefix": "v",
+    "maintainers": "mafintosh",
+    "skip": "win32"
+  },
   "eslint": {
     "prefix": "v",
     "flaky": ["s390", "ubuntu"],
@@ -333,6 +338,11 @@
     "skip": ["win32"],
     "repo": "https://github.com/pugjs/pug"
   },
+  "pump": {
+    "prefix": "v",
+    "maintainers": "mafintosh",
+    "skip": "win32"
+  },  
   "pumpify": {
     "prefix": "v",
     "maintainers": "mafintosh",


### PR DESCRIPTION
Adds end-of-stream and pump to CITGM.

Some minor releases in Node 10 broke both so it would have been good to have caught that early instead :)