### PR TITLE
Skip level on debian 8

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -245,7 +245,7 @@
     "prefix": "v",
     "flaky": ["aix", "s390"],
     "maintainers": ["ralphtheninja", "vweevers"],
-    "skip": "win32"
+    "skip": ["win32", "debian-8"]
   },
   "leveldown": {
     "prefix": "v",

--- a/lib/match-conditions.js
+++ b/lib/match-conditions.js
@@ -42,6 +42,7 @@ function isStringMatch(conditions) {
   const checks = [
     distro,
     release,
+    [distro, release].join('-'),
     version,
     [platform, arch].join('-'),
     endian,

--- a/test/test-match-conditions.js
+++ b/test/test-match-conditions.js
@@ -83,6 +83,17 @@ function testPlatforms(t, testFunction) {
   revertShim();
 }
 
+function testDistros(t, testFunction) {
+  shim();
+  t.ok(testFunction('macos-10.12.2'), 'macos-10.12.2 is matched');
+  t.ok(testFunction('macos'), 'macos is matched');
+  t.ok(testFunction('10.12.2'), '10.12.2 is matched');
+  t.notok(testFunction('macos-1.1.1'), 'macos-1.1.1 is not matched');
+  t.notok(testFunction('debian'), 'debian is not matched');
+  t.notok(testFunction('1.1.1'), '1.1.1 is not matched');
+  revertShim();
+}
+
 function testArrays(t, testFunction) {
   shim();
   t.ok(
@@ -127,6 +138,7 @@ test('isStringMatch', (t) => {
   const isStringMatch = isMatch.__get__('isStringMatch');
   testVersions(t, isStringMatch);
   testPlatforms(t, isStringMatch);
+  testDistros(t, isStringMatch);
   t.end();
 });
 
@@ -145,6 +157,7 @@ test('isArrayMatch', (t) => {
 test('isMatch', (t) => {
   testVersions(t, isMatch);
   testPlatforms(t, isMatch);
+  testDistros(t, isMatch);
   testArrays(t, isMatch);
   testObjects(t, isMatch);
   t.ok(isMatch(true), 'true is matched');


### PR DESCRIPTION
Because the prebuilt binaries of `leveldown` are not compatible with Debian 8, surfaced in https://github.com/nodejs/node/pull/29504#issuecomment-536988422.

@Trott /cc @ralphtheninja

##### Checklist

- [x] `npm test` passes
- [x] tests are included
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
