### PR TITLE
lib: show stderr when getting project from npm fails

### DIFF
--- a/lib/grab-project.js
+++ b/lib/grab-project.js
@@ -32,10 +32,8 @@ async function grabProject(context) {
       `Downloading project: ${packageName}`
     );
     let options = createOptions(context.path, context);
-    options.stdio = ['ignore', 'pipe', 'ignore'];
+    options.stdio = ['ignore', 'pipe', 'pipe'];
     const proc = spawn('npm', ['pack', packageName], options);
-
-    let filename = '';
 
     // Default timeout to 10 minutes if not provided
     const timeout = setTimeout(
@@ -56,8 +54,16 @@ async function grabProject(context) {
       reject(new Error('Download Timed Out'));
     }
 
+    let filename = '';
+    proc.stdout.setEncoding('utf8');
     proc.stdout.on('data', (chunk) => {
       filename += chunk;
+    });
+
+    let stderr = '';
+    proc.stderr.setEncoding('utf8');
+    proc.stderr.on('data', (chunk) => {
+      stderr += chunk;
     });
 
     proc.on('error', (err) => {
@@ -70,7 +76,7 @@ async function grabProject(context) {
       if (bailed) return;
       clearTimeout(timeout);
       if (code > 0) {
-        return reject(new Error('Failure getting project from npm'));
+        return reject(new Error(`Failure getting project from npm\n${stderr}`));
       }
       filename = filename.trim();
       if (context.module.type === 'directory') {
@@ -78,7 +84,7 @@ async function grabProject(context) {
         filename = filename.pop();
       }
       if (filename === '') {
-        return reject(new Error('No project downloaded'));
+        return reject(new Error(`No project downloaded\n${stderr}`));
       }
       context.emit(
         'data',

--- a/test/test-grab-project.js
+++ b/test/test-grab-project.js
@@ -89,7 +89,7 @@ test('grab-project: local', async (t) => {
 });
 
 test('grab-project: module does not exist', async (t) => {
-  t.plan(1);
+  t.plan(2);
   const context = {
     emit: function() {},
     path: sandbox,
@@ -101,7 +101,8 @@ test('grab-project: module does not exist', async (t) => {
   try {
     await grabProject(context);
   } catch (err) {
-    t.equals(err && err.message, 'Failure getting project from npm');
+    t.ok(err);
+    t.match(err.message, /^Failure getting project from npm/);
   }
 });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes (mostly – but failures seem unrelated)
- [x] tests are included
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
