### PR TITLE
lookup: skip s390 and ppc for react

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -353,7 +353,7 @@
     "prefix": "v",
     "maintainers": ["acdlite", "gaearon", "sophiebits"],
     "yarn": true,
-    "skip": [">=12", "aix"]
+    "skip": [">=12", "aix", "s390", "ppc"]
   },
   "readable-stream": {
     "prefix": "v",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->
React's failing on ppc and s390. The issue seems to be that it tries to download electron and there are no pre-compiled binaries of electron for these platforms.

```
Error: GET https://github.com/electron/electron/releases/download/v5.0.9/electron-v5.0.9-linux-ppc64.zip returned 404
 /home/iojs/tmp/citgm_tmp/490f84ce-553a-42cc-8633-20997dbe5f7d/react/node_modules/electron/install.js:49
   throw err
   ^
 Error: Failed to find Electron v5.0.9 for linux-ppc64 at https://github.com/electron/electron/releases/download/v5.0.9/electron-v5.0.9-linux-ppc64.zip
```
https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
