### PR TITLE
lib: redirect homedir for modules being tested

### DIFF
--- a/lib/create-options.js
+++ b/lib/create-options.js
@@ -12,6 +12,8 @@ function createOptions(cwd, context) {
     if (context.options.gid) options.gid = context.options.gid;
   }
   options.env = Object.create(process.env);
+  options.env['HOME'] = context.homeDir;
+  options.env['USERPROFILE'] = context.homeDir;
   options.env['npm_config_loglevel'] = context.options.npmLevel;
   options.env['npm_config_tmp'] = context.npmConfigTmp;
   options.env['TEMP'] = context.npmConfigTmp;

--- a/lib/temp-directory.js
+++ b/lib/temp-directory.js
@@ -21,8 +21,10 @@ async function create(context) {
     context.path
   );
 
+  context.homeDir = path.join(context.path, 'home');
   context.npmConfigTmp = path.join(context.path, 'npm_config_tmp');
 
+  await mkdirp(context.homeDir);
   await mkdirp(context.npmConfigTmp);
 }
 

--- a/test/test-create-options.js
+++ b/test/test-create-options.js
@@ -17,6 +17,7 @@ test('create-options:', (t) => {
       npmLevel: 'warning'
     },
     emit: function() {},
+    homeDir: 'homedir',
     npmConfigTmp: 'npm_config_tmp',
     module: { envVar: { testenvVar: 'thisisatest' } }
   };
@@ -26,6 +27,8 @@ test('create-options:', (t) => {
   // Create a copy of process.env to set the properties added by createOptions
   // for the deepequal test.
   const env = Object.create(process.env);
+  env['HOME'] = 'homedir';
+  env['USERPROFILE'] = 'homedir';
   env['npm_config_loglevel'] = 'warning';
   env['npm_config_tmp'] = 'npm_config_tmp';
   env['testenvVar'] = 'thisisatest';


### PR DESCRIPTION
The tests for some modules write into `os.homedir()` and are not
cleaning up afterwards. This is accumulating over time on our CI
and require periodic manual cleaning.

Redirect the environment variables used by `os.homedir()` into
CITGM's temporary directory for the module being tested, which gets
removed at the end of the test run.

Refs: https://github.com/nodejs/build/issues/1908#issuecomment-544298898

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
