### PR TITLE
chore: update dependencies

### DIFF
--- a/bin/citgm-all.js
+++ b/bin/citgm-all.js
@@ -205,7 +205,7 @@ function launch() {
   const q = async.queue(runTask, app.parallel || 1);
   q.push(collection);
   function done() {
-    q.drain = null;
+    q.kill();
     reporter.logger(log, modules);
 
     if (app.markdown) {
@@ -239,7 +239,7 @@ function launch() {
     done();
   }
 
-  q.drain = done;
+  q.drain(done);
 
   process.on('SIGINT', abort);
   process.on('SIGHUP', abort);

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "read-package-json": "^2.0.13",
     "readable-stream": "^3.3.0",
     "request": "^2.88.0",
-    "rimraf": "^2.6.3",
+    "rimraf": "^3.0.0",
     "root-check": "^1.0.0",
     "semver": "^6.0.0",
     "strip-ansi": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "columnify": "^1.5.4",
     "execa": "^1.0.0",
     "lodash": "^4.17.11",
-    "make-promises-safe": "^5.0.0",
+    "make-promises-safe": "^5.1.0",
     "mkdirp": "^0.5.1",
     "normalize-git-url": "^3.0.2",
     "npm-package-arg": "^6.1.0",
@@ -51,7 +51,7 @@
     "semver": "^6.0.0",
     "strip-ansi": "^5.2.0",
     "supports-color": "^6.1.0",
-    "tar": "^4.4.8",
+    "tar": "^4.4.13",
     "uid-number": "0.0.6",
     "update-notifier": "^3.0.0",
     "uuid": "^3.3.2",
@@ -60,12 +60,12 @@
     "xml-sanitizer": "^1.1.6",
     "xmlbuilder": "^13.0.1",
     "yargs": "^13.2.4",
-    "yarn": "^1.16.0"
+    "yarn": "^1.19.1"
   },
   "devDependencies": {
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^4.2.0",
-    "eslint-plugin-prettier": "^3.1.0",
+    "eslint-plugin-prettier": "^3.1.1",
     "fs-extra": "^8.0.1",
     "prettier": "1.17.1",
     "proxyquire": "^2.1.0",
@@ -73,7 +73,7 @@
     "string-to-stream": "^1.1.1",
     "tap": "^13.1.8",
     "tap-parser": "^9.3.2",
-    "xml2js": "^0.4.19"
+    "xml2js": "^0.4.22"
   },
   "prettier": {
     "arrowParens": "always",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "^3.1.0",
-    "bl": "^3.0.0",
+    "bl": "^4.0.0",
     "chalk": "^2.4.2",
     "columnify": "^1.5.4",
     "execa": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "bl": "^4.0.0",
     "chalk": "^2.4.2",
     "columnify": "^1.5.4",
-    "execa": "^1.0.0",
+    "execa": "^3.2.0",
     "lodash": "^4.17.11",
     "make-promises-safe": "^5.1.0",
     "mkdirp": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "winston": "^3.2.1",
     "xml-sanitizer": "^1.1.6",
     "xmlbuilder": "^13.0.1",
-    "yargs": "^13.2.4",
+    "yargs": "^14.2.0",
     "yarn": "^1.19.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "semver": "^6.0.0",
     "strip-ansi": "^5.2.0",
     "supports-color": "^7.1.0",
-    "tar": "^4.4.13",
+    "tar": "^5.0.5",
     "uid-number": "0.0.6",
     "update-notifier": "^3.0.0",
     "uuid": "^3.3.2",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "uid-number": "0.0.6",
     "update-notifier": "^3.0.0",
     "uuid": "^3.3.2",
-    "which": "^1.3.1",
+    "which": "^2.0.1",
     "winston": "^3.2.1",
     "xml-sanitizer": "^1.1.6",
     "xmlbuilder": "^13.0.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "root-check": "^1.0.0",
     "semver": "^6.0.0",
     "strip-ansi": "^5.2.0",
-    "supports-color": "^6.1.0",
+    "supports-color": "^7.1.0",
     "tar": "^4.4.13",
     "uid-number": "0.0.6",
     "update-notifier": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "async": "^2.6.2",
+    "async": "^3.1.0",
     "bl": "^3.0.0",
     "chalk": "^2.4.2",
     "columnify": "^1.5.4",

--- a/test/test-grab-project.js
+++ b/test/test-grab-project.js
@@ -142,7 +142,7 @@ test('grab-project: fail with bad ref', async (t) => {
   } catch (err) {
     t.match(
       err.message,
-      /^Command failed: git fetch --depth=1 origin bad-git-ref/
+      /^Command failed\b.+\bgit fetch --depth=1 origin bad-git-ref/
     );
   }
 });


### PR DESCRIPTION
* make-promises-safe@5.0.0 updated to 5.1.0
* tar@4.4.8 updated to 4.4.13
* yarn@1.16.0 updated to 1.19.1
* eslint-plugin-prettier@3.1.0 updated to 3.1.1
* xml2js@0.4.19 updated to 0.4.22

* update async@2.6.2 to 3.1.0
    
    This is a breaking change. Code involving the drain property of the
    queue objects had to be modified. See third bullet point under
    https://github.com/caolan/async/blob/master/CHANGELOG.md#breaking-changes

* update bl@3.0.0 to 4.0.0

* update execa@1.0.0 to 3.2.0
    
    This required updating the expected error message in a test, as execa
    now provides more detail than it used to.

* update rimraf@2.6.3 to 3.0.0

* update supports-color@6.1.0 to 7.1.0

*  update tar@4.4.13 to 5.0.3

* update which@1.3.1 to 2.0.1

* update yargs@13.3.0 to 14.2.0

Closes: https://github.com/nodejs/citgm/issues/757

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
