### PR TITLE
fix: support lookup with semver ranges

### DIFF
--- a/lib/grab-module-data.js
+++ b/lib/grab-module-data.js
@@ -41,14 +41,28 @@ function grabModuleData(context) {
         resolve();
         return;
       }
+
+      if (data === '') {
+        reject(
+          new Error(`No module version found satisfying ${context.module.raw}`)
+        );
+        return;
+      }
+
       context.emit(
         'data',
         'silly',
         `${context.module.name} npm-view`,
         'Data retrieved'
       );
+
       try {
         context.meta = JSON.parse(data);
+        if (Array.isArray(context.meta)) {
+          // A semver range was passed and multiple versions matched.
+          // Use the last compatible version.
+          context.meta = context.meta[context.meta.length - 1];
+        }
       } catch (ex) {
         reject(ex);
         return;

--- a/test/test-grab-module-data.js
+++ b/test/test-grab-module-data.js
@@ -83,3 +83,52 @@ test('grab-module-data: hosted', async (t) => {
       ' include a type of git and the supplied url'
   );
 });
+
+test('grab-module-data: inexistant version', async (t) => {
+  t.plan(1);
+  const context = {
+    path: __dirname,
+    module: {
+      raw: 'lodash@0.0.0',
+      type: null,
+      hosted: {
+        type: null
+      }
+    },
+    emit: function() {},
+    options: {}
+  };
+
+  await t.rejects(grabModuleData(context), {
+    message: 'No module version found satisfying lodash@0.0.0'
+  });
+});
+
+test('grab-module-data: semver range', async (t) => {
+  t.plan(3);
+  const context = {
+    path: __dirname,
+    module: {
+      raw: 'omg-i-pass@^2.0.0',
+      type: null,
+      hosted: {
+        type: null
+      }
+    },
+    emit: function() {},
+    options: {}
+  };
+
+  await grabModuleData(context);
+  t.ok(context.meta, 'There should be a context.meta');
+  t.equals(
+    context.meta.name,
+    'omg-i-pass',
+    'The name of the results should be omg-i-pass'
+  );
+  t.equals(
+    context.meta.version,
+    '2.0.1',
+    'The version should be the latest satisfying the semver range'
+  );
+});


### PR DESCRIPTION
Use the latest satisfying version returned by npm.
Throw an error if nothing matches.

Fixes: https://github.com/nodejs/citgm/issues/762
