### PR TITLE
fix: escape carets on Windows cmd arguments

### DIFF
--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -18,7 +18,9 @@ function spawn(cmd, args, options) {
       // The problem is that `mungeCmd()` (
       // https://github.com/tapjs/spawn-wrap/blob/7931ab5c/index.js#L143)
       // incorrectly replaces `spawn()` args.
-      args = ['/C', cmd].concat(args);
+      args = ['/C', cmd].concat(args).map((arg) => {
+        return arg.replace(/\^/g, '^^^^');
+      });
       cmd = 'cmd';
     }
   }

--- a/test/test-grab-project.js
+++ b/test/test-grab-project.js
@@ -153,7 +153,8 @@ test('grab-project: timeout', async (t) => {
     emit: function() {},
     path: sandbox,
     module: {
-      name: 'omg-i-pass'
+      name: 'omg-i-pass',
+      raw: 'omg-i-pass'
     },
     meta: {},
     options: {


### PR DESCRIPTION
/cc @richardlau 