### PR TITLE
feat: allow overriding install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
 "skipAnsi": true             Strip ansi data from output stream of npm
 "sha": "<git-commit-sha>"    Test against a specific commit
 "envVar"                     Pass an environment variable before running
-"install": ["--param1", "--param2"] - Array of extra command line parameters passed to 'npm install'
+"install": ["install", "--param1", "--param2"] - Array of command line parameters passed to 'npm' or 'yarn' as install arguments
 "maintainers": ["user1", "user2"] - List of module maintainers to be contacted with issues
 "scripts": ["script1", "script2"] - List of scripts from package.json to run instead of 'test'
 "tags": ["tag1", "tag2"]     Specify which tags apply to the module

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -452,7 +452,7 @@
     "maintainers": "substack"
   },
   "thread-sleep": {
-    "install": ["--build-from-source"],
+    "install": ["install", "--build-from-source"],
     "tags": "native",
     "maintainers": ["forbeslindesay", "timothygu"]
   },

--- a/lib/package-manager/install.js
+++ b/lib/package-manager/install.js
@@ -32,7 +32,7 @@ function install(packageManager, context) {
     );
 
     if (context.module.install) {
-      args = args.concat(context.module.install);
+      args = context.module.install;
     }
 
     const packageManagerBin =

--- a/test/npm/test-npm-install.js
+++ b/test/npm/test-npm-install.js
@@ -46,12 +46,12 @@ test('npm-install: basic module', async () => {
   await packageManagerInstall('npm', context);
 });
 
-test('npm-install: extra install parameters', async (t) => {
+test('npm-install: custom install command', async (t) => {
   t.plan(1);
   const context = makeContext.npmContext(
     {
       name: 'omg-i-pass-with-install-param',
-      install: ['--extra-param']
+      install: ['install', '--extra-param']
     },
     packageManagers,
     sandbox,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)

For #728 so we can skip the TypeScript compilation. Seems like only a single module used the option anyways, so I just changed its meaning. Not sure if that's considered a breaking change?