### PR TITLE
fix: don't mark module as flaky on time outs

### DIFF
--- a/lib/timeout.js
+++ b/lib/timeout.js
@@ -25,7 +25,6 @@ function timeout(context, proc, next, step) {
 
     clearTimeout(timeout);
     if (timedOut) {
-      context.module.flaky = true;
       context.emit(
         'data',
         'error',

--- a/test/npm/test-npm-install.js
+++ b/test/npm/test-npm-install.js
@@ -95,7 +95,7 @@ test('npm-install: timeout', async (t) => {
   try {
     await packageManagerInstall('npm', context);
   } catch (err) {
-    t.ok(context.module.flaky, 'Module is Flaky because install timed out');
+    t.notOk(context.module.flaky, 'Time out should not mark module flaky');
     t.equals(err && err.message, 'Install Timed Out');
   }
 });

--- a/test/npm/test-npm-test.js
+++ b/test/npm/test-npm-test.js
@@ -132,7 +132,7 @@ test('npm-test: timeout', async (t) => {
   try {
     await packageManagerTest('npm', context);
   } catch (err) {
-    t.ok(context.module.flaky, 'Module is Flaky because tests timed out');
+    t.notOk(context.module.flaky, 'Time out should not mark module flaky');
     t.equals(err && err.message, 'Test Timed Out');
   }
 });

--- a/test/test-timeout.js
+++ b/test/test-timeout.js
@@ -41,7 +41,7 @@ test('timeout:', (t) => {
   };
   const finish = timeout(context, proc, next, 'Tap');
   setTimeout(() => {
-    t.ok(context.module.flaky, 'Module is Flaky because timed out');
+    t.notOk(context.module.flaky, 'Time out should not mark module flaky');
     t.equals(proc.killed, 1);
     t.equals(ret, null);
     t.ok(err instanceof Error, 'err should be an Error');
@@ -88,7 +88,7 @@ test('timeout:', (t) => {
   t.equals(ret, sentinel3);
   setTimeout(() => {
     const r = finish(1, 2);
-    t.ok(!context.module.flaky, 'Module is not Flaky finish called');
+    t.notOk(context.module.flaky, 'Module is not Flaky finish called');
     t.equals(r, undefined);
     t.equals(proc.killed, 0);
     t.equals(err, sentinel2);

--- a/test/yarn/test-yarn-install.js
+++ b/test/yarn/test-yarn-install.js
@@ -71,7 +71,7 @@ test('yarn-install: timeout', async (t) => {
   try {
     await packageManagerInstall('yarn', context);
   } catch (err) {
-    t.ok(context.module.flaky, 'Module is Flaky because install timed out');
+    t.notOk(context.module.flaky, 'Time out should not mark module flaky');
     t.equals(err && err.message, 'Install Timed Out');
   }
 });

--- a/test/yarn/test-yarn-test.js
+++ b/test/yarn/test-yarn-test.js
@@ -127,7 +127,7 @@ test('yarn-test: timeout', async (t) => {
   try {
     await packageManagerTest('yarn', context);
   } catch (err) {
-    t.ok(context.module.flaky, 'Module is Flaky because tests timed out');
+    t.notOk(context.module.flaky, 'Time out should not mark module flaky');
     t.equals(err && err.message, 'Test Timed Out');
   }
 });


### PR DESCRIPTION
Refs: https://github.com/nodejs/citgm/pull/728#issuecomment-548698680

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
