### PR TITLE
Update lookup dec 2019

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -539,6 +539,6 @@
     "prefix": "v",
     "tags": "native",
     "maintainers": ["lgeiger", "rgbkrk"],
-    "skip": ["s390", "ppc", "win32"]
+    "skip": [true, "s390", "ppc", "win32"]
   }
 }

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -309,7 +309,7 @@
     "prefix": "v",
     "tags": "native",
     "maintainers": ["nodejs/node-gyp"],
-    "skip": "win32"
+    "skip": [true, "win32"]
   },
   "node-report": {
     "prefix": "v",

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -92,6 +92,7 @@
   },
   "commander": {
     "prefix": "v",
+    "flaky": true,
     "skip": "win32",
     "maintainers": "tj"
   },


### PR DESCRIPTION
* Skip zeromq
  - cmake not on buildbots
* skip node-gyp
  - new test fails on new releases
* set commander as flaky
  - timeouts on our infra