### PR TITLE
lookup: add `resolve`

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -376,6 +376,10 @@
     "skip": "aix",
     "maintainers": "mikeal"
   },
+  "resolve": {
+    "prefix": "v",
+    "maintainers": "ljharb"
+  },
   "rewire": {
     "prefix": "v",
     "maintainers": "jhnns"


### PR DESCRIPTION
Running `resolve`'s tests will help avoid problems like https://github.com/nodejs/node/pull/30963 from occurring silently.

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)

Hard Requirements

 - [x] Module source code must be on Github.
 - [x] Published versions must include a tag on Github
 - [x] The test process must be executable with only the commands npm install && npm test or (yarn install && yarn test) using the tarball downloaded from the Github tag mentioned above
 - [ ] The tests pass on supported major release lines
 - [x] The maintainers of the module remain responsive when there are problems
 - [x] At least one module maintainer must be added to the lookup maintainers field

Soft Requirements

At least one of:

 - [x] The module must be actively used by the community OR
 - [x] The module must be heavily depended on OR
 - [x] The module must cover unique portions of our API OR
 - [ ] The module fits into a key category (e.g. Testing, Streams, Monitoring, etc.) OR
 - [ ] The module is under the Node.js foundation Github org OR
 - [ ] The module is identified as an important module by a Node.js Working Group

Tests currently fail on v13.4 due to https://github.com/nodejs/node/pull/30963 not being included in it; the next release of resolve will fix that.