### PR TITLE
lookup: unskip node-gyp

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -308,10 +308,11 @@
     "tags": "native"
   },
   "node-gyp": {
+    "envVar": {"FAST_TEST": "true"},
     "prefix": "v",
     "tags": "native",
     "maintainers": ["nodejs/node-gyp"],
-    "skip": [true, "win32"]
+    "skip": ["win32"]
   },
   "node-report": {
     "prefix": "v",


### PR DESCRIPTION
Set the `FAST_TEST` environment variable to skip the headers download
test.

Fixes: https://github.com/nodejs/node-gyp/issues/2000

With `-v silly` I get the following with a fake Node.js v13.6.0 (v13.5.0 with the minor version bumped):
```console
verbose: node-gyp npm-test:  | # Subtest: download headers (actual)
verbose: node-gyp npm-test:  | ok 1 - Skipping acutal download of headers due to test environment configuration # SKIP
verbose: node-gyp npm-test:  | 1..1
verbose: node-gyp npm-test:  | # skip: 1
verbose: node-gyp npm-test:  | ok 5 - download headers (actual) # time=2.199ms
```

cc @MylesBorins 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
