### PR TITLE
lookup: skip clinic on AIX and Windows

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -85,7 +85,8 @@
   "clinic": {
     "maintainers": "mcollina",
     "flaky": ["rhel"],
-    "prefix": "v"
+    "prefix": "v",
+    "skip": ["aix", "win32"]
   },
   "coffeescript": {
     "maintainers": ["jashkenas", "GeoffreyBooth"],


### PR DESCRIPTION
See #779

Using this PR to kick off a test run to see if CITGM on AIX gets further when this module is skipped.