### PR TITLE
Re-enable AVA

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -30,7 +30,7 @@
   },
   "ava": {
     "prefix": "v",
-    "skip": [true, "ppc", "win32", "x86", "rhel", "aix", "ia32", "10"],
+    "skip": ["ppc", "x86", "rhel", "aix", "ia32"],
     "maintainers": ["sindresorhus", "novemberborn"]
   },
   "bcrypt": {


### PR DESCRIPTION
AVA@3 tests should no longer be flaky. We've also removed some tight coupling with Node.js versions, so overall it should be more reliable.

I'm not sure what all the skipped values are, but I'm intending to re-enable tests in Node.js 10 and above, as well as 64-bit Windows.
