### PR TITLE
lookup: remove 'request'

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -371,12 +371,6 @@
     "maintainers": "TooTallNate",
     "skip": [true, "12", "win32"]
   },
-  "request": {
-    "prefix": "v",
-    "flaky": true,
-    "skip": "aix",
-    "maintainers": "mikeal"
-  },
   "resolve": {
     "prefix": "v",
     "maintainers": "ljharb"


### PR DESCRIPTION
`request` has been deprecated (https://github.com/request/request/issues/3142). npm has started raising warnings that it is deprecated and the maintainer is suggesting to use other libraries as a drop in.

Discussed with @BethGriggs, and thought it may be worth it to discuss removing it from citgm since the tests are also marked as flaky. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
