### PR TITLE
lookup: remove "flaky" and add "skip" to flaky modules

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -25,8 +25,8 @@
   },
   "async": {
     "prefix": "v",
-    "flaky": true,
-    "maintainers": ["aearly", "megawac"]
+    "maintainers": ["aearly", "megawac"],
+    "skip": true
   },
   "ava": {
     "prefix": "v",
@@ -93,9 +93,8 @@
   },
   "commander": {
     "prefix": "v",
-    "flaky": true,
-    "skip": "win32",
-    "maintainers": "tj"
+    "maintainers": "tj",
+    "skip": true
   },
   "crc32-stream": {
     "maintainers": "ctalkington",
@@ -321,10 +320,10 @@
   },
   "node-sass": {
     "prefix": "v",
-    "flaky": true,
     "tags": "native",
     "maintainers": "xzyfer",
-    "comment": "Flaky because of test timeouts"
+    "comment": "Flaky because of test timeouts",
+    "skip": true
   },
   "path-to-regexp": {
     "prefix": "v",
@@ -373,9 +372,8 @@
   },
   "request": {
     "prefix": "v",
-    "flaky": true,
-    "skip": "aix",
-    "maintainers": "mikeal"
+    "maintainers": "mikeal",
+    "skip": true
   },
   "resolve": {
     "prefix": "v",
@@ -507,9 +505,9 @@
   },
   "vinyl-fs": {
     "prefix": "v",
-    "flaky": true,
     "master": true,
-    "maintainers": ["contra", "phated"]
+    "maintainers": ["contra", "phated"],
+    "skip": true
   },
   "watchify": {
     "prefix": "v",


### PR DESCRIPTION
To make citgm testing faster, mark the flaky tests as 'skip' until the flaky tests can be fixed. Marking them as 'skip' (instead of removing) will keep the modules around to be eventually added back to the test suite.

#### Modules changed: 
- async
- commander
- node-sass
- request
- vinyl-fs

Discussed with @BethGriggs and @MylesBorins, and we decided this would be a good first step towards remediating some of the flaky test suites.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] documentation is changed or added
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
