### PR TITLE
build: remove travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-os:
-  - linux
-  - osx
-  - windows
-node_js:
-  - '12'
-script: 'export PATH=/c/program\ files/git/mingw64/libexec/git-core:$PATH && echo $PATH && npm run test-ci'
-after_script: 'bash <(curl -s https://codecov.io/bash)'

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 citgm is a simple tool for pulling down an arbitrary module from npm and testing
 it using a specific version of the node runtime.
 
+[![Build Status](https://github.com/nodejs/citgm/workflows/Node.js%20CI/badge.svg?branch=master)](https://github.com/nodejs/citgm/actions?query=workflow%3A%22Node.js+CI%22)
 [![dependencies Status](https://david-dm.org/nodejs/citgm/status.svg)](https://david-dm.org/nodejs/citgm)
 [![devDependencies Status](https://david-dm.org/nodejs/citgm/dev-status.svg)](https://david-dm.org/nodejs/citgm?type=dev)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 citgm is a simple tool for pulling down an arbitrary module from npm and testing
 it using a specific version of the node runtime.
 
-[![Build Status](https://travis-ci.com/nodejs/citgm.svg?branch=master)](https://travis-ci.com/nodejs/citgm)
 [![dependencies Status](https://david-dm.org/nodejs/citgm/status.svg)](https://david-dm.org/nodejs/citgm)
 [![devDependencies Status](https://david-dm.org/nodejs/citgm/dev-status.svg)](https://david-dm.org/nodejs/citgm?type=dev)
 


### PR DESCRIPTION
We currently have a full test matrix via github actions which tends to
be more reliable / stable than the travis CI build. Is there a reason
we are keeping support for travis at this point?
