### PR TITLE
lookup: mark got as skip on all versions

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -201,7 +201,7 @@
   "got": {
     "maintainers": ["sindresorhus"],
     "prefix": "v",
-    "skip": [">=11"]
+    "skip": true
   },
   "graceful-fs": {
     "prefix": "v",


### PR DESCRIPTION
Got seems to be failing on all Node.js versions across all platforms with:

<details>

got@10.6.0 test /Users/bethgriggs/got
xo && tsc --noEmit && nyc ava

`parseForESLint` from parser `@typescript-eslint/parser` is invalid and will just be ignored

  source/normalize-arguments.ts:46:1
  ⚠   46:1   Unexpected todo comment.                                                                                    no-warning-comments
  ⚠   47:38  Arrow function has a complexity of 49. Maximum allowed is 20.                                               complexity
  ⚠  320:2   Unexpected todo comment.                                                                                    no-warning-comments
  ⚠  375:42  Async arrow function has a complexity of 57. Maximum allowed is 20.                                         complexity
  ⚠  383:3   Unexpected todo comment.                                                                                    no-warning-comments

  source/request-as-event-emitter.ts:59:26
  ⚠   59:26  Async arrow function has a complexity of 23. Maximum allowed is 20.                                         complexity

  source/types.ts:63:1
  ⚠   63:1   Unexpected todo comment.                                                                                    no-warning-comments

  source/utils/options-to-url.ts:41:16
  ⚠   41:16  Arrow function has a complexity of 21. Maximum allowed is 20.                                               complexity

  source/utils/url-to-options.ts:4:1
  ⚠    4:1   Unexpected todo comment.                                                                                    no-warning-comments

  test/timeout.ts:13:33
  ⚠  430:1   Unexpected todo comment.                                                                                    no-warning-comments
  ⚠  588:1   Unexpected todo comment.                                                                                    no-warning-comments
  ⚠  602:1   Unexpected todo comment.                                                                                    no-warning-comments
  ✖   13:33  Parse errors in imported module ../source: Cannot read property name of undefined (undefined:undefined)     import/namespace
  ✖   13:33  Parse errors in imported module ../source: Cannot read property name of undefined (undefined:undefined)     import/default
  ✖   13:33  Parse errors in imported module ../source: Cannot read property name of undefined (undefined:undefined)     import/no-named-as-default-member
  ✖   13:33  Parse errors in imported module ../source: Cannot read property name of undefined (undefined:undefined)     import/no-named-as-default
  ...
  test/helpers/types.ts:4:19
  ✖    4:19  Parse errors in imported module ../../source: Cannot read property name of undefined (undefined:undefined)  import/namespace

  14 warnings
  83 errors
npm ERR! Test failed.  See above for more details.