### PR TITLE
remove darwin as flaky from module readable-stream

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -361,7 +361,7 @@
   },
   "readable-stream": {
     "prefix": "v",
-    "flaky": ["ppc", "darwin"],
+    "flaky": ["ppc"],
     "maintainers": "nodejs/streams",
     "skip": [">=12", "win32"]
   },


### PR DESCRIPTION
removes darwin from flaky platform of readable-stream (https://github.com/nodejs/citgm/issues/787)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
