### PR TITLE
Re-enable AVA

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -30,7 +30,7 @@
   },
   "ava": {
     "prefix": "v",
-    "skip": ["ppc", "x86", "rhel", "aix", "ia32"],
+    "skip": ["ppc", "win32", "x86", "rhel", "aix", "ia32", "10"],
     "maintainers": ["sindresorhus", "novemberborn"]
   },
   "bcrypt": {

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -30,7 +30,7 @@
   },
   "ava": {
     "prefix": "v",
-    "skip": ["ppc", "win32", "x86", "rhel", "aix", "ia32", "10"],
+    "skip": ["ppc", "win32", "x86", "rhel", "aix", "ia32"],
     "maintainers": ["sindresorhus", "novemberborn"]
   },
   "bcrypt": {

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -30,7 +30,7 @@
   },
   "ava": {
     "prefix": "v",
-    "skip": [true, "ppc", "win32", "x86", "rhel", "aix", "ia32", "10"],
+    "skip": ["ppc", "x86", "rhel", "aix", "ia32"],
     "maintainers": ["sindresorhus", "novemberborn"]
   },
   "bcrypt": {


### PR DESCRIPTION
Follow-up to https://github.com/nodejs/citgm/pull/781#issuecomment-597471298 — AVA 3.5.1 addresses the test failures.