### PR TITLE
lookup: skip bson on all platforms

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -70,7 +70,7 @@
     "prefix": "V",
     "maintainers": "christkv",
     "scripts": ["test-node"],
-    "skip": "win32"
+    "skip": true
   },
   "bufferutil": {
     "prefix": "v",


### PR DESCRIPTION
`bson` currently failing on all platforms

failing since v1.1.4 was published 6 hours a go.