### PR TITLE
ci: update GitHub actions workflow

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 13
+      - name: Use Node.js 14
         uses: actions/setup-node@v1
         with:
-          node-version: 13
+          node-version: 14.x
       - name: npm install and lint
         run: |
           npm install
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10.x, 12.x, 13.x]
+        node-version: [10.x, 12.x, 13.x, 14.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -40,7 +40,5 @@ jobs:
         run: |
           npm install
           npm run tap -- --coverage-report=lcov
-        env:
-          CI: true
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v1

--- a/test/fixtures/omg-i-write-to-tmpdir/test.js
+++ b/test/fixtures/omg-i-write-to-tmpdir/test.js
@@ -4,4 +4,4 @@ const { join } = require('path');
 const { tmpdir } = require('os');
 const { writeFileSync } = require('fs');
 
-writeFileSync(join(tmpdir(), 'omg-i-write-to-tmpdir-testfile'));
+writeFileSync(join(tmpdir(), 'omg-i-write-to-tmpdir-testfile'), '');


### PR DESCRIPTION
- Remove actions/setup-node from lint job

There's already a version of Node.js installed on the action runners so
we do not need to explicitly install another one.

- Add Node.js 14.x to the test matrix

- Remove CI: true from the environment

The variable is already set by GitHub

