### PR TITLE
Added pino

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -330,6 +330,10 @@
     "prefix": "v",
     "maintainers": "blakeembrey"
   },
+  "pino": {
+    "prefix": "v",
+    "maintainers": "mcollina"
+  },
   "pug": {
     "prefix": "pug@",
     "yarn": true,


### PR DESCRIPTION
Adds the pino logger. It currently has 2 mln downloads/month, and it's probably worthwhile to check it before release of Node.

Note that it currently does not pass on Windows with v14, likely due to https://github.com/nodejs/node/issues/33166 or some other regression. See https://github.com/pinojs/pino/pull/839 for some details.

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
