### PR TITLE
lookup: avoid browser testing for through2

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -466,6 +466,7 @@
     "maintainers": "rvagg",
     "prefix": "v",
     "scripts": ["test:node"],
+    "skip": ["aix", "win32"],
     "stripAnsi": true
   },
   "throughv": {

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -463,9 +463,10 @@
     "maintainers": ["forbeslindesay", "timothygu"]
   },
   "through2": {
+    "maintainers": "rvagg",
     "prefix": "v",
-    "stripAnsi": true,
-    "maintainers": "rvagg"
+    "scripts": ["test:node"],
+    "stripAnsi": true
   },
   "throughv": {
     "prefix": "v",


### PR DESCRIPTION
Use a different npm script to avoid browser tests for through2 and sort
the keys for the through2 entry in lookup.json.

Fixes: https://github.com/nodejs/citgm/issues/809

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
