### PR TITLE
lib: allow modules without a script called `test`

### DIFF
--- a/lib/package-manager/test.js
+++ b/lib/package-manager/test.js
@@ -36,7 +36,10 @@ async function test(packageManager, context) {
   } catch (err) {
     throw new Error('Package.json Could not be found');
   }
-  if (data.scripts === undefined || data.scripts.test === undefined) {
+  if (
+    data.scripts === undefined ||
+    (data.scripts.test === undefined && context.module.scripts === undefined)
+  ) {
     if (data.author) {
       context.emit(
         'data',

--- a/test/fixtures/omg-i-have-no-test-script/package.json
+++ b/test/fixtures/omg-i-have-no-test-script/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "omg-i-have-no-test-script",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "test:browser": "exit 1",
+    "test:node": "exit 0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nodejs/citgm"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/test/npm/test-npm-test.js
+++ b/test/npm/test-npm-test.js
@@ -25,6 +25,9 @@ const failTemp = path.join(sandbox, 'omg-i-fail');
 const badFixtures = path.join(fixtures, 'omg-i-do-not-support-testing');
 const badTemp = path.join(sandbox, 'omg-i-do-not-support-testing');
 
+const noTestScriptFixtures = path.join(fixtures, 'omg-i-have-no-test-script');
+const noTestScriptTemp = path.join(sandbox, 'omg-i-have-no-test-script');
+
 const scriptsFixtures = path.join(fixtures, 'omg-i-pass-with-scripts');
 const scriptsTemp = path.join(sandbox, 'omg-i-pass-with-scripts');
 
@@ -40,6 +43,7 @@ test('npm-test: setup', async () => {
     copy(passFixtures, passTemp),
     copy(failFixtures, failTemp),
     copy(badFixtures, badTemp),
+    copy(noTestScriptFixtures, noTestScriptTemp),
     copy(scriptsFixtures, scriptsTemp),
     copy(writeTmpdirFixtures, writeTmpdirTemp)
   ]);
@@ -142,6 +146,40 @@ test('npm-test: module with scripts passing', async () => {
     {
       name: 'omg-i-pass-with-scripts',
       scripts: ['test-build', 'test']
+    },
+    packageManagers,
+    sandbox,
+    {
+      npmLevel: 'silly'
+    }
+  );
+  await packageManagerTest('npm', context);
+});
+
+test('npm-test: module with no test script failing', async (t) => {
+  t.plan(1);
+  const context = makeContext.npmContext(
+    {
+      name: 'omg-i-have-no-test-script'
+    },
+    packageManagers,
+    sandbox,
+    {
+      npmLevel: 'silly'
+    }
+  );
+  try {
+    await packageManagerTest('npm', context);
+  } catch (err) {
+    t.equals(err && err.message, 'Module does not support npm-test!');
+  }
+});
+
+test('npm-test: module with no test script passing', async () => {
+  const context = makeContext.npmContext(
+    {
+      name: 'omg-i-have-no-test-script',
+      scripts: ['test:node']
     },
     packageManagers,
     sandbox,

--- a/test/yarn/test-yarn-test.js
+++ b/test/yarn/test-yarn-test.js
@@ -25,6 +25,9 @@ const failTemp = path.join(sandbox, 'omg-i-fail');
 const badFixtures = path.join(fixtures, 'omg-i-do-not-support-testing');
 const badTemp = path.join(sandbox, 'omg-i-do-not-support-testing');
 
+const noTestScriptFixtures = path.join(fixtures, 'omg-i-have-no-test-script');
+const noTestScriptTemp = path.join(sandbox, 'omg-i-have-no-test-script');
+
 const scriptsFixtures = path.join(fixtures, 'omg-i-pass-with-scripts');
 const scriptsTemp = path.join(sandbox, 'omg-i-pass-with-scripts');
 
@@ -40,6 +43,7 @@ test('yarn-test: setup', async () => {
     copy(passFixtures, passTemp),
     copy(failFixtures, failTemp),
     copy(badFixtures, badTemp),
+    copy(noTestScriptFixtures, noTestScriptTemp),
     copy(scriptsFixtures, scriptsTemp),
     copy(writeTmpdirFixtures, writeTmpdirTemp)
   ]);
@@ -145,6 +149,40 @@ test('yarn-test: module with scripts passing', async () => {
     }
   );
 
+  await packageManagerTest('yarn', context);
+});
+
+test('yarn-test: module with no test script failing', async (t) => {
+  t.plan(1);
+  const context = makeContext.npmContext(
+    {
+      name: 'omg-i-have-no-test-script'
+    },
+    packageManagers,
+    sandbox,
+    {
+      npmLevel: 'silly'
+    }
+  );
+  try {
+    await packageManagerTest('yarn', context);
+  } catch (err) {
+    t.equals(err && err.message, 'Module does not support yarn-test!');
+  }
+});
+
+test('yarn-test: module with no test script passing', async () => {
+  const context = makeContext.npmContext(
+    {
+      name: 'omg-i-have-no-test-script',
+      scripts: ['test:node']
+    },
+    packageManagers,
+    sandbox,
+    {
+      npmLevel: 'silly'
+    }
+  );
   await packageManagerTest('yarn', context);
 });
 


### PR DESCRIPTION
Some modules do not call their test script `test`. For example, a
module using [Yarn workspaces](https://yarnpkg.com/advanced/qa#how-to-share-scripts-between-workspaces) may define `workspace:test` as their
testing script. We can specify the script to run in our `lookup.json`
but there was a place in our code that was specifically looking for
a script called `test`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
