### PR TITLE
lookup: skip gulp on darwin

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -211,7 +211,7 @@
   "gulp": {
     "prefix": "v",
     "flaky": ["ppc", "rhel"],
-    "skip": "win32",
+    "skip": ["win32", "darwin"],
     "maintainers": "contra"
   },
   "gulp-util": {


### PR DESCRIPTION
Currently tracking down failures on v14.x and uncovered that `gulp`
is relying on an out of date / unsupported version of `chokidar`
which is itself relying on an out of date version of `fsevents`.

The file watching dependency `glob-watcher` is currently broken
on both 12.x and 14.x due to this. While the tests may pass on
some platforms I think it may be prudent to skip gulp altogether
on darwin platforms until they have fixed their dependency issues.