### PR TITLE
Revert "lookup: skip shot on v14.x"

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -414,7 +414,6 @@
     "skip": ["win32"]
   },
   "shot": {
-    "skip": ["14"],
     "prefix": "v",
     "maintainers": "mtharrison"
   },


### PR DESCRIPTION
This reverts commit 24acf67c2b6ed3dce7157215998ce576a2c82650.

Shot will now pass on 14.x

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
