### PR TITLE
lookup: skip watchify on darwin

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -516,7 +516,7 @@
     "prefix": "v",
     "flaky": ["ppc", "s390", "ubuntu", "rhel"],
     "maintainers": "substack",
-    "skip": "win32"
+    "skip": ["win32", "darwin"]
   },
   "weak": {
     "tags": "native",


### PR DESCRIPTION
Watchify relies on an old version of chokidar which has an old version
of fsevents, which doesn't support Node.js 12.x+

Skipping on MacOS until this is fixed upstream
