### PR TITLE
npm-install: use --no-audit and --no-fund by default

### DIFF
--- a/lib/package-manager/install.js
+++ b/lib/package-manager/install.js
@@ -31,6 +31,11 @@ function install(packageManager, context) {
       `Using temp directory: "${options.env['npm_config_tmp']}"`
     );
 
+    if (packageManager === 'npm') {
+      args.push('--no-audit');
+      args.push('--no-fund');
+    }
+
     if (context.module.install) {
       args = context.module.install;
     }


### PR DESCRIPTION
This can speed up install time by a non-trivial amount.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/master/CONTRIBUTING.md)
