### PR TITLE
lookup: skip split2

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -441,7 +441,7 @@
   "split2": {
     "prefix": "v",
     "maintainers": "mcollina",
-    "skip": true
+    "master": true
   },
   "sqlite3": {
     "prefix": "v",


### PR DESCRIPTION
The current published version has a gitHead in the packument
that is not available on github

Refs: https://github.com/mcollina/split2/issues/40
