### PR TITLE
lookup: specify scripts for debug

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -113,7 +113,8 @@
   },
   "debug": {
     "maintainers": ["qix", "tootallnate"],
-    "skip": ["aix", "ppc", "s390", "win32"]
+    "skip": ["aix", "ppc", "s390", "win32"],
+    "scripts": ["test:node", "lint"]
   },
   "dicer": {
     "prefix": "v",


### PR DESCRIPTION
debug just made it's first release in 2 years and now uses headless
chrome for testing. We can no longer use the default test script due
to this. Manually run a subset of the tests that we can support.
