### PR TITLE
lookup: skip shot

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -415,7 +415,8 @@
   },
   "shot": {
     "prefix": "v",
-    "maintainers": "mtharrison"
+    "maintainers": "mtharrison",
+    "skip": true
   },
   "socket.io": {
     "maintainers": "rauchg"


### PR DESCRIPTION
The module was fixed upstream but continues to fail in our CI.
The issue previously was lab failing on new JS globals, assuming
they were leaks. New versions have been published, and it shouldn't
be failing anymore, but perhaps due to an npm cache, it is still happening.

/cc @nodejs/build maybe you can help clean up the machines.

Until this module can pass we should skip it.

/cc @cjihrig 