### PR TITLE
lib: handle temporary directory removal errors

### DIFF
--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -126,7 +126,11 @@ class Tester extends EventEmitter {
       if (this.testError !== '') {
         payload.testOutput += `${this.testError.toString()}\n`;
       }
-      await tempDirectory.remove(this);
+      try {
+        await tempDirectory.remove(this);
+      } catch (err) {
+        this.emit('data', 'error', `${this.module.name} cleanup`, err);
+      }
       this.emit('end', payload);
       this.cleanexit = true;
     }

--- a/test/fixtures/omg-i-timeout/package.json
+++ b/test/fixtures/omg-i-timeout/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "omg-i-timeout",
+  "version": "1.0.0",
+  "description": "Test suite times out while writing to tmpdir",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nodejs/citgm.git"
+  },
+  "main": "index.js",
+  "scripts": {
+    "test": "node test.js",
+    "install": "exit 0"
+  },
+  "keywords": [
+    "always",
+    "passes"
+  ],
+  "license": "MIT"
+}

--- a/test/fixtures/omg-i-timeout/test.js
+++ b/test/fixtures/omg-i-timeout/test.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const { join } = require('path');
+const { spawn } = require('child_process');
+const { tmpdir } = require('os');
+const { closeSync, open, write } = require('fs');
+
+if (process.argv[2] === 'child') {
+  const file = join(tmpdir(), 'omg-i-timeout-tmpfile');
+  open(file, 'w', (err, fd) => {
+    if (!err) {
+      write(fd, 'first write', (err) => {
+        if (!err) {
+          setTimeout(() => {
+            write(fd, 'second write', () => {
+              closeSync(fd);
+            });
+          }, 60 * 1000);
+        }
+      });
+    }
+  });
+  return;
+}
+
+const p = spawn(process.execPath, [__filename, 'child']);
+p.on('end', () => {
+  console.log('end');
+});

--- a/test/test-citgm-timeout.js
+++ b/test/test-citgm-timeout.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const { test } = require('tap');
+const rewire = require('rewire');
+const citgm = rewire('../lib/citgm');
+const { create } = require('../lib/temp-directory');
+let expectedError;
+citgm.__set__('tempDirectory', {
+  create,
+  remove: (context) => {
+    // Simulate an error when removing the temporary directory.
+    const err = new Error(
+      `EBUSY: resource busy or locked, rmdir '${context.path}'`
+    );
+    err.errno = -4082;
+    err.code = 'EBUSY';
+    err.syscall = 'rmdir';
+    err.path = context.path;
+    expectedError = err;
+    throw err;
+  }
+});
+
+test('citgm: omg-i-timeout from local path', (t) => {
+  t.plan(4);
+
+  const options = {
+    hmac: null,
+    lookup: null,
+    nodedir: null,
+    level: null,
+    timeout: 30000
+  };
+
+  const mod = './test/fixtures/omg-i-timeout';
+
+  const tester = new citgm.Tester(mod, options);
+  tester
+    .on('start', (name) => {
+      t.equals(name, mod, 'it should be the local path');
+    })
+    .on('data', (type, key, msg) => {
+      if (type === 'error' && key.endsWith('cleanup')) {
+        t.match(msg, expectedError, 'it should log cleanup error');
+      }
+    })
+    .on('fail', (err) => {
+      t.match(
+        err,
+        { name: 'Error', message: 'Test Timed Out' },
+        'it should time out'
+      );
+    })
+    .on('end', () => {
+      t.notOk(tester.cleanexit, 'it should not cleanly exit');
+      t.end();
+    })
+    .run();
+});


### PR DESCRIPTION
Previously any errors occurring when removing the temporary directory
during cleanup after a test were not caught and resulted in the `end`
event not being emitted. For `citgm-all` this prevented moving onto
the next module to test.

Refs: https://github.com/nodejs/citgm/issues/802

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
