### PR TITLE
fix: don't set YARN_IGNORE_ENGINES env variable

### DIFF
--- a/lib/create-options.js
+++ b/lib/create-options.js
@@ -19,10 +19,6 @@ function createOptions(cwd, context) {
   options.env['TEMP'] = context.npmConfigTmp;
   options.env['TMP'] = context.npmConfigTmp;
   options.env['TMPDIR'] = context.npmConfigTmp;
-  // Explicitly tell yarn to ignore the "engines" field in `package.json`.
-  // If dependencies of tested modules have set it and CITGM is testing an
-  // unreleased version of Node.js, this prevents `yarn install` from failing.
-  options.env['YARN_IGNORE_ENGINES'] = 'true';
 
   if (context.options.nodedir) {
     const nodedir = path.resolve(process.cwd(), context.options.nodedir);

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -341,6 +341,7 @@
     "maintainers": "mcollina"
   },
   "pug": {
+    "envVar": { "YARN_IGNORE_ENGINES": true },
     "prefix": "pug@",
     "yarn": true,
     "maintainers": ["tj", "ForbesLindesay"],

--- a/test/test-create-options.js
+++ b/test/test-create-options.js
@@ -35,7 +35,6 @@ test('create-options:', (t) => {
   env['TEMP'] = 'npm_config_tmp';
   env['TMP'] = 'npm_config_tmp';
   env['TMPDIR'] = 'npm_config_tmp';
-  env['YARN_IGNORE_ENGINES'] = 'true';
   // Set dynamically to support Windows.
   env['npm_config_nodedir'] = path.resolve(process.cwd(), nodePath);
 


### PR DESCRIPTION
This partially reverts c3917aaf7983f730ada846e4a83d69558b3eb1a7.
yarn v2 does not support the YARN_IGNORE_ENGINES option.

Fixes: https://github.com/nodejs/citgm/issues/824

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
