### PR TITLE
fix: don't ignore engines with yarn v2+

### DIFF
--- a/lib/create-options.js
+++ b/lib/create-options.js
@@ -19,10 +19,6 @@ function createOptions(cwd, context) {
   options.env['TEMP'] = context.npmConfigTmp;
   options.env['TMP'] = context.npmConfigTmp;
   options.env['TMPDIR'] = context.npmConfigTmp;
-  // Explicitly tell yarn to ignore the "engines" field in `package.json`.
-  // If dependencies of tested modules have set it and CITGM is testing an
-  // unreleased version of Node.js, this prevents `yarn install` from failing.
-  options.env['YARN_IGNORE_ENGINES'] = 'true';
 
   if (context.options.nodedir) {
     const nodedir = path.resolve(process.cwd(), context.options.nodedir);

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -133,6 +133,7 @@
     "maintainers": "mafintosh"
   },
   "ember-cli": {
+    "envVar": { "YARN_IGNORE_ENGINES": "true" },
     "prefix": "v",
     "flaky": ["win32", "rhel", "sles"],
     "master": true,

--- a/lib/package-manager/install.js
+++ b/lib/package-manager/install.js
@@ -2,13 +2,47 @@
 
 const path = require('path');
 
+const semverLt = require('semver/functions/lt');
 const stripAnsi = require('strip-ansi');
 
 const createOptions = require('../create-options');
 const spawn = require('../spawn');
+const { spawnSync } = require('child_process');
 const timeout = require('../timeout');
 
 const envSeparator = process.platform === 'win32' ? ';' : ':';
+
+function getVersion(packageManager, context) {
+  const options = createOptions(
+    path.join(context.path, context.module.name),
+    context
+  );
+  const packageManagerBin =
+    packageManager === 'npm' ? context.npmPath : context.yarnPath;
+
+  const binDirectory = path.dirname(packageManagerBin);
+  options.env.PATH = `${binDirectory}${envSeparator}${process.env.PATH}`;
+  options.encoding = 'utf8';
+
+  const proc = spawnSync(packageManagerBin, ['--version'], options);
+  if (proc.status !== 0) {
+    context.emit(
+      'data',
+      'warn',
+      `${context.module.name} ${packageManager}:`,
+      `Unable to determine ${packageManager} version:\n${proc.stdout}` +
+        `\n${proc.stderr}`
+    );
+    return undefined;
+  }
+  context.emit(
+    'data',
+    'verbose',
+    `${context.module.name} ${packageManager}:`,
+    `${packageManager} version ${proc.stdout}`
+  );
+  return proc.stdout;
+}
 
 function install(packageManager, context) {
   return new Promise((resolve, reject) => {
@@ -34,6 +68,14 @@ function install(packageManager, context) {
     if (packageManager === 'npm') {
       args.push('--no-audit');
       args.push('--no-fund');
+    } else if (packageManager === 'yarn') {
+      // Tell yarn versions earlier than v2 to ignore the "engines" field in
+      // `package.json` (if present) to allow installation with unreleased
+      // versions of Node.js.
+      const version = getVersion(packageManager, context);
+      if (version && semverLt(version, '2.0.0', { includePrerelease: true })) {
+        options.env['YARN_IGNORE_ENGINES'] = 'true';
+      }
     }
 
     if (context.module.install) {

--- a/test/test-create-options.js
+++ b/test/test-create-options.js
@@ -35,7 +35,6 @@ test('create-options:', (t) => {
   env['TEMP'] = 'npm_config_tmp';
   env['TMP'] = 'npm_config_tmp';
   env['TMPDIR'] = 'npm_config_tmp';
-  env['YARN_IGNORE_ENGINES'] = 'true';
   // Set dynamically to support Windows.
   env['npm_config_nodedir'] = path.resolve(process.cwd(), nodePath);
 


### PR DESCRIPTION
yarn v2 doesn't support the `YARN_IGNORE_ENGINES` environment variable.
We still need to set `YARN_IGNORE_ENGINES` for older versions of yarn
to allow installation with unreleased versions of Node.js. Projects are
able to use yarn policies to set the version of yarn they are using,
so we need to version sniff to determine whether or not to set the
environment variable.

Fixes: https://github.com/nodejs/citgm/issues/824

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
