### PR TITLE
lookup: add `is-core-module`

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -383,7 +383,8 @@
   },
   "resolve": {
     "prefix": "v",
-    "maintainers": "ljharb"
+    "maintainers": "ljharb",
+    "scripts": ["tests-only", "posttest"]
   },
   "rewire": {
     "prefix": "v",

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -235,6 +235,11 @@
     "prefix": "v",
     "maintainers": "isaacs"
   },
+  "is-core-module": {
+    "prefix": "v",
+    "maintainers": "ljharb",
+    "scripts": ["tests-only"]
+  },
   "isarray": {
     "prefix": "v",
     "maintainers": "juliangruber"


### PR DESCRIPTION
`is-core-module` is the extracted "is core module" logic used by `resolve`

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
