### PR TITLE
lookup: skip eslint-plugin-jest on big endian platforms

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -151,7 +151,7 @@
     "prefix": "v",
     "maintainers": "SimenB",
     "yarn": true,
-    "skip": ["aix"]
+    "skip": ["aix", "s390x"]
   },
   "esprima": {
     "maintainers": "ariya",


### PR DESCRIPTION
eslint-plugin-jest uses yarn policies which uses emscripten which
only supports little endian architectures.

Refs: https://github.com/nodejs/citgm/issues/824#issuecomment-699470974

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
