### PR TITLE
lookup: use yarn for radium

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -366,6 +366,7 @@
   "radium": {
     "prefix": "v",
     "expectFail": "fips",
+    "yarn": true,
     "maintainers": ["ianobermiller", "alexlande"],
     "scripts": ["test-node"]
   },

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -367,6 +367,7 @@
     "prefix": "v",
     "expectFail": "fips",
     "yarn": true,
+    "skip": ["aix", "ppc"],
     "maintainers": ["ianobermiller", "alexlande"],
     "scripts": ["test-node"]
   },


### PR DESCRIPTION
radium ships with a yarn.lock file and they use yarn to install
and run their test suite in CI. Seems appropriate to use yarn
for this project in CITGM.