### PR TITLE
lookup: use master for socket.io

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -428,7 +428,8 @@
     "skip": ["win32"]
   },
   "socket.io": {
-    "maintainers": "rauchg"
+    "maintainers": "rauchg",
+    "master": true
   },
   "spawn-wrap": {
     "prefix": "v",


### PR DESCRIPTION
The 3.0.1 release has a broken test suite.

Refs: https://github.com/socketio/socket.io/commit/e69d0ad6020828e9811f8a71b614e97f12131603