### PR TITLE
lookup: use master for cheerio

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -84,6 +84,7 @@
   },
   "cheerio": {
     "skip": "win32",
+    "master": true,
     "maintainers": ["matthewmueller", "jugglinmike"]
   },
   "clinic": {


### PR DESCRIPTION
The latest release depends on a broken version of the workerpool module
for its test runner.
