### PR TITLE
ci: add a GitHub workflow to test a module with CITGM

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,8 +28,6 @@ jobs:
         run: npm run lint
 
   test:
-    name: Test on Node.js ${{ matrix.node-version }} and ${{ matrix.os }}
-
     strategy:
       fail-fast: false
       matrix:
@@ -41,6 +39,7 @@ jobs:
           - 10.x
           - 12.x
           - 14.x
+          - 15.x
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   show-parameters:
-    name: Testing ${{ github.event.inputs.module }}
+    name: Parameters for testing "${{ github.event.inputs.module }}"
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -28,8 +28,6 @@ jobs:
         run: echo "$WORKFLOW_PARAMETERS"
 
   test-module:
-    name: Test on Node.js ${{ matrix.node-version }} and ${{ matrix.os }}
-
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -19,6 +19,8 @@ jobs:
   show-parameters:
     name: Testing ${{ github.event.inputs.module }}
 
+    runs-on: ubuntu-latest
+
     steps:
       - name: Log workflow parameters
         env:

--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -1,0 +1,53 @@
+name: Test a module with CITGM
+
+on:
+  workflow_dispatch:
+    inputs:
+      module:
+        description: 'Module to test'
+        required: true
+      repository:
+        description: 'CITGM repository to checkout'
+        required: true
+        default: nodejs/citgm
+      ref:
+        description: 'CITGM GitHub ref to checkout'
+        required: true
+        default: main
+
+jobs:
+  test-module:
+    name: Test on Node.js ${{ matrix.node-version }} and ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+        node-version:
+          - 10.x
+          - 12.x
+          - 14.x
+          - 15.x
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.event.inputs.repository }}
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install packages
+        run: npm install
+
+      - name: Run CITGM
+        run: node bin/citgm.js ${{ github.event.inputs.module }}

--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -16,6 +16,15 @@ on:
         default: main
 
 jobs:
+  show-parameters:
+    name: Testing ${{ github.event.inputs.module }}
+
+    steps:
+      - name: Log workflow parameters
+        env:
+          WORKFLOW_PARAMETERS: ${{ toJSON(github.event.inputs) }}
+        run: echo "$WORKFLOW_PARAMETERS"
+
   test-module:
     name: Test on Node.js ${{ matrix.node-version }} and ${{ matrix.os }}
 


### PR DESCRIPTION
Form:

![image](https://user-images.githubusercontent.com/2352663/110097266-1de8cc00-7d9f-11eb-9544-c2d08976ed1e.png)

Example run on my fork with `lodash` module: https://github.com/targos/citgm/actions/runs/623994089

Another example with:
- module: https-proxy-agent
- repository: lpinca/citgm
- ref: add/https-proxy-agent
https://github.com/targos/citgm/actions/runs/624006145