### PR TITLE
lookup: skip yeoman-generator on v10.x

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -574,7 +574,8 @@
     "prefix": "v",
     "flaky": ["ppc", "rhel"],
     "expectFail": "fips",
-    "maintainers": ["SBoudrias", "sindresorhus"]
+    "maintainers": ["SBoudrias", "sindresorhus"],
+    "skip": "10.x"
   },
   "zeromq": {
     "prefix": "v",


### PR DESCRIPTION
It depends on `Object.fromEntries` which doesn't exist in that version.
