### PR TITLE
lookup: skip node-report on Node.js 15.x and later

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -341,7 +341,8 @@
   "node-report": {
     "prefix": "v",
     "tags": "native",
-    "maintainers": ["rnchamberlain", "richardlau"]
+    "maintainers": ["richardlau"],
+    "skip:": [">=15"]
   },
   "node-sass": {
     "prefix": "v",


### PR DESCRIPTION
node-report has traditionally only supported LTS releases and is
planned to be archived once Node.js 10 goes End-of-Life and all
remaining in support versions of Node.js have the diagnostic report
feature.

Refs: https://github.com/nodejs/node-report/issues/142
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
