### PR TITLE
Provide missing code coverage in tests in package-manager

### DIFF
--- a/test/bin/test-citgm-all.js
+++ b/test/bin/test-citgm-all.js
@@ -249,6 +249,21 @@ test('citgm-all: skip /w rootcheck /w tap to fs /w junit to fs /w append', (t) =
   });
 });
 
+test('citgm-all: install with yarn', (t) => {
+  t.plan(1);
+  const proc = spawn(citgmAllPath, [
+    '-l',
+    'test/fixtures/custom-lookup.json',
+    '-y'
+  ]);
+  proc.on('error', (err) => {
+    t.error(err);
+  });
+  proc.on('close', (code) => {
+    t.equals(code, 0, 'citgm-all should only run omg-i-pass');
+  });
+});
+
 test('bin: sigterm', (t) => {
   t.plan(1);
 


### PR DESCRIPTION
Previously, the functions pkgInstall and pkgTest are missing
code coverage for the lines involving yarn. The test added
now checks these lines by passing in the -y argument when
calling spawn. This does not test when the package doesn't include
the tests, forcing citgm to grab the tarball from github.
Writing such a test would involve setting the property
useYarn.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
