### PR TITLE
lookup: fix skip for node-report

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -342,7 +342,7 @@
     "prefix": "v",
     "tags": "native",
     "maintainers": ["richardlau"],
-    "skip:": [">=15"]
+    "skip": [">=15"]
   },
   "node-sass": {
     "prefix": "v",


### PR DESCRIPTION
0249f2c62e40e4c914faa31fc82763e7cbea092a included an errant ":" in the
"skip" key.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
