### PR TITLE
lookup: skip permanent failures

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -88,7 +88,7 @@
     "skip": "win32"
   },
   "cheerio": {
-    "skip": "win32",
+    "skip": ["aix", "win32"],
     "head": true,
     "maintainers": ["matthewmueller", "jugglinmike"]
   },
@@ -104,7 +104,8 @@
   },
   "commander": {
     "prefix": "v",
-    "maintainers": ["shadowspawn", "abetomo"]
+    "maintainers": ["shadowspawn", "abetomo"],
+    "skip": ["aix"]
   },
   "crc32-stream": {
     "maintainers": "ctalkington",
@@ -122,7 +123,7 @@
   },
   "debug": {
     "maintainers": ["qix", "tootallnate"],
-    "skip": ["aix", "ppc", "s390", "win32"],
+    "skip": [true, "aix", "ppc", "s390", "win32"],
     "scripts": ["test:node", "lint"]
   },
   "dicer": {
@@ -161,7 +162,7 @@
   "esprima": {
     "maintainers": "ariya",
     "expectFail": "fips",
-    "skip": "win32"
+    "skip": ["win32"]
   },
   "express": {
     "flaky": "ppc",
@@ -206,7 +207,8 @@
     "prefix": "v",
     "flaky": ["win32"],
     "expectFail": "fips",
-    "maintainers": "isaacs"
+    "maintainers": "isaacs",
+    "skip": true
   },
   "got": {
     "maintainers": ["sindresorhus"],
@@ -329,7 +331,8 @@
     "maintainers": ["nodejs/addon-api"],
     "prefix": "v",
     "scripts": ["rebuild-tests", "test"],
-    "tags": "native"
+    "tags": "native",
+    "head": true
   },
   "node-gyp": {
     "envVar": { "FAST_TEST": "true" },
@@ -354,7 +357,7 @@
   "npm": {
     "maintainers": ["nodejs/npm"],
     "prefix": "v",
-    "skip": "s390"
+    "skip": ["aix", "s390"]
   },
   "path-to-regexp": {
     "prefix": "v",
@@ -579,7 +582,8 @@
     "prefix": "v",
     "flaky": "ppc",
     "expectFail": "fips",
-    "maintainers": ["bcoe", "addaleax"]
+    "maintainers": ["bcoe", "addaleax"],
+    "head": true
   },
   "yeoman-generator": {
     "prefix": "v",


### PR DESCRIPTION
PPC segfaults all seem related to the TypeScript compiler.

- use HEAD for "nan" (test fixes not in a release)
- use HEAD for "yargs" (lint fixes not in a release)
- commander errors on AIX and segfaults on PPC
- cheerio times out on AIX
- npm errors on AIX
- socket.io fails in a V8 CHECK on AIX and segfaults on PPC
- esprima fails on AIX and segfault on PPC
- path-to-regexp segfaults on PPC
- ws fails in a V8 CHECK on PPC
- glob fails everywhere, including their own CI on Travis
- jest fails everywhere because MongoDB cannot start
- debug fails everywhere, including their own CI on Travis
