### PR TITLE
lookup: change osx to darwin and add debian-10 for skip on hapi

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -2,7 +2,7 @@
   "@hapi/hapi": {
     "prefix": "v",
     "maintainers": ["devinivy", "DavidTPate", "AdriVanHoudt"],
-    "skip": ["osx", "aix"]
+    "skip": ["darwin", "aix", "debian-10"]
   },
   "@hapi/shot": {
     "maintainers": "cjihrig",


### PR DESCRIPTION
`@hapi/hapi` tests are still being run by CITGM, so changing the flag name to `darwin`. Also, the `debian10` distro consistently fails, so I've added that OS to skip as well.

##### Checklist

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
