### PR TITLE
lookup: mark thread-sleep as flaky

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -504,7 +504,8 @@
   "thread-sleep": {
     "install": ["install", "--build-from-source"],
     "tags": "native",
-    "maintainers": ["forbeslindesay", "timothygu"]
+    "maintainers": ["forbeslindesay", "timothygu"],
+    "flaky": true
   },
   "through2": {
     "maintainers": "rvagg",


### PR DESCRIPTION
If I'm reading the test correctly, it looks like the test expects this: https://github.com/ForbesLindesay/thread-sleep/blob/master/index.js#L10-L30, to run a specified amount of time according to this test: https://github.com/ForbesLindesay/thread-sleep/blob/master/test.js#L37. We're seeing the test flake because the time returned doesn't always pass the assertion. (ie. https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/2707/nodes=win-vs2019/testReport/junit/(root)/citgm/thread_sleep_v2_2_0/)

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
