### PR TITLE
lookup: ignore git head for underscore

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -538,7 +538,8 @@
   "underscore": {
     "flaky": ["aix", "s390"],
     "skip": "win32",
-    "maintainers": "jashkenas"
+    "maintainers": "jashkenas",
+    "ignoreGitHead": true
   },
   "undici": {
     "prefix": "v",


### PR DESCRIPTION
It points to a SHA that doesn't exist in the repository:
Refs: https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker-nobuild/1097/nodes=centos7-ppcle/testReport/junit/(root)/citgm/underscore_v1_13_1/