### PR TITLE
doc: correct `stripAnsi` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
 "skip": true                 Completely skip the module
 "expectFail"                 Expect the module to fail, error if it passes
 "repo": "https://github.com/pugjs/jade" - Use a different github repo
-"skipAnsi": true             Strip ansi data from output stream of npm
+"stripAnsi": true            Strip ansi data from output stream of npm
 "sha": "<git-commit-sha>"    Test against a specific commit
 "envVar"                     Pass an environment variable before running
 "install": ["install", "--param1", "--param2"] - Array of command line parameters passed to 'npm' or 'yarn' as install arguments


### PR DESCRIPTION
The correct attribute to strip out ANSI data is `stripAnsi`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
