### PR TITLE
lookup: skip `blake2b-wasm` on `aix` and `s390`

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -61,7 +61,7 @@
   "blake2b-wasm": {
     "maintainers": ["mafintosh", "addaleax"],
     "prefix": "v",
-    "skip": ["win32"]
+    "skip": ["win32", "aix", "s390"]
   },
   "bluebird": {
     "prefix": "v",


### PR DESCRIPTION
https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker-nobuild/1121/nodes=rhel7-s390x/testReport/junit/(root)/citgm/blake2b_wasm_v2_4_0/
https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker-nobuild/1121/nodes=aix72-ppc64/testReport/junit/(root)/citgm/blake2b_wasm_v2_4_0/