### PR TITLE
lookup: skip `cheerio` on `s390`

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -88,7 +88,7 @@
     "skip": "win32"
   },
   "cheerio": {
-    "skip": ["aix", "win32"],
+    "skip": ["aix", "s390", "win32"],
     "head": true,
     "useGitClone": true,
     "maintainers": ["matthewmueller", "jugglinmike"]


### PR DESCRIPTION
https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker-nobuild/1121/nodes=rhel7-s390x/testReport/junit/(root)/citgm/cheerio_v1_0_0_rc_10/