### PR TITLE
lookup: add tough-cookie

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -536,6 +536,9 @@
     "prefix": "v",
     "maintainers": "mafintosh"
   },
+  "tough-cookie": {
+    "maintainers": ["awaterma", "colincasey", "ruoho", "wjharney"]
+  },
   "uglify-js": {
     "prefix": "v",
     "flaky": ["ppc", "darwin"],


### PR DESCRIPTION
Adds `tough-cookie` (42 million weekly downloads) to `lookup.json`.

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md):
  - [x] Module source code must be on Github.
  - [x] Published versions must include a tag on Github
  - [x] The test process must be executable with only the commands
  `npm install && npm test` or (`yarn install && yarn test`) using the tarball
  downloaded from the Github tag mentioned above
  - [x] The tests pass on supported major release lines
  - [x] The maintainers of the module remain responsive when there are problems
  - [x] At least one module maintainer must be added to the lookup maintainers field
  - [x] The module must be actively used by the community
  - [x] The module must be heavily depended on
