### PR TITLE
lookup: temporarily use head for jest

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -260,7 +260,8 @@
     "scripts": ["remove-examples", "build:js", "test-ci-partial"],
     "envVar": { "CI": true },
     "skip": ["aix", "s390x", "ppc", "darwin", "win32"],
-    "timeout": 1800000
+    "timeout": 1800000,
+    "head": true
   },
   "jquery": {
     "skip": "win32",


### PR DESCRIPTION
Refs: https://github.com/nodejs/citgm/issues/894#issuecomment-1091596960

---
Possibly not worth releasing on its own - but thinking it would be good to merge so we can run CITGM pointing to `citgm#master` to try and get green(er) results for Node.js 18.