### PR TITLE
lookup: only run tests for cheerio

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -91,7 +91,8 @@
     "skip": ["aix", "s390", "win32"],
     "head": true,
     "useGitClone": true,
-    "maintainers": ["matthewmueller", "jugglinmike"]
+    "maintainers": ["matthewmueller", "jugglinmike"],
+    "scripts": ["test:jest"]
   },
   "clinic": {
     "maintainers": "mcollina",


### PR DESCRIPTION
Cheerio currently fails on all platforms (refs: https://ci.nodejs.org/job/citgm-smoker-nobuild/1184/console):

```
 > cheerio@1.0.0-rc.10 prepare
 > husky install
 husky - Git hooks installed
 added 583 packages in 15s
 > cheerio@1.0.0-rc.10 test
 > npm run lint && npm run test:jest
 > cheerio@1.0.0-rc.10 lint
 > npm run lint:es && npm run lint:prettier
 > cheerio@1.0.0-rc.10 lint:es
 > eslint --ignore-path .gitignore .
 /home/iojs/tmp/citgm_tmp/1433aa07-54bb-4025-9179-f8c17b9ca201/cheerio/benchmark/suite.ts
   43:28  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   50:41  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   54:28  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   58:60  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
 /home/iojs/tmp/citgm_tmp/1433aa07-54bb-4025-9179-f8c17b9ca201/cheerio/scripts/fetch-sponsors.ts
   101:56  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   167:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   224:21  warning  Forbidden non-null assertion              @typescript-eslint/no-non-null-assertion
 /home/iojs/tmp/citgm_tmp/1433aa07-54bb-4025-9179-f8c17b9ca201/cheerio/src/api/manipulation.spec.ts
   284:33  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
 /home/iojs/tmp/citgm_tmp/1433aa07-54bb-4025-9179-f8c17b9ca201/cheerio/src/api/traversing.ts
   984:5  error  Unexpected aliasing of 'this' to local variable  @typescript-eslint/no-this-alias
 /home/iojs/tmp/citgm_tmp/1433aa07-54bb-4025-9179-f8c17b9ca201/cheerio/src/cheerio.ts
   54:23  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
 /home/iojs/tmp/citgm_tmp/1433aa07-54bb-4025-9179-f8c17b9ca201/cheerio/src/load.ts
   176:28  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   210:46  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   234:22  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
 /home/iojs/tmp/citgm_tmp/1433aa07-54bb-4025-9179-f8c17b9ca201/cheerio/src/static.ts
   268:28  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
 /home/iojs/tmp/citgm_tmp/1433aa07-54bb-4025-9179-f8c17b9ca201/cheerio/src/utils.ts
   23:44  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  15 problems (1 error, 14 warnings)
  ```
  
As this is in the ` eslint --ignore-path .gitignore .` step - I propose we just run the `test:jest` script target which passes. I think this is probably more useful for our smoke testing right now. 
* CI: https://ci.nodejs.org/job/citgm-smoker-nobuild/1185/console 

