### PR TITLE
Revert "lookup: temporarily use head for jest"

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -265,8 +265,7 @@
     "scripts": ["remove-examples", "build:js", "test-ci-partial"],
     "envVar": { "CI": true },
     "skip": ["aix", "s390x", "ppc", "darwin", "win32"],
-    "timeout": 1800000,
-    "head": true
+    "timeout": 1800000
   },
   "jquery": {
     "skip": "win32",


### PR DESCRIPTION
Reverts nodejs/citgm#899

----

It seems Jest failing under CITGM on all platforms with v28.0.1 (peerDeps related?)
 * https://ci.nodejs.org/job/citgm-smoker-nobuild/1205/nodes=rhel8-x64/consoleFull