### PR TITLE
lookup: skip JSONStream on Node.js 14

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -26,7 +26,7 @@
   },
   "JSONStream": {
     "prefix": "v",
-    "skip": "win32",
+    "skip": ["win32", "14"],
     "maintainers": "dominictarr"
   },
   "acorn": {


### PR DESCRIPTION
One of JSONStream's dependencies is using a now deprecated git protocol
and will not pass on with npm@6.

----
Just gradually trying to remove some of the noise in the results.