### PR TITLE
Use auto-updating Node.js test matrix via pkgjs/action

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Use Node.js 16
+      - name: Use LTS Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: lts/*
 
       - name: Install packages
         run: npm install
@@ -28,34 +28,12 @@ jobs:
         run: npm run lint
 
   test:
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - macos-latest
-          - ubuntu-latest
-          - windows-latest
-        node-version:
-          - 14.x
-          - 16.x
-          - 18.x
+    name: Test
 
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - name: Install packages
-        run: npm install
-
-      - name: Run test
-        run: npm run tap -- --coverage-report=lcov
-
-      - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v3
+    uses: pkgjs/action/.github/workflows/node-test.yaml@v0.1
+    with:
+      runs-on: ubuntu-latest, macos-latest, windows-latest
+      test-command: npm run tap -- --coverage-report=lcov
+      post-test-steps: |
+        - name: Coverage Report
+          uses: codecov/codecov-action@v3

--- a/package.json
+++ b/package.json
@@ -88,5 +88,8 @@
   "tap": {
     "timeout": 480,
     "check-coverage": false
+  },
+  "engines": {
+    "node": "14.x || 16.x || 18.x"
   }
 }


### PR DESCRIPTION
As discussed in #891. Not closing it just yet, because I'm pondering if I should add a feature into `pkgjs/action` to enable the same approach for the `test-module` workflow... Not sure just yet. It is possible to use [just the matrix generator](https://github.com/pkgjs/action/tree/main/.github/actions/prepare-node-test-matrix-action) from there, but it requires a bunch of boilerplate.

---

The matrix will be constructed automatically to include all supported versions, starting with the earliest one defined in the `engines` filed in `package.json`.

Note that this will also include Node@17 for the time being, because technically it's still supported - it will drop off the matrix once support ends.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes: https://github.com/dominykas/node-citgm/actions/runs/2295632089
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
