### PR TITLE
chore: update undici to 5.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "supports-color": "^9.2.1",
     "tar": "^6.1.11",
     "uid-number": "0.0.6",
-    "undici": "^4.11.0",
+    "undici": "^5.5.1",
     "uuid": "^8.3.2",
     "which": "^2.0.2",
     "winston": "^3.3.3",


### PR DESCRIPTION
Steps I took to test this:

1. `npm install && npm run test`: Tests pass with undici@4
2. `npm uninstall undici && npm run test`: Tests fail
3. `npm install undici && npm run test`: Tests pass with undici@5

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
