### PR TITLE
lookup: remove david

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -118,11 +118,6 @@
     "flaky": "win32",
     "maintainers": "mafintosh"
   },
-  "david": {
-    "prefix": "v",
-    "maintainers": "alanshaw",
-    "skip": true
-  },
   "debug": {
     "maintainers": ["qix", "tootallnate"],
     "skip": [true, "aix", "ppc", "s390", "win32"],


### PR DESCRIPTION
The module `david` has been skipped for 4 years in CITGM, has minimal
downloads, and no longer appears to be actively maintained.