### PR TITLE
lookup: remove weak

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -579,11 +579,6 @@
     "maintainers": "substack",
     "skip": ["win32", "darwin"]
   },
-  "weak": {
-    "tags": "native",
-    "skip": [">=12"],
-    "maintainers": "tootallnate"
-  },
   "winston": {
     "flaky": ["win32", "ppc", "s390", "darwin"],
     "maintainers": "indexzero"


### PR DESCRIPTION
The last release of `weak` was six years ago and it does not work
on any currently supported version of Node.js. It has been skipped
in CITGM for all versions of Node.js > 10 [1] for over four years.

[1]: https://github.com/nodejs/citgm/pull/563

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
