### PR TITLE
lookup: use head for weak

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -580,9 +580,9 @@
     "skip": ["win32", "darwin"]
   },
   "weak": {
-    "tags": "native",
-    "skip": [">=12"],
-    "maintainers": "tootallnate"
+    "head": true,
+    "maintainers": "tootallnate",
+    "tags": "native"
   },
   "winston": {
     "flaky": ["win32", "ppc", "s390", "darwin"],


### PR DESCRIPTION
Unskip and use `head` for `weak` instead of the last published
version from six years ago.

CI: https://ci.nodejs.org/job/citgm-smoker-pipeline/164/