### PR TITLE
lookup: remove node-report

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -344,12 +344,6 @@
     "maintainers": ["nodejs/node-gyp"],
     "skip": ["win32"]
   },
-  "node-report": {
-    "prefix": "v",
-    "tags": "native",
-    "maintainers": ["richardlau"],
-    "skip": [">=16"]
-  },
   "node-sass": {
     "prefix": "v",
     "tags": "native",


### PR DESCRIPTION
The module `node-report` is deprecated on npm and only has 1,500
downloads per week.

----

My gut feel is that we're probably not getting the value from including this module with it having low downloads, being deprecated, and skipped on all supported versions apart from Node.js 14. 
