### PR TITLE
lookup(express-session): remove skipping node 16 version and above 

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -169,7 +169,6 @@
   "express-session": {
     "prefix": "v",
     "maintainers": "dougwilson",
-    "skip": ">=16",
     "comment": "https://github.com/expressjs/session/pull/844"
   },
   "fastify": {

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -168,8 +168,7 @@
   },
   "express-session": {
     "prefix": "v",
-    "maintainers": "dougwilson",
-    "comment": "https://github.com/expressjs/session/pull/844"
+    "maintainers": "dougwilson"
   },
   "fastify": {
     "maintainers": ["mcollina", "delvedor"],


### PR DESCRIPTION
Tested running on Node 14, 16 and 18 in ppc, s390 and x64_86 architectures. It fails only on node 14 in s390x