### PR TITLE
lookup: only skip mkdirp on win32

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -311,7 +311,7 @@
   },
   "mkdirp": {
     "head": true,
-    "skip": true,
+    "skip": "win32",
     "maintainers": "substack"
   },
   "mocha": {


### PR DESCRIPTION
From CITGM Smoker Pipeline runs, this module appears to now only fail on
Windows.

----

Runs - https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker-pipeline/168