### PR TITLE
lookup(ffi): remove ffi from citgm lookup.json

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -176,12 +176,6 @@
     "maintainers": ["mcollina", "delvedor"],
     "prefix": "v"
   },
-  "ffi": {
-    "flaky": ["ppc", "aix", "s390", "ubuntu"],
-    "skip": true,
-    "tags": "native",
-    "maintainers": "TooTallNate"
-  },
   "flush-write-stream": {
     "prefix": "v",
     "maintainers": "mafintosh",


### PR DESCRIPTION
* It fails in the majority of the platforms architectures.
* No commit on their github repo since January 2019.
* Current npm downloads ~5.000/per week.
* No activity on the github issues, with 218 issues open. 
* Last issue resolved was on 14 Dec 2020