### PR TITLE
lookup: remove time

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -527,12 +527,6 @@
     "stripAnsi": true,
     "maintainers": "mcollina"
   },
-  "time": {
-    "flaky": ["linux-ia32", "s390"],
-    "skip": ["win32", "aix", ">=11"],
-    "tags": "native",
-    "maintainers": "TooTallNate"
-  },
   "torrent-stream": {
     "prefix": "v",
     "maintainers": "mafintosh"


### PR DESCRIPTION
The `time` module has been skipped since Node.js 11, has not had a new
version published in 5 years, and has a relatively low number of
downloads.

----
Number of downloads per week is ~1,700. Also fails on all supported versions. The PR that skipped it in CITGM referenced  https://github.com/TooTallNate/node-time/pull/76, which I'd guess is unlikely to land.