### PR TITLE
lookup: unskip path-to-regexp for Node.js 18

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -365,8 +365,7 @@
   "path-to-regexp": {
     "prefix": "v",
     "maintainers": "blakeembrey",
-    "skip": ["aix", ">=17"],
-    "comment": "OpenSSL 3.0"
+    "skip": ["aix"]
   },
   "pino": {
     "prefix": "v",


### PR DESCRIPTION
`path-to-regexp` tests no longer fail on Node.js 18 and later.

---

CI: https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker-pipeline/177/

Tests still fail on AIX, so it remains skipped on that platform only.

