### PR TITLE
lookup: set ignore scripts for semver

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -454,7 +454,9 @@
     "skip": "win32",
     "prefix": "v",
     "maintainers": "isaacs",
-    "expectFail": "fips"
+    "expectFail": "fips",
+    "envVar": { "npm_config_ignore_scripts": "true" },
+    "comment": "postlint script fails"
   },
   "serialport": {
     "prefix": "serialport@",


### PR DESCRIPTION
semver's test suite is passing but a later failing post script results
in it being reported as a failure.

---- 
 * Node.js 18 - https://ci.nodejs.org/job/citgm-smoker-nobuild/1315
    * only failure is #917
