### PR TITLE
un-skipping blake2b-wasm on s390x

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -61,7 +61,7 @@
   "blake2b-wasm": {
     "maintainers": ["mafintosh", "addaleax"],
     "prefix": "v",
-    "skip": ["win32", "aix", "s390"]
+    "skip": ["win32", "aix"]
   },
   "bluebird": {
     "prefix": "v",


### PR DESCRIPTION
This PR un-skips blake2b-wasm for s390x system architecture, after the recent upgrade of esbuild on wasm-tools (which is a dependency on blake2b-wasm). There is an open PR on blake2b-wasm for upgrading wasm-tools https://github.com/mafintosh/blake2b-wasm/pull/21 although we dont have to wait for the PR to land, due to npm resolves wasm-tools, during blake2b-wasm npm install, from 0.2.0 to 0.2.1 