### PR TITLE
grab-module-data: fix broken test

### DIFF
--- a/lib/grab-module-data.js
+++ b/lib/grab-module-data.js
@@ -17,14 +17,18 @@ export function grabModuleData(context) {
       createOptions(context.path, context)
     );
     let data = '';
+    let errData = '';
     proc.stdout.on('data', (chunk) => {
       data += chunk;
+    });
+    proc.stderr.on('data', (chunk) => {
+      errData += chunk;
     });
     proc.once('error', (err) => {
       reject(err);
     });
     proc.on('close', (code) => {
-      if (code > 0) {
+      if (code > 0 && !errData?.match(/No match found for version/)) {
         context.emit(
           'data',
           'verbose',


### PR DESCRIPTION
npm 7 and higher now have an exit code for failed fetches. This introduces a subtle behavior change in testing as the error cases are slightly different. This tiny change to `grab-module-data.js` adds a regex to ensure a consistent code path is followed across all maintained versions of npm.

TBH there is likely a cleaner way to fix this, but it would involve a lot more refactoring which could create other unexpected bugs.

This should fix the broken CITGM test suite