### PR TITLE
lookup: add jose

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -255,6 +255,14 @@
     "skip": ["aix", "s390x", "ppc", "darwin", "win32"],
     "timeout": 1800000
   },
+  "jose": {
+    "maintainers": ["panva"],
+    "prefix": "v",
+    "scripts": ["test", "tap:node"],
+    "envVar": { "CITGM": true },
+    "skip": ["aix"],
+    "comment": "esbuild doesn't support aix"
+  },
   "jquery": {
     "skip": "win32",
     "flaky": ["linux", "aix", "darwin"],


### PR DESCRIPTION
adds [`jose`](https://www.npmjs.com/package/jose)

It covers the `node:crypto`, and `Web Cryptography API` modules.