### PR TITLE
deps: add ansi-regex as devdep

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "yarn": "^1.22.17"
   },
   "devDependencies": {
+    "ansi-regex": "^6.0.1",
     "c8": "^7.10.0",
     "eslint": "^8.4.0",
     "eslint-config-prettier": "^8.3.0",


### PR DESCRIPTION
This is currently imported in the test suite. It is only a transitive dependency right now. Installing as dev-dep to avoid issues with availability in the future.
