### PR TITLE
lib: fix edge case for npm 9

### DIFF
--- a/lib/grab-module-data.js
+++ b/lib/grab-module-data.js
@@ -50,7 +50,7 @@ export function grabModuleData(context) {
         return;
       }
 
-      if (data === '') {
+      if (data === '' || errData?.match(/No match found for version/)) {
         reject(
           new Error(`No module version found satisfying ${context.module.raw}`)
         );


### PR DESCRIPTION
The way npm 9 errors for non-existent module versions differs from previous versions. Adding an extra regex to check for that case and use the correct erroring code path internally.
