### PR TITLE
fix: parse boolean to number

### DIFF
--- a/lib/bin/citgm-all.js
+++ b/lib/bin/citgm-all.js
@@ -195,7 +195,7 @@ function launch() {
 
   const q = async.queue(runTask, app.parallel || 1);
   q.push(collection);
-  function done() {
+  function done(exitCode = 0) {
     q.kill();
     reporter.logger(log, modules);
 
@@ -217,17 +217,17 @@ function launch() {
       reporter.junit(junit, modules, app.append);
     }
 
-    process.exit(reporter.util.hasFailures(modules));
+    const hasFailures = reporter.util.hasFailures(modules) ? 1 : 0;
+    process.exit(hasFailures || exitCode);
   }
 
   function abort() {
     q.pause();
     q.kill();
-    process.exitCode = 1;
     process.removeListener('SIGINT', abort);
     process.removeListener('SIGHUP', abort);
     process.removeListener('SIGBREAK', abort);
-    done();
+    done(1);
   }
 
   q.drain(done);


### PR DESCRIPTION
I am running the `citgm` locally in a custom Node.js build and I got the following error:

```
...
error: done                | The smoke test has failed.
TypeError [ERR_INVALID_ARG_TYPE]: The "code" argument must be of type number. Received type boolean (true)
    at process.set [as exitCode] (node:internal/bootstrap/node:128:9)
    at process.exit (node:internal/process/per_thread:187:24)
    at done (file:///home/rafaelgss/repos/os/citgm/lib/bin/citgm-all.js:220:13)
    at /home/rafaelgss/repos/os/citgm/node_modules/async/dist/async.js:1496:46
    at Array.forEach (<anonymous>)
    at trigger (/home/rafaelgss/repos/os/citgm/node_modules/async/dist/async.js:1496:27)
    at /home/rafaelgss/repos/os/citgm/node_modules/async/dist/async.js:1569:21
    at /home/rafaelgss/repos/os/citgm/node_modules/async/dist/async.js:327:20
    at Tester.<anonymous> (file:///home/rafaelgss/repos/os/citgm/lib/bin/citgm-all.js:180:14)
    at Tester.emit (node:events:519:28) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

This PR fixes it by parsing the boolean to a number. 

UPDATE: Basically, when you call `process.exit()` passing a non-number argument (`process.exit(false)`) it won't exit as 0. It will use instead the `process.exitCode` value. So, that's the reason I've adjusted the code to pass the exit code and do it explicitly.

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [X] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
