### PR TITLE
chore: remove rimraf from deps

### DIFF
--- a/lib/temp-directory.js
+++ b/lib/temp-directory.js
@@ -1,12 +1,8 @@
-import { promisify } from 'util';
 import { join } from 'path';
-import { promises as fs } from 'fs';
+import { mkdir, rm } from 'node:fs/promises';
 
-import rimrafLib from 'rimraf';
 import { v4 as uuid } from 'uuid';
 import osenv from 'osenv';
-
-const rimraf = promisify(rimrafLib);
 
 export async function create(context) {
   if (context.options && context.options.tmpDir) {
@@ -24,8 +20,8 @@ export async function create(context) {
   context.homeDir = join(context.path, 'home');
   context.npmConfigTmp = join(context.path, 'npm_config_tmp');
 
-  await fs.mkdir(context.homeDir, { recursive: true });
-  await fs.mkdir(context.npmConfigTmp, { recursive: true });
+  await mkdir(context.homeDir, { recursive: true });
+  await mkdir(context.npmConfigTmp, { recursive: true });
 }
 
 export let remove = async function remove(context) {
@@ -38,7 +34,7 @@ export let remove = async function remove(context) {
     `${context.module.name} rm.tempdir`,
     context.path
   );
-  await rimraf(context.path);
+  await rm(context.path, { recursive: true });
 };
 
 // Used in tests to simulate errors in rimraf.

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "read-package-json": "^4.1.1",
     "readable-stream": "^3.6.0",
     "request": "^2.88.2",
-    "rimraf": "^3.0.2",
     "root-check": "^2.0.0",
     "semver": "^7.3.5",
     "strip-ansi": "^7.0.1",

--- a/test/npm/test-npm-install.js
+++ b/test/npm/test-npm-install.js
@@ -1,19 +1,16 @@
 import { tmpdir } from 'os';
 import { join, dirname } from 'path';
-import { promisify } from 'util';
 import { fileURLToPath } from 'url';
-import { promises as fs } from 'fs';
+import { mkdir, rm } from 'node:fs/promises';
 
 import fse from 'fs-extra';
 import tap from 'tap';
-import rimrafLib from 'rimraf';
 
 import { getPackageManagers } from '../../lib/package-manager/index.js';
 import packageManagerInstall from '../../lib/package-manager/install.js';
 import { npmContext } from '../helpers/make-context.js';
 
 const { test } = tap;
-const rimraf = promisify(rimrafLib);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const sandbox = join(tmpdir(), `citgm-${Date.now()}`);
@@ -29,7 +26,7 @@ let packageManagers;
 
 test('npm-install: setup', async () => {
   packageManagers = await getPackageManagers();
-  await fs.mkdir(sandbox, { recursive: true });
+  await mkdir(sandbox, { recursive: true });
   await Promise.all([
     fse.copy(moduleFixtures, moduleTemp),
     fse.copy(extraParamFixtures, extraParamTemp),
@@ -107,5 +104,5 @@ test('npm-install: failed install', async (t) => {
 });
 
 test('npm-install: teardown', async () => {
-  await rimraf(sandbox);
+  await rm(sandbox, { recursive: true });
 });

--- a/test/npm/test-npm-test.js
+++ b/test/npm/test-npm-test.js
@@ -1,19 +1,17 @@
 import { tmpdir } from 'os';
 import { join, resolve, dirname } from 'path';
-import { promisify } from 'util';
 import { fileURLToPath } from 'url';
-import { existsSync, promises as fs } from 'fs';
+import { existsSync } from 'fs';
+import { mkdir, rm } from 'node:fs/promises';
 
 import fse from 'fs-extra';
 import tap from 'tap';
-import rimrafLib from 'rimraf';
 
 import { npmContext } from '../helpers/make-context.js';
 import { getPackageManagers } from '../../lib/package-manager/index.js';
 import { test as packageManagerTest } from '../../lib/package-manager/test.js';
 
 const { test } = tap;
-const rimraf = promisify(rimrafLib);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const sandbox = join(tmpdir(), `citgm-${Date.now()}`);
@@ -41,7 +39,7 @@ let packageManagers;
 
 test('npm-test: setup', async () => {
   packageManagers = await getPackageManagers();
-  await fs.mkdir(sandbox, { recursive: true });
+  await mkdir(sandbox, { recursive: true });
   await Promise.all([
     fse.copy(passFixtures, passTemp),
     fse.copy(failFixtures, failTemp),
@@ -189,5 +187,5 @@ test('npm-test: tmpdir is redirected', async (t) => {
 });
 
 test('npm-test: teardown', async () => {
-  await rimraf(sandbox);
+  await rm(sandbox, { recursive: true });
 });

--- a/test/reporter/test-reporter-junit.js
+++ b/test/reporter/test-reporter-junit.js
@@ -1,18 +1,17 @@
-import { readFileSync, writeFileSync, promises as fs } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
+import { mkdir, rm } from 'node:fs/promises';
 import { dirname, join } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
 import { promisify } from 'util';
 
 import tap from 'tap';
-import rimrafLib from 'rimraf';
 import _ from 'lodash';
 import xml2js from 'xml2js';
 
 import junitReporter from '../../lib/reporter/junit.js';
 
 const { test } = tap;
-const rimraf = promisify(rimrafLib);
 const parseString = promisify(xml2js.parseString);
 
 const fixtures = JSON.parse(
@@ -60,7 +59,7 @@ const badOutput = readFileSync(badOutputPath, 'utf-8');
 const badOutputToo = readFileSync(badOutputTooPath, 'utf-8');
 
 test('reporter.junit(): setup', async () => {
-  await fs.mkdir(sandbox, { recursive: true });
+  await mkdir(sandbox, { recursive: true });
 });
 
 test('reporter.junit(): passing', (t) => {
@@ -156,5 +155,5 @@ test('reporter.junit(): append to disk', (t) => {
 });
 
 test('reporter.junit(): teardown', async () => {
-  await rimraf(sandbox);
+  await rm(sandbox, { recursive: true });
 });

--- a/test/reporter/test-reporter-tap.js
+++ b/test/reporter/test-reporter-tap.js
@@ -1,13 +1,12 @@
 // TODO this test does not test any functionality currently
 
-import { readFileSync, writeFileSync, promises as fs } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
+import { mkdir, rm } from 'node:fs/promises';
 import { join, dirname } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
-import { promisify } from 'util';
 
 import tap from 'tap';
-import rimrafLib from 'rimraf';
 import Parser from 'tap-parser';
 import str from 'string-to-stream';
 
@@ -18,7 +17,6 @@ const fixtures = JSON.parse(
 );
 
 const { test } = tap;
-const rimraf = promisify(rimrafLib);
 
 const fixturesPath = join(
   dirname(fileURLToPath(import.meta.url)),
@@ -52,7 +50,7 @@ const failingExpectedPath = join(fixturesPath, 'test-out-tap-failing.txt');
 const failingExpected = readFileSync(failingExpectedPath, 'utf-8');
 
 test('reporter.tap(): setup', async () => {
-  await fs.mkdir(sandbox, { recursive: true });
+  await mkdir(sandbox, { recursive: true });
 });
 
 test('reporter.tap(): passing', (t) => {
@@ -132,5 +130,5 @@ test('reporter.tap(): append to disk when file does not exist', (t) => {
 });
 
 test('reporter.tap(): teardown', async () => {
-  await rimraf(sandbox);
+  await rm(sandbox, { recursive: true });
 });

--- a/test/test-grab-project.js
+++ b/test/test-grab-project.js
@@ -5,23 +5,20 @@
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { tmpdir } from 'os';
-import { promisify } from 'util';
-import { promises as fs } from 'fs';
+import { mkdir, stat, rm } from 'node:fs/promises';
 
 import tap from 'tap';
-import rimrafLib from 'rimraf';
 
 import { grabProject } from '../lib/grab-project.js';
 
 const { test } = tap;
-const rimraf = promisify(rimrafLib);
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const sandbox = join(tmpdir(), `citgm-${Date.now()}`);
 const fixtures = join(__dirname, 'fixtures');
 
 test('grab-project: setup', async () => {
-  await fs.mkdir(sandbox, { recursive: true });
+  await mkdir(sandbox, { recursive: true });
 });
 
 test('grab-project: npm module', async (t) => {
@@ -36,7 +33,7 @@ test('grab-project: npm module', async (t) => {
     options: {}
   };
   await grabProject(context);
-  const stats = await fs.stat(context.unpack);
+  const stats = await stat(context.unpack);
   t.ok(stats.isFile(), 'The tar ball should exist on the system');
 });
 
@@ -53,7 +50,7 @@ test('grab-project: local', async (t) => {
     options: {}
   };
   await grabProject(context);
-  const stats = await fs.stat(context.unpack);
+  const stats = await stat(context.unpack);
   t.ok(stats.isFile(), 'The tar ball should exist on the system');
 });
 
@@ -69,7 +66,7 @@ test('grab-project: lookup table', async (t) => {
     options: {}
   };
   await grabProject(context);
-  const stats = await fs.stat(context.unpack);
+  const stats = await stat(context.unpack);
   t.ok(stats.isFile(), 'The tar ball should exist on the system');
 });
 
@@ -86,7 +83,7 @@ test('grab-project: local', async (t) => {
   };
   process.chdir(fixtures);
   await grabProject(context);
-  const stats = await fs.stat(context.unpack);
+  const stats = await stat(context.unpack);
   t.ok(stats.isFile(), 'The tar ball should exist on the system');
   process.chdir(__dirname);
 });
@@ -123,7 +120,7 @@ test('grab-project: use git clone', async (t) => {
     options: {}
   };
   await grabProject(context);
-  const stats = await fs.stat(join(context.path, 'omg-i-pass/package.json'));
+  const stats = await stat(join(context.path, 'omg-i-pass/package.json'));
   t.ok(stats.isFile(), 'The project must be cloned locally');
 });
 
@@ -173,5 +170,7 @@ test('grab-project: timeout', async (t) => {
 });
 
 test('grab-project: teardown', async () => {
-  await rimraf(sandbox);
+  await rm(sandbox, {
+    recursive: true
+  });
 });

--- a/test/test-temp-directory.js
+++ b/test/test-temp-directory.js
@@ -1,13 +1,10 @@
-import { promisify } from 'util';
-import { promises as fs } from 'fs';
+import { stat, rm } from 'node:fs/promises';
 
 import tap from 'tap';
-import rimrafLib from 'rimraf';
 
 import * as tempDirectory from '../lib/temp-directory.js';
 
 const { test } = tap;
-const rimraf = promisify(rimrafLib);
 
 const isWin32 = process.platform === 'win32';
 const nullDevice = isWin32 ? '\\\\.\\NUL' : '/dev/null';
@@ -36,7 +33,7 @@ test('tempDirectory.create:', async (t) => {
   t.notOk(context.path, 'context should not have a path');
   await tempDirectory.create(context);
   t.ok(context.path, 'context should now have a path');
-  const stats = await fs.stat(context.path);
+  const stats = await stat(context.path);
   t.ok(stats.isDirectory(), 'the path should exist and be a folder');
 });
 
@@ -47,9 +44,9 @@ test('tempDirectory.create --tmpDir:', async (t) => {
     contextTmpDir.path.match(/thisisatest[/\\].*-.*-.*-.*-.*/),
     'the path should match --tmpDir'
   );
-  const stats = await fs.stat(contextTmpDir.path);
+  const stats = await stat(contextTmpDir.path);
   t.ok(stats.isDirectory(), 'the path should exist and be a folder');
-  await rimraf('./.thisisatest');
+  await rm('./.thisisatest', { recursive: true });
 });
 
 test('tempDirectory.remove:', async (t) => {
@@ -57,7 +54,7 @@ test('tempDirectory.remove:', async (t) => {
   t.ok(context.path, 'context should have a path');
   await tempDirectory.remove(context);
   await t.rejects(
-    fs.stat(context.path),
+    stat(context.path),
     'we should get an error as the path does not exist'
   );
 });

--- a/test/yarn/test-yarn-install.js
+++ b/test/yarn/test-yarn-install.js
@@ -1,19 +1,16 @@
 import { tmpdir } from 'os';
-import { promises as fs } from 'fs';
+import { mkdir, rm } from 'node:fs/promises';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { promisify } from 'util';
 
 import fse from 'fs-extra';
 import tap from 'tap';
-import rimrafLib from 'rimraf';
 
 import { getPackageManagers } from '../../lib/package-manager/index.js';
 import packageManagerInstall from '../../lib/package-manager/install.js';
 import { npmContext } from '../helpers/make-context.js';
 
 const { test } = tap;
-const rimraf = promisify(rimrafLib);
 
 const sandbox = join(tmpdir(), `citgm-${Date.now()}`);
 const fixtures = join(
@@ -32,7 +29,7 @@ let packageManagers;
 
 test('yarn-install: setup', async () => {
   packageManagers = await getPackageManagers();
-  await fs.mkdir(sandbox, { recursive: true });
+  await mkdir(sandbox, { recursive: true });
   await Promise.all([
     fse.copy(moduleFixtures, moduleTemp),
     fse.copy(extraParamFixtures, extraParamTemp),
@@ -85,5 +82,5 @@ test('yarn-install: failed install', async (t) => {
 });
 
 test('yarn-install: teardown', async () => {
-  await rimraf(sandbox);
+  await rm(sandbox, { recursive: true });
 });

--- a/test/yarn/test-yarn-test.js
+++ b/test/yarn/test-yarn-test.js
@@ -1,19 +1,17 @@
-import { existsSync, promises as fs } from 'fs';
+import { existsSync } from 'fs';
+import { mkdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'os';
 import { join, resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { promisify } from 'util';
 
 import fse from 'fs-extra';
 import tap from 'tap';
-import rimrafLib from 'rimraf';
 
 import { npmContext } from '../helpers/make-context.js';
 import { getPackageManagers } from '../../lib/package-manager/index.js';
 import { test as packageManagerTest } from '../../lib/package-manager/test.js';
 
 const { test } = tap;
-const rimraf = promisify(rimrafLib);
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -42,7 +40,7 @@ let packageManagers;
 
 test('yarn-test: setup', async () => {
   packageManagers = await getPackageManagers();
-  await fs.mkdir(sandbox, { recursive: true });
+  await mkdir(sandbox, { recursive: true });
   await Promise.all([
     fse.copy(passFixtures, passTemp),
     fse.copy(failFixtures, failTemp),
@@ -187,5 +185,5 @@ test('yarn-test: tmpdir is redirected', async (t) => {
 });
 
 test('yarn-test: teardown', async () => {
-  await rimraf(sandbox);
+  await rm(sandbox, { recursive: true });
 });


### PR DESCRIPTION
Node.js now natively supports recursive directory removal so we no longer need to use `rimraf` in the project.

This will hopefully help with some flaky tests on windows
