### PR TITLE
chore: bump xml2js to 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "string-to-stream": "^3.0.1",
     "tap": "^16.2.0",
     "tap-parser": "^11.0.1",
-    "xml2js": "^0.4.23"
+    "xml2js": "^0.5.0"
   },
   "prettier": {
     "proseWrap": "always",


### PR DESCRIPTION
Dependabot can't do this because we don't have a package-lock.json.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
