### PR TITLE
Un-flakying underscore package on s390x as is no longer flaky

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -538,7 +538,7 @@
     "comment": "Tests timeout"
   },
   "underscore": {
-    "flaky": ["aix", "s390"],
+    "flaky": ["aix"],
     "skip": "win32",
     "maintainers": "jashkenas",
     "ignoreGitHead": true


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

Underscore package is no longer flaky and it passes on s390x systems, so its good adding it for increasing the Node.js test coverage.

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
