### PR TITLE
Moving level package from flaky to skip

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -275,9 +275,9 @@
   },
   "level": {
     "prefix": "v",
-    "flaky": ["aix", "s390"],
+    "flaky": ["aix"],
     "maintainers": ["ralphtheninja", "vweevers"],
-    "skip": "win32"
+    "skip": ["win32", "s390"]
   },
   "leveldown": {
     "prefix": "v",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

Level package fails on s390x, therefore it should be as skipped.

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
