### PR TITLE
Moving leveldown from flaky to skip on ppc and s390 systems

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -264,7 +264,7 @@
   "leveldown": {
     "head": true,
     "useGitClone": true,
-    "flaky": ["ppc", "s390"],
+    "skip": ["ppc", "s390"],
     "tags": "native",
     "maintainers": ["ralphtheninja", "vweevers"]
   },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->
Leveldown package fails on s390x and on ppc systems, therefore it should be as skipped.

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
