### PR TITLE
lookup: add import-in-the-middle

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -232,6 +232,11 @@
     "tags": "native",
     "maintainers": "bnoordhuis"
   },
+  "import-in-the-middle": {
+    "prefix": "v",
+    "skip": "win32",
+    "maintainers": ["bengl", "Qard"]
+  },
   "inherits": {
     "prefix": "v",
     "maintainers": "isaacs"


### PR DESCRIPTION
Ref: https://github.com/nodejs/TSC/issues/1397

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

I believe all the [requirements](https://github.com/nodejs/citgm/blob/main/CONTRIBUTING.md#submitting-a-module-to-citgm) are met. [The module has 1,778,787 weekly downloads on npm](https://www.npmjs.com/package/import-in-the-middle) and uses loaders, which AFAIK no others in `lookup.json` do.

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
