### PR TITLE
lookup: declare bankruptcy on flaky modules

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -29,19 +29,6 @@
     "skip": ["win32", "14"],
     "maintainers": "dominictarr"
   },
-  "acorn": {
-    "maintainers": "marijnh",
-    "skip": ["win32", "ppc"]
-  },
-  "async": {
-    "prefix": "v",
-    "maintainers": ["aearly", "megawac"]
-  },
-  "ava": {
-    "prefix": "v",
-    "skip": ["14", "ppc", "win32", "x86", "rhel", "aix", "ia32"],
-    "maintainers": ["sindresorhus", "novemberborn"]
-  },
   "bcrypt": {
     "prefix": "v",
     "tags": "native",
@@ -81,24 +68,12 @@
     "scripts": ["test-node"],
     "skip": true
   },
-  "bufferutil": {
-    "prefix": "v",
-    "tags": "native",
-    "maintainers": ["3rdeden", "einaros", "lpinca"],
-    "skip": "win32"
-  },
   "cheerio": {
     "skip": ["aix", "win32"],
     "head": true,
     "useGitClone": true,
     "maintainers": ["matthewmueller", "jugglinmike"],
     "scripts": ["test:jest"]
-  },
-  "clinic": {
-    "maintainers": "mcollina",
-    "flaky": ["rhel"],
-    "prefix": "v",
-    "skip": ["aix", "win32"]
   },
   "coffeescript": {
     "maintainers": ["jashkenas", "GeoffreyBooth"],
@@ -135,14 +110,6 @@
     "prefix": "v",
     "maintainers": "mafintosh"
   },
-  "ember-cli": {
-    "envVar": { "YARN_IGNORE_ENGINES": "true" },
-    "prefix": "v",
-    "flaky": ["win32", "rhel", "sles"],
-    "head": true,
-    "expectFail": "fips",
-    "maintainers": ["stefanpenner", "rwjblue", "Turbo87", "kellyselden"]
-  },
   "end-of-stream": {
     "prefix": "v",
     "maintainers": "mafintosh",
@@ -161,18 +128,9 @@
     "expectFail": "fips",
     "skip": ["win32"]
   },
-  "express": {
-    "flaky": "ppc",
-    "maintainers": "dougwilson",
-    "skip": "win32"
-  },
   "express-session": {
     "prefix": "v",
     "maintainers": "dougwilson"
-  },
-  "fastify": {
-    "maintainers": ["mcollina", "delvedor"],
-    "prefix": "v"
   },
   "flush-write-stream": {
     "prefix": "v",
@@ -222,10 +180,6 @@
     "maintainers": "contra",
     "skip": "win32"
   },
-  "https-proxy-agent": {
-    "maintainers": "TooTallNate",
-    "scripts": ["build", "test"]
-  },
   "iconv": {
     "prefix": "v",
     "flaky": "aix",
@@ -241,24 +195,9 @@
     "prefix": "v",
     "maintainers": "isaacs"
   },
-  "is-core-module": {
-    "prefix": "v",
-    "maintainers": "ljharb",
-    "scripts": ["tests-only"]
-  },
   "isarray": {
     "prefix": "v",
     "maintainers": "juliangruber"
-  },
-  "jest": {
-    "prefix": "v",
-    "maintainers": ["cpojer", "scotthovestadt", "SimenB", "thymikee", "jeysal"],
-    "yarn": true,
-    "install": ["install", "--no-immutable"],
-    "scripts": ["build:js", "remove-examples", "test-ci-partial"],
-    "envVar": { "CI": true },
-    "skip": ["aix", "s390x", "ppc", "darwin", "win32"],
-    "timeout": 1800000
   },
   "jose": {
     "maintainers": ["panva"],
@@ -284,13 +223,6 @@
     "maintainers": ["ralphtheninja", "vweevers"],
     "skip": "win32"
   },
-  "leveldown": {
-    "prefix": "v",
-    "useGitClone": true,
-    "flaky": ["ppc", "s390"],
-    "tags": "native",
-    "maintainers": ["ralphtheninja", "vweevers"]
-  },
   "libxmljs": {
     "prefix": "v",
     "flaky": ["aix", "sles", "rhel", "darwin"],
@@ -310,19 +242,6 @@
     "skip": "aix",
     "comment": "Marked as flaky on win32 due to this issue https://github.com/nodejs/citgm/issues/930"
   },
-  "microtime": {
-    "prefix": "v",
-    "tags": "native",
-    "maintainers": "wadey"
-  },
-  "mime": {
-    "prefix": "v",
-    "maintainers": "broofa"
-  },
-  "minimist": {
-    "npm": true,
-    "maintainers": "substack"
-  },
   "mkdirp": {
     "head": true,
     "skip": ["win32", true],
@@ -339,18 +258,6 @@
     "maintainers": "ichernev",
     "skip": [true, "ppc", "s390"]
   },
-  "multer": {
-    "prefix": "v",
-    "skip": "win32",
-    "maintainers": "linusu"
-  },
-  "nan": {
-    "maintainers": ["nodejs/addon-api"],
-    "prefix": "v",
-    "scripts": ["rebuild-tests", "test"],
-    "tags": "native",
-    "head": true
-  },
   "node-gyp": {
     "envVar": { "FAST_TEST": "true" },
     "prefix": "v",
@@ -365,23 +272,10 @@
     "comment": "Flaky because of test timeouts",
     "skip": true
   },
-  "npm": {
-    "maintainers": ["nodejs/npm"],
-    "prefix": "v",
-    "skip": ["aix", "s390"]
-  },
   "path-to-regexp": {
     "prefix": "v",
     "maintainers": "blakeembrey",
     "skip": ["aix"]
-  },
-  "pino": {
-    "prefix": "v",
-    "maintainers": "mcollina"
-  },
-  "prom-client": {
-    "prefix": "v",
-    "maintainers": ["siimon", "zbjornson", "SimenB"]
   },
   "pug": {
     "prefix": "pug@",
@@ -390,11 +284,6 @@
     "skip": ["win32", "aix", ">=16"],
     "comment": "Error message changes in V8 9.3",
     "repo": "https://github.com/pugjs/pug"
-  },
-  "pump": {
-    "prefix": "v",
-    "maintainers": "mafintosh",
-    "skip": "win32"
   },
   "pumpify": {
     "prefix": "v",
@@ -429,20 +318,6 @@
     "maintainers": "ljharb",
     "scripts": ["tests-only", "posttest"]
   },
-  "rewire": {
-    "prefix": "v",
-    "maintainers": "jhnns"
-  },
-  "rimraf": {
-    "prefix": "v",
-    "flaky": "win32",
-    "maintainers": "isaacs"
-  },
-  "router": {
-    "prefix": "v",
-    "maintainers": "dougwilson",
-    "skip": "win32"
-  },
   "sax": {
     "skip": "win32",
     "prefix": "v",
@@ -457,24 +332,11 @@
     "envVar": { "npm_config_ignore_scripts": "true" },
     "comment": "postlint script fails"
   },
-  "serialport": {
-    "prefix": "serialport@",
-    "flaky": ["ppc", "rhel"],
-    "tags": "native",
-    "maintainers": "reconbot",
-    "skip": ["win32"]
-  },
   "socket.io": {
     "maintainers": "rauchg",
     "head": true,
     "skip": ">=17",
     "comment": "WS is not compatible"
-  },
-  "spawn-wrap": {
-    "prefix": "v",
-    "flaky": ["sles", "aix", "darwin"],
-    "maintainers": "isaacs",
-    "skip": "win32"
   },
   "spdy": {
     "prefix": "v",
@@ -505,11 +367,6 @@
     "maintainers": "tj",
     "skip": ">=11"
   },
-  "tape": {
-    "head": true,
-    "prefix": "v",
-    "maintainers": "substack"
-  },
   "thread-sleep": {
     "install": ["install", "--build-from-source"],
     "tags": "native",
@@ -528,34 +385,12 @@
     "stripAnsi": true,
     "maintainers": "mcollina"
   },
-  "torrent-stream": {
-    "prefix": "v",
-    "maintainers": "mafintosh"
-  },
-  "tough-cookie": {
-    "maintainers": ["awaterma", "colincasey", "ruoho", "wjharney"]
-  },
   "uglify-js": {
     "prefix": "v",
     "flaky": ["ppc", "darwin"],
     "maintainers": "mishoo",
     "skip": ["12", true],
     "comment": "Tests timeout"
-  },
-  "underscore": {
-    "flaky": ["aix", "s390"],
-    "skip": "win32",
-    "maintainers": "jashkenas",
-    "ignoreGitHead": true
-  },
-  "undici": {
-    "prefix": "v",
-    "maintainers": ["mcollina", "ronag"]
-  },
-  "uuid": {
-    "prefix": "v",
-    "maintainers": ["ctavan", "broofa"],
-    "skip": ["win32", "aix"]
   },
   "vinyl": {
     "prefix": "v",
@@ -578,14 +413,6 @@
     "head": true,
     "maintainers": "tootallnate",
     "tags": "native"
-  },
-  "winston": {
-    "flaky": ["win32", "ppc", "s390", "darwin"],
-    "maintainers": "indexzero"
-  },
-  "ws": {
-    "expectFail": "fips",
-    "maintainers": ["einaros", "3rd-Eden", "lpinca"]
   },
   "yargs": {
     "comment": "Install from source is currently broken due to TS error",

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -65,10 +65,7 @@ test('lookup[getLookupTable]:', (t) => {
   });
   t.ok(table, 'table should exist');
   t.ok(table.lodash, 'lodash should be in the table');
-  t.ok(
-    table.underscore.maintainers,
-    'underscore should contain a maintainers parameter'
-  );
+  t.ok(table.weak.maintainers, 'weak should contain a maintainers parameter');
   t.end();
 });
 


### PR DESCRIPTION
Remove all modules that failed the latest 20.x release run. We need to be able to trust that a failed CITGM run is something that needs to be investigated.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
