### PR TITLE
lookup: increase acorn timeout to 30 minutes

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -31,7 +31,8 @@
   },
   "acorn": {
     "maintainers": "marijnh",
-    "skip": ["win32", "ppc"]
+    "skip": ["win32", "ppc"],
+    "timeout": 1800000
   },
   "ava": {
     "prefix": "v",


### PR DESCRIPTION
acorn needs more time so that it can install the test262 dependencies (which we then won't use/test, but what can you do?).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
