### PR TITLE
fix: get Jest green

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -244,7 +244,7 @@
   },
   "jest": {
     "prefix": "v",
-    "maintainers": ["cpojer", "scotthovestadt", "SimenB", "thymikee", "jeysal"],
+    "maintainers": ["cpojer", "SimenB", "thymikee", "jeysal"],
     "yarn": true,
     "install": ["install", "--no-immutable"],
     "scripts": ["build:js", "remove-examples", "test-ci-partial"],

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -246,6 +246,7 @@
     "prefix": "v",
     "maintainers": ["cpojer", "SimenB", "thymikee", "jeysal"],
     "yarn": true,
+    "head": true,
     "install": ["install", "--no-immutable"],
     "scripts": ["build:js", "remove-examples", "test-ci-partial"],
     "envVar": { "CI": true },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)

Ref #959.

I've gone through CITGM smoker builds from 3220 to 3228 (at the time of writing, the last completed run) and checked them all for failures with Jest.

- [3220](https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/3220/)
  - due to `punycode` deprecation, which will be fixed when we upgrade JSDOM to the latest (this is a breaking change, but I'll start landing those this weekend or next week)
  - There's also a [no space left on device](https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/3220/nodes=ubuntu1804-64/testReport/junit/(root)/citgm/jest_v29_6_2/) error. Extra weird here is that it uses 29.6.2, instead of 29.6.4
- [3221](https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/3221/)
  - Timed out on `fedora-last-latest-x64`, `fedora-latest-x64`, `rhel8-x64` and `debian10-x64`.
  - Same `no space left on device` for `ubuntu1804-64`
- [3222](https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/3222/)
  - Identical as 3220 - `punycode` deprecation and `no space left on device`
- [3223](https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/3223/)
  - only running `pino`
- [3224](https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/3224/)
  - only running `fastify`
- [3225](https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/3225/)
  - Timed out on `fedora-last-latest-x64`, `rhel8-x64` and `debian10-x64`
- [3226](https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/3226/)
  - only running `pino`
- [3227](https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/3227/)
  - only running `fastify`
- [3228](https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/3228/)
  - Failed with a mismatch in error message. My guess is that the version check [here](https://github.com/jestjs/jest/blob/cbe0ac1b7677df0f856b09e30180ec7916752c6b/packages/jest-config/src/__tests__/normalize.test.ts#L1102-L1104) was fooled by the node version present in the run?

---

Based on those I think there are 4 kinds of errors

1. For Node 21, the deprecation of `punycode`. This is addressed by [upgrading JSDOM](https://github.com/jestjs/jest/pull/13825) and patching `psl` (which has [already landed](https://github.com/jestjs/jest/pull/14502))
1. `no space left on device` - I don't think Jest can do anything about that?
1. 18.x run fools version detection, so we assert on the wrong error message on syntax error in JSON - I'll take a look at this
1. Timeouts.

Number 4 is where this PR comes in - I'd like to figure out what we can do (I'll dig into the 18.x error later). I think there's 3 options

1. Skip the platforms that are timing out
1. Increase the timeout
1. Only run a subset of the tests

I don't think number 1 is the way to go as, from what I can tell, Jest is only running on those 5 platforms 😅 But maybe if we only run on e.g. Ubuntu (and its disk space issues are sorted) that's good enough for Jest, and it'd still detect issues. Mac and Windows are already skipped, and I don't think wider coverage of Linux platforms provides much additional value.

Is number 2 feasible? The timeout is already at 30 minutes, so I'm not sure...

Number 3 seems the most likely. If that's what we want to do, I can spend some time and try to put together a subset of the tests that exercises the parts of Jest that I think are most likely to discover regressions in Node (usage of `vm` API (especially the ESM parts of it)).

---

For now - this PR is opened as a draft and only removes a maintainer that haven't been one for a few years at this point.