### PR TITLE
fix: use `head` of `prom-client`

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -375,6 +375,7 @@
   "prom-client": {
     "prefix": "v",
     "maintainers": ["siimon", "zbjornson", "SimenB"]
+    "head": true
   },
   "pug": {
     "prefix": "pug@",

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -374,7 +374,7 @@
   },
   "prom-client": {
     "prefix": "v",
-    "maintainers": ["siimon", "zbjornson", "SimenB"]
+    "maintainers": ["siimon", "zbjornson", "SimenB"],
     "head": true
   },
   "pug": {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)

From looking at the results of runs 3220-3228, `prom-client` only fails on Windows. I'd like to first try and see if using `head` works (as we've upgraded the version of Jest used there).

If this doesn't work, I guess we can skip Windows platform instead.