### PR TITLE
chore: increase timeout for flaky test

### DIFF
--- a/test/test-citgm.js
+++ b/test/test-citgm.js
@@ -3,6 +3,7 @@ import { test } from 'tap';
 import { Tester } from '../lib/citgm.js';
 
 test('citgm: omg-i-pass', (t) => {
+  t.setTimeout(30000);
   t.plan(2);
   const options = {
     hmac: null,
@@ -28,6 +29,7 @@ test('citgm: omg-i-pass', (t) => {
 });
 
 test('citgm: omg-i-pass from git url', (t) => {
+  t.setTimeout(30000);
   t.plan(3);
 
   const options = {


### PR DESCRIPTION
This test times out a lot in GitHub Actions. Increase the timeout.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
