### PR TITLE
lookup: use GitHub head for serialport

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -420,7 +420,7 @@
     "comment": "postlint script fails"
   },
   "serialport": {
-    "prefix": "serialport@",
+    "head": true,
     "tags": "native",
     "maintainers": "reconbot"
   },


### PR DESCRIPTION
This will hopefully fix serialport when run against a `-pre` version of Node.js. Eventually, this fix will be in a release of serialport, but it's in GitHub now.

Closes: https://github.com/nodejs/citgm/issues/991

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
