### PR TITLE
lookup: skip platforms for serialport

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -420,6 +420,7 @@
     "comment": "postlint script fails"
   },
   "serialport": {
+    "skip": ["ppc", "s390x"],
     "head": true,
     "tags": "native",
     "maintainers": "reconbot"


### PR DESCRIPTION
This skips the remaining platforms that still pose a problem for verifying serialport against a `-pre` version of Node.js
Relates to: [#992](https://github.com/nodejs/citgm/pull/992)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
