### PR TITLE
chore: remove torrent-stream

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -501,10 +501,6 @@
     "stripAnsi": true,
     "maintainers": "mcollina"
   },
-  "torrent-stream": {
-    "prefix": "v",
-    "maintainers": "mafintosh"
-  },
   "uglify-js": {
     "prefix": "v",
     "flaky": ["ppc", "darwin"],


### PR DESCRIPTION
Removing `torrent-stream` from lib/lookup.json since it has been failing
regularly on both `v18.x` and `v20.x` release lines due to a timeout.

Refs: https://github.com/nodejs/citgm/issues/1000