### PR TITLE
chore: mark pino as flaky

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -368,6 +368,7 @@
   "pino": {
     "prefix": "v",
     "maintainers": "mcollina",
+    "flaky": true,
     "skip": ["aix", "s390x"]
   },
   "prom-client": {


### PR DESCRIPTION
Marking `pino` as flaking since it's failing in many platforms for both `v18.x` and `v20.x` release lines.

Refs: https://github.com/nodejs/citgm/issues/988