### PR TITLE
chore: increasing timeout for ava

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -32,7 +32,8 @@
   "ava": {
     "prefix": "v",
     "skip": ["14", "ppc", "win32", "x86", "rhel", "aix", "ia32"],
-    "maintainers": ["sindresorhus", "novemberborn"]
+    "maintainers": ["sindresorhus", "novemberborn"],
+    "timeout": 600000
   },
   "bcrypt": {
     "prefix": "v",


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)

In 2 cases in the recent builds ava failed due to timeouts. This PR increase the ava timeout to **10 minutes**.

This is the issue reported: 
```
153 tests passed
11 tests remained pending after a timeout
```

Reference to the issues: 
- https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/3302/nodes=fedora-last-latest-x64/testReport/junit/(root)/citgm/ava_v5_3_1/
- https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/3297/nodes=fedora-last-latest-x64/testReport/junit/(root)/citgm/ava_v5_3_1/

I'm not sure if this is a proper solution. As an alternative, we can set the module as flaky.

@sindresorhus @novemberborn I'm tagging you since you are listed as the package maintainers, maybe you have more info about how we can solve the issue :) 