### PR TITLE
chore: increased semver timeout

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -435,7 +435,8 @@
     "maintainers": "isaacs",
     "expectFail": "fips",
     "envVar": { "npm_config_ignore_scripts": "true" },
-    "comment": "postlint script fails"
+    "comment": "postlint script fails",
+    "timeout": 300000
   },
   "serialport": {
     "skip": ["ppc", "s390x"],


### PR DESCRIPTION
During the last [CI run](https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/3310/nodes=rhel8-ppc64le/testReport/(root)/citgm/semver_v7_5_4/), semver failed due to a timeout. This PR will increase the timeout time to 5 minutes

##### Checklist

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)


