### PR TITLE
chore: skip failing packages on macOS

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -90,7 +90,7 @@
     "prefix": "v",
     "tags": "native",
     "maintainers": ["3rdeden", "einaros", "lpinca"],
-    "skip": "win32"
+    "skip": ["win32", "darwin"]
   },
   "cheerio": {
     "skip": ["aix", "win32"],
@@ -281,7 +281,7 @@
   "leveldown": {
     "head": true,
     "useGitClone": true,
-    "skip": ["ppc", "s390"],
+    "skip": ["ppc", "s390", "darwin"],
     "tags": "native",
     "maintainers": ["ralphtheninja", "vweevers"]
   },
@@ -307,7 +307,8 @@
   "microtime": {
     "prefix": "v",
     "tags": "native",
-    "maintainers": "wadey"
+    "maintainers": "wadey",
+    "skip": ["darwin"]
   },
   "mime": {
     "prefix": "v",


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)

Three packages are always failing during the install phase: 
- Failed on [3310](https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/3310/)
- Failed on [3309](https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/3309/testReport/)
- Failed on [3300](https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/3300/nodes=osx1015/testReport/)