### PR TITLE
chore: disable underscore on macOS

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -512,7 +512,7 @@
   },
   "underscore": {
     "flaky": ["aix", "s390"],
-    "skip": "win32",
+    "skip": ["win32", "darwin"],
     "maintainers": "jashkenas"
   },
   "uuid": {


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)

Underscore is constantly failing on Node.js v18.x:
- https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/3310/nodes=osx1015/testReport/(root)/citgm/underscore_v1_13_6/
- https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/3309/nodes=osx1015/testReport/(root)/citgm/underscore_v1_13_6/
- https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/3300/nodes=osx1015/testReport/(root)/citgm/underscore_v1_13_6/

This PR will disable underscore for now. 

@jashkenas you are listed as the maintainer of this package, can you please take a look at the issue and evaluate if is a legitimate issue or a false positive from citgm that we can fix? :) 
By running `citgm underscore` I'm currently not able to reproduce the issue on my (macOS) machine.