### PR TITLE
Semver timeout increased for single test

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -438,7 +438,8 @@
     "expectFail": "fips",
     "envVar": { "npm_config_ignore_scripts": "true" },
     "comment": "postlint script fails",
-    "timeout": 300000
+    "timeout": 300000,
+    "scripts": ["test -- --timeout 60000"]
   },
   "serialport": {
     "skip": ["ppc", "s390x"],


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)

Even if we increased the overall Semver test suite timeout in #1004, some tests still fail due to timeout. 
https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/3318/nodes=rhel8-ppc64le/testReport/junit/(root)/citgm/semver_v7_5_4/

This change will bring the timeout for the single test to 60s.
I'm not sure if this is a proper solution, but we can give it a shot.