### PR TITLE
test: avoid colliding sandboxes

### DIFF
--- a/test/npm/test-npm-install.js
+++ b/test/npm/test-npm-install.js
@@ -12,7 +12,7 @@ import { npmContext } from '../helpers/make-context.js';
 const { test } = tap;
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const sandbox = join(tmpdir(), `citgm-${Date.now()}`);
+const sandbox = join(tmpdir(), `citgm-${Date.now()}-npm-install`);
 const fixtures = join(__dirname, '..', 'fixtures');
 const moduleFixtures = join(fixtures, 'omg-i-pass');
 const moduleTemp = join(sandbox, 'omg-i-pass');

--- a/test/npm/test-npm-test.js
+++ b/test/npm/test-npm-test.js
@@ -12,7 +12,7 @@ import { test as packageManagerTest } from '../../lib/package-manager/test.js';
 const { test } = tap;
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const sandbox = join(tmpdir(), `citgm-${Date.now()}`);
+const sandbox = join(tmpdir(), `citgm-${Date.now()}-npm-test`);
 const fixtures = join(__dirname, '..', 'fixtures');
 
 const passFixtures = join(fixtures, 'omg-i-pass');

--- a/test/reporter/test-reporter-junit.js
+++ b/test/reporter/test-reporter-junit.js
@@ -22,7 +22,7 @@ const fixturesPath = join(
   '..',
   'fixtures'
 );
-const sandbox = join(tmpdir(), `citgm-${Date.now()}`);
+const sandbox = join(tmpdir(), `citgm-${Date.now()}-test-reporter-junit`);
 const outputFile = join(sandbox, 'test.xml');
 const outputFileAppend = join(sandbox, 'test-append.xml');
 

--- a/test/reporter/test-reporter-tap.js
+++ b/test/reporter/test-reporter-tap.js
@@ -22,7 +22,7 @@ const fixturesPath = join(
   '..',
   'fixtures'
 );
-const sandbox = join(tmpdir(), `citgm-${Date.now()}`);
+const sandbox = join(tmpdir(), `citgm-${Date.now()}-test-reporter-tap`);
 const outputFile = join(sandbox, 'test.tap');
 const outputFileAppend = join(sandbox, 'test-append.tap');
 const outputFileAppendBlank = join(sandbox, 'test-append-blank.tap');

--- a/test/test-grab-project.js
+++ b/test/test-grab-project.js
@@ -14,7 +14,7 @@ import { grabProject } from '../lib/grab-project.js';
 const { test } = tap;
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const sandbox = join(tmpdir(), `citgm-${Date.now()}`);
+const sandbox = join(tmpdir(), `citgm-${Date.now()}-grab-project`);
 const fixtures = join(__dirname, 'fixtures');
 
 test('grab-project: setup', async () => {

--- a/test/test-timeout.js
+++ b/test/test-timeout.js
@@ -10,7 +10,7 @@ import { npmContext } from './helpers/make-context.js';
 
 const { test } = tap;
 
-const sandbox = join(tmpdir(), `citgm-${Date.now()}`);
+const sandbox = join(tmpdir(), `citgm-${Date.now()}-test-timeout`);
 
 let packageManagers;
 

--- a/test/yarn/test-yarn-install.js
+++ b/test/yarn/test-yarn-install.js
@@ -11,7 +11,7 @@ import { npmContext } from '../helpers/make-context.js';
 
 const { test } = tap;
 
-const sandbox = join(tmpdir(), `citgm-${Date.now()}`);
+const sandbox = join(tmpdir(), `citgm-${Date.now()}-yarn-install`);
 const fixtures = join(
   dirname(fileURLToPath(import.meta.url)),
   '..',

--- a/test/yarn/test-yarn-test.js
+++ b/test/yarn/test-yarn-test.js
@@ -11,7 +11,7 @@ import { test as packageManagerTest } from '../../lib/package-manager/test.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const sandbox = join(tmpdir(), `citgm-${Date.now()}`);
+const sandbox = join(tmpdir(), `citgm-${Date.now()}-yarn-test`);
 const fixtures = join(__dirname, '..', 'fixtures');
 
 const passFixtures = join(fixtures, 'omg-i-pass');


### PR DESCRIPTION
I was getting errors on my machine because multiple tests were creating sandboxes with the same name, because `citgm-${Date.now()}` wasn’t unique enough.