### PR TITLE
lib: log correct version and sha for -c option

### DIFF
--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -111,6 +111,9 @@ export class Tester extends EventEmitter {
         flaky: this.module.flaky,
         expectFail: this.module.expectFail
       };
+
+      if (this.options.sha) payload.sha = this.module.sha;
+
       if (err) {
         if (!payload.expectFail) {
           this.emit('fail', err);

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -143,12 +143,13 @@ export function lookup(context) {
           context.module.ref = ref;
         } else {
           const gitHead = rep.head || rep.ignoreGitHead ? null : meta.gitHead;
+          const sha = context.options.sha || rep.sha || gitHead;
           const url = makeUrl(
             getRepo(rep.repo, meta),
             rep.head ? null : detail.fetchSpec,
             meta['dist-tags'],
             rep.head ? null : rep.prefix,
-            context.options.sha || rep.sha || gitHead
+            sha
           );
           context.emit(
             'data',
@@ -194,16 +195,12 @@ export function lookup(context) {
         : defaultMatcher.isMatch(rep.expectFail);
     } else {
       context.emit('data', 'info', 'lookup-notfound', detail.name);
+      const sha = context.options.sha || meta.gitHead;
       if (meta.gitHead) {
-        const url = makeUrl(
-          getRepo(null, meta),
-          null,
-          null,
-          null,
-          context.options.sha || meta.gitHead
-        );
+        const url = makeUrl(getRepo(null, meta), null, null, null, sha);
         context.emit('data', 'info', 'lookup-githead', url);
         context.module.raw = url;
+        context.module.sha = sha;
       }
     }
   }

--- a/lib/package-manager/test.js
+++ b/lib/package-manager/test.js
@@ -33,6 +33,8 @@ export async function test(packageManager, context) {
   let data;
   try {
     data = await readPackage(join(wd, 'package.json'), false);
+    // Explicitly set the version to the value in the downloaded package.json.
+    context.module.version = data.version;
   } catch (err) {
     throw new Error('Package.json Could not be found');
   }

--- a/lib/reporter/logger.js
+++ b/lib/reporter/logger.js
@@ -8,6 +8,8 @@ function logModule(log, logType, module) {
   log[logType](chalk.yellow('module name:'), module.name);
   if (!module.skipped) {
     log[logType](chalk.yellow('version:'), module.version);
+
+    if (module.sha) log[logType](chalk.yellow('sha:'), module.sha);
   }
   if (module.error) {
     if (!module.testOutput) module.testOutput = '';


### PR DESCRIPTION
The main motivation here is to fix misleading version output when using the `-c` option.

```console
$ npx citgm -v verbose -c 37c34bad omg-i-pass 
info: starting            | omg-i-pass          
verbose: omg-i-pass using-uid| 501                 
verbose: omg-i-pass using-gid| 20                  
verbose: omg-i-pass using-node| /Users/bgriggs/.nvm/versions/node/v20.9.0/bin/node
verbose: omg-i-pass mk.tempdir| /var/folders/9g/93qrln9j5yq3396zcjzsghf00000gn/T/11c4180e-ff8e-4b33-8641-5dfa4dc76c80
verbose: omg-i-pass npm-view | Retrieving Meta Data
verbose: omg-i-pass npm-view | Data retrieved      
info: lookup              | omg-i-pass          
info: lookup-notfound     | omg-i-pass          
info: lookup-githead      | https://github.com/TheAlphaNerd/omg-i-pass/archive/37c34bad.tar.gz
info: omg-i-pass npm:     | Downloading project: https://github.com/TheAlphaNerd/omg-i-pass/archive/37c34bad.tar.gz
info: omg-i-pass npm:     | Project downloaded 37c34bad.tar.gz
info: omg-i-pass npm:     | npm install started 
verbose: omg-i-pass npm:     | Using temp directory: "/var/folders/9g/93qrln9j5yq3396zcjzsghf00000gn/T/11c4180e-ff8e-4b33-8641-5dfa4dc76c80/npm_config_
verbose: omg-i-pass npm-install:| up to date in 103ms 
info: omg-i-pass npm:     | npm install successfully completed
info: omg-i-pass npm:     | test suite started  
verbose: omg-i-pass npm-test:| > omg-i-pass@2.0.1 test
verbose:                     | > exit 0               
info: passing module(s)   |                     
info: module name:        | omg-i-pass          
info: version:            | 3.0.0               
info: done                | The smoke test has passed.
info: duration            | test duration: 1666ms
````

Note that `omg-i-pass@2.0.1 test` is what was run as expected (corresponding to https://github.com/MylesBorins/omg-i-pass/commit/37c34bad563599782c622baf3aaf55776fbc38a8) but CITGM reports it as latest: `info: version: | 3.0.0`. 

With this change:

```console
$ node ./bin/citgm -v verbose -c 37c34bad omg-i-pass 
info: starting            | omg-i-pass          
verbose: omg-i-pass using-uid| 501                 
verbose: omg-i-pass using-gid| 20                  
verbose: omg-i-pass using-node| /Users/bgriggs/.nvm/versions/node/v20.9.0/bin/node
verbose: omg-i-pass mk.tempdir| /var/folders/9g/93qrln9j5yq3396zcjzsghf00000gn/T/954b0474-9012-486c-b7d8-a4cec87a279e
verbose: omg-i-pass npm-view | Retrieving Meta Data
verbose: omg-i-pass npm-view | Data retrieved      
info: lookup              | omg-i-pass          
info: lookup-notfound     | omg-i-pass          
info: lookup-githead      | https://github.com/TheAlphaNerd/omg-i-pass/archive/37c34bad.tar.gz
info: omg-i-pass npm:     | Downloading project: https://github.com/TheAlphaNerd/omg-i-pass/archive/37c34bad.tar.gz
info: omg-i-pass npm:     | Project downloaded 37c34bad.tar.gz
info: omg-i-pass npm:     | npm install started 
verbose: omg-i-pass npm:     | Using temp directory: "/var/folders/9g/93qrln9j5yq3396zcjzsghf00000gn/T/954b0474-9012-486c-b7d8-a4cec87a279e/npm_config_
verbose: omg-i-pass npm-install:| up to date in 128ms 
info: omg-i-pass npm:     | npm install successfully completed
info: omg-i-pass npm:     | test suite started  
verbose: omg-i-pass npm-test:| > omg-i-pass@2.0.1 test
verbose:                     | > exit 0               
info: passing module(s)   |                     
info: module name:        | omg-i-pass          
info: version:            | 2.0.1               
info: sha:                | 37c34bad            
info: done                | The smoke test has passed.
info: duration            | test duration: 1725ms
```

I also added `info: sha: | 37c34bad` as extra log information _only_ when using the `-c` option because it's possible multiple commits will reference the same version, and the explicit debug information seems like it would be useful.

This was a bit of a 🐰 🕳️  so if anyone has a better suggestion for how to correct this feel free 🙂 

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
