### PR TITLE
lookup: remove vinyl-fs

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -535,12 +535,6 @@
     "maintainers": ["contra", "phated"],
     "skip": "win32"
   },
-  "vinyl-fs": {
-    "prefix": "v",
-    "head": true,
-    "maintainers": ["contra", "phated"],
-    "skip": true
-  },
   "watchify": {
     "prefix": "v",
     "flaky": ["ppc", "s390", "ubuntu", "rhel"],


### PR DESCRIPTION
Refs: https://github.com/nodejs/citgm/issues/444
Refs: https://github.com/nodejs/citgm/issues/537

----

This module has been marked flaky since at least 2017, and skipped for 3 years. At this point, I think we should consider removing it as it hasn't been used for our regression testing for so long. The test suite also consistently fails locally for me on Node.js 18+, and on all platforms ([refs](https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker-nobuild/lastCompletedBuild/testReport/)).