### PR TITLE
lib: drop skipped modules

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -387,11 +387,6 @@
     "maintainers": "koistya",
     "skip": ["12", "win32"]
   },
-  "stylus": {
-    "flaky": ["win32", "aix"],
-    "maintainers": "tj",
-    "skip": ">=11"
-  },
   "tape": {
     "head": true,
     "prefix": "v",

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -344,12 +344,6 @@
     "maintainers": "kriskowal",
     "skip": "win32"
   },
-  "readable-stream": {
-    "prefix": "v",
-    "flaky": ["ppc"],
-    "maintainers": "nodejs/streams",
-    "skip": [">=12", "win32"]
-  },
   "ref": {
     "flaky": "aix",
     "tags": "native",

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -344,12 +344,6 @@
     "maintainers": "kriskowal",
     "skip": "win32"
   },
-  "react": {
-    "prefix": "v",
-    "maintainers": ["acdlite", "gaearon", "sophiebits"],
-    "yarn": true,
-    "skip": [">=12", "aix", "s390", "ppc"]
-  },
   "readable-stream": {
     "prefix": "v",
     "flaky": ["ppc"],

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -297,11 +297,6 @@
     "skip": "win32",
     "maintainers": "ljharb"
   },
-  "mkdirp": {
-    "head": true,
-    "skip": ["win32", true],
-    "maintainers": "isaacs"
-  },
   "mocha": {
     "prefix": "v",
     "skip": true,

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -344,12 +344,6 @@
     "maintainers": "kriskowal",
     "skip": "win32"
   },
-  "ref": {
-    "flaky": "aix",
-    "tags": "native",
-    "maintainers": "TooTallNate",
-    "skip": [true, "12", "win32"]
-  },
   "resolve": {
     "prefix": "v",
     "maintainers": "ljharb",

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -448,11 +448,5 @@
     "flaky": ["ppc", "rhel"],
     "expectFail": "fips",
     "maintainers": ["SBoudrias", "sindresorhus"]
-  },
-  "zeromq": {
-    "prefix": "v",
-    "tags": "native",
-    "maintainers": ["lgeiger", "rgbkrk"],
-    "skip": [true, "s390", "ppc", "win32"]
   }
 }

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -270,13 +270,6 @@
     "tags": "native",
     "maintainers": ["ralphtheninja", "vweevers"]
   },
-  "libxmljs": {
-    "prefix": "v",
-    "flaky": ["aix", "sles", "rhel", "darwin"],
-    "skip": ">=12",
-    "tags": "native",
-    "maintainers": "defunctzombie"
-  },
   "lodash": {
     "expectFail": "fips",
     "maintainers": "jdalton"

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -427,12 +427,6 @@
     "maintainers": ["contra", "phated"],
     "skip": "win32"
   },
-  "vinyl-fs": {
-    "prefix": "v",
-    "head": true,
-    "maintainers": ["contra", "phated"],
-    "skip": true
-  },
   "watchify": {
     "prefix": "v",
     "flaky": ["ppc", "s390", "ubuntu", "rhel"],

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -190,11 +190,6 @@
     "prefix": "v",
     "skip": true
   },
-  "graceful-fs": {
-    "prefix": "v",
-    "maintainers": "isaacs",
-    "skip": ">=11"
-  },
   "gulp": {
     "prefix": "v",
     "flaky": ["ppc", "rhel"],

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -412,13 +412,6 @@
     "stripAnsi": true,
     "maintainers": "mcollina"
   },
-  "uglify-js": {
-    "prefix": "v",
-    "flaky": ["ppc", "darwin"],
-    "maintainers": "mishoo",
-    "skip": ["12", true],
-    "comment": "Tests timeout"
-  },
   "underscore": {
     "flaky": ["aix"],
     "skip": ["win32", "darwin"],

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -297,10 +297,6 @@
     "skip": "win32",
     "maintainers": "ljharb"
   },
-  "moment": {
-    "maintainers": "ichernev",
-    "skip": [true, "ppc", "s390"]
-  },
   "multer": {
     "prefix": "v",
     "skip": "win32",

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -297,13 +297,6 @@
     "skip": "win32",
     "maintainers": "ljharb"
   },
-  "mocha": {
-    "prefix": "v",
-    "skip": true,
-    "expectFail": "fips",
-    "maintainers": ["tj", "boneskull"],
-    "comment": "Skipped because requires to install Google Chrome for browser tests"
-  },
   "moment": {
     "maintainers": "ichernev",
     "skip": [true, "ppc", "s390"]

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -375,12 +375,6 @@
     "tags": "native",
     "maintainers": "reconbot"
   },
-  "spdy": {
-    "prefix": "v",
-    "flaky": ["aix", "sles"],
-    "skip": ">=12",
-    "maintainers": "diasdavid"
-  },
   "spdy-transport": {
     "prefix": "v",
     "skip": ">=12",

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -75,12 +75,6 @@
     "expectFail": "fips",
     "maintainers": "substack"
   },
-  "bson": {
-    "prefix": "V",
-    "maintainers": "christkv",
-    "scripts": ["test-node"],
-    "skip": true
-  },
   "bufferutil": {
     "prefix": "v",
     "tags": "native",

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -375,12 +375,6 @@
     "tags": "native",
     "maintainers": "reconbot"
   },
-  "spdy-transport": {
-    "prefix": "v",
-    "skip": ">=12",
-    "flaky": "aix",
-    "maintainers": "diasdavid"
-  },
   "split2": {
     "prefix": "v",
     "maintainers": "mcollina",

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -14,12 +14,6 @@
     "prefix": "v",
     "flaky": true
   },
-  "@hapi/hapi": {
-    "prefix": "v",
-    "maintainers": ["devinivy", "DavidTPate", "AdriVanHoudt"],
-    "skip": ["darwin", "aix", "debian", ">=17"],
-    "comment": "Verbatim DNS output"
-  },
   "@hapi/shot": {
     "maintainers": "cjihrig",
     "prefix": "v"

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -334,14 +334,6 @@
     "maintainers": ["siimon", "zbjornson", "SimenB"],
     "head": true
   },
-  "pug": {
-    "prefix": "pug@",
-    "yarn": true,
-    "maintainers": ["tj", "ForbesLindesay"],
-    "skip": ["win32", "aix", ">=16"],
-    "comment": "Error message changes in V8 9.3",
-    "repo": "https://github.com/pugjs/pug"
-  },
   "pumpify": {
     "prefix": "v",
     "maintainers": "mafintosh",

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -319,13 +319,6 @@
     "skip": ["win32"],
     "head": true
   },
-  "node-sass": {
-    "prefix": "v",
-    "tags": "native",
-    "maintainers": "xzyfer",
-    "comment": "Flaky because of test timeouts",
-    "skip": true
-  },
   "path-to-regexp": {
     "prefix": "v",
     "maintainers": "blakeembrey",

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -174,12 +174,6 @@
     "prefix": "v",
     "maintainers": ["mafintosh", "hughsk"]
   },
-  "fs-extra": {
-    "flaky": ["linux-ia32", "aix", "s390", "win32"],
-    "skip": ">=12",
-    "expectFail": "fips",
-    "maintainers": "jprichardson"
-  },
   "full-icu-test": {
     "prefix": "v",
     "maintainers": "srl295"

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -375,12 +375,6 @@
     "tags": "native",
     "maintainers": "reconbot"
   },
-  "socket.io": {
-    "maintainers": "rauchg",
-    "head": true,
-    "skip": ">=17",
-    "comment": "WS is not compatible"
-  },
   "spdy": {
     "prefix": "v",
     "flaky": ["aix", "sles"],

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -443,13 +443,6 @@
     "maintainers": ["einaros", "3rd-Eden", "lpinca"],
     "scripts": ["test -- --timeout 30000"]
   },
-  "yargs": {
-    "comment": "Install from source is currently broken due to TS error",
-    "prefix": "v",
-    "expectFail": "fips",
-    "maintainers": ["bcoe", "addaleax"],
-    "skip": true
-  },
   "yeoman-generator": {
     "prefix": "v",
     "flaky": ["ppc", "rhel"],


### PR DESCRIPTION
Following up on the recent bankruptcy of the CITGM, this PR removes all modules that are being skipped by either having a "skip: true" or because we're skipping all active release lines, for instance: ">= 17" or ">= 16". I know that the idea of "skip: true" was temporary, but some modules have been skipped for quite some time.

My suggestion for the modules that still want to be included in the current CITGM is to open a new PR to add it back so we guarantee our CITGM will not be red/failing until issues are fixed - please note a flaky CITGM affects directly the efforts of a release.

Before pinging module authors I'd like to get @nodejs/tsc approval since the list is big and I don't want to cause any more noise in their notification box.