### PR TITLE
lookup: remove EOL versions from lookup.json

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -37,12 +37,12 @@
   },
   "JSONStream": {
     "prefix": "v",
-    "skip": ["win32", "14"],
+    "skip": "win32",
     "maintainers": "dominictarr"
   },
   "ava": {
     "prefix": "v",
-    "skip": ["14", "ppc", "win32", "x86", "rhel", "aix", "ia32"],
+    "skip": ["ppc", "win32", "x86", "rhel", "aix", "ia32"],
     "maintainers": ["sindresorhus", "novemberborn"],
     "timeout": 600000
   },
@@ -386,7 +386,7 @@
     "tags": "native",
     "flaky": "ppc",
     "maintainers": "koistya",
-    "skip": ["12", "win32"]
+    "skip": "win32"
   },
   "tape": {
     "head": true,


### PR DESCRIPTION
In an effort to tidy up the skip/flaky tags.

##### Checklist

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
      
  
 
