### PR TITLE
lookup: unskip bufferutil on win32

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -78,8 +78,7 @@
   "bufferutil": {
     "prefix": "v",
     "tags": "native",
-    "maintainers": ["3rdeden", "einaros", "lpinca"],
-    "skip": "win32"
+    "maintainers": ["3rdeden", "einaros", "lpinca"]
   },
   "cheerio": {
     "skip": ["aix", "win32"],


### PR DESCRIPTION
The condition was added in 861b02bc260a but it is not clear why. Maybe the tests pass now.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
