### PR TITLE
lookup: fix handling of npm-package-arg result

### DIFF
--- a/lib/citgm.js
+++ b/lib/citgm.js
@@ -1,7 +1,5 @@
-import { createHash } from 'crypto';
 import { EventEmitter } from 'events';
 
-import npa from 'npm-package-arg';
 import BufferList from 'bl';
 import which from 'which';
 
@@ -15,6 +13,7 @@ import {
 } from './package-manager/index.js';
 import * as tempDirectory from './temp-directory.js';
 import { unpack } from './unpack.js';
+import { parsePackageArg } from './utils.js';
 
 export const windows = process.platform === 'win32';
 
@@ -53,18 +52,6 @@ function init(context) {
   );
 }
 
-function sha1(mod) {
-  const shasum = createHash('sha1');
-  shasum.update(mod);
-  return shasum.digest('hex');
-}
-
-function extractDetail(mod) {
-  const detail = npa(mod); // Will throw if mod is invalid
-  detail.name = detail.name || `noname-${sha1(mod)}`;
-  return detail;
-}
-
 /**
  * The Tester will emit specific events once it is run:
  *  - end = emitted when the test is complete
@@ -75,7 +62,7 @@ function extractDetail(mod) {
 export class Tester extends EventEmitter {
   constructor(mod, options) {
     super();
-    this.module = extractDetail(mod);
+    this.module = parsePackageArg(mod);
     this.options = options;
     this.testOutput = new BufferList();
     this.testError = new BufferList();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,7 @@
+import { createHash } from 'node:crypto';
 import fs from 'node:fs/promises';
+
+import npa from 'npm-package-arg';
 
 /**
  * Remove directory recursively with retries for Windows.
@@ -11,4 +14,19 @@ export async function removeDirectory(path) {
     maxRetries: 10,
     retryDelay: 50
   });
+}
+
+function sha1(mod) {
+  const shasum = createHash('sha1');
+  shasum.update(mod);
+  return shasum.digest('hex');
+}
+
+export function parsePackageArg(mod) {
+  const detail = npa(mod); // Will throw if mod is invalid
+  detail.name = detail.name || `noname-${sha1(mod)}`;
+  if (detail.fetchSpec === '*') {
+    detail.fetchSpec = 'latest';
+  }
+  return detail;
 }


### PR DESCRIPTION
Convert `fetchSpec` to "latest" when it's "*" to accomodate for
the breaking change that happened in version 10 of the library.
Make lookup tests closer to reality by using the package arg parser
there and constructing fake module metadata that look more like
what the npm API returns.

Refs: https://github.com/nodejs/citgm/pull/628
Refs: https://github.com/npm/npm-package-arg/releases/tag/v10.0.0

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
