### PR TITLE
lookup: drop mime and jest from CITGM

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -290,11 +290,6 @@
     "tags": "native",
     "maintainers": "wadey"
   },
-  "mime": {
-    "prefix": "v",
-    "maintainers": "broofa",
-    "skip": "win32"
-  },
   "minimist": {
     "npm": true,
     "skip": "win32",

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -231,17 +231,6 @@
     "prefix": "v",
     "maintainers": "juliangruber"
   },
-  "jest": {
-    "prefix": "v",
-    "maintainers": ["cpojer", "SimenB", "thymikee", "jeysal"],
-    "yarn": true,
-    "head": true,
-    "install": ["install", "--no-immutable"],
-    "scripts": ["build:js", "remove-examples", "test-ci-partial"],
-    "envVar": { "CI": true },
-    "skip": ["aix", "s390x", "ppc", "darwin", "win32"],
-    "timeout": 1800000
-  },
   "jose": {
     "maintainers": ["panva"],
     "prefix": "v",


### PR DESCRIPTION
As discussed in the last Release WG meeting, we'll remove the offending modules and according to https://github.com/nodejs/citgm/issues/1060, those modules are failing often unrelated to machine errors.

cc: @nodejs/releasers 