### PR TITLE
lookup: add openid-client

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -334,6 +334,12 @@
   "on-finished": {
     "maintainers": "wesleytodd"
   },
+  "openid-client": {
+    "maintainers": ["panva"],
+    "prefix": "v",
+    "scripts": ["tap:node"],
+    "skip": ["<20"]
+  },
   "path-to-regexp": {
     "prefix": "v",
     "maintainers": "blakeembrey",


### PR DESCRIPTION
adds [`openid-client`](https://www.npmjs.com/package/openid-client) (and intrinsically also [`oauth4webapi`](https://www.npmjs.com/package/oauth4webapi) and [`oidc-provider`](https://www.npmjs.com/package/oidc-provider))

This covers the `Web Cryptography API` and `Fetch API` modules.