### PR TITLE
fix: resolve symlinks for test context's path

### DIFF
--- a/lib/temp-directory.js
+++ b/lib/temp-directory.js
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { promises as fs } from 'fs';
+import { promises as fs, realpathSync } from 'fs';
 import { randomUUID } from 'crypto';
 import { tmpdir } from 'os';
 
@@ -7,9 +7,9 @@ import { removeDirectory } from './utils.js';
 
 export async function create(context) {
   if (context.options && context.options.tmpDir) {
-    context.path = join(context.options.tmpDir, randomUUID());
+    context.path = join(realpathSync(context.options.tmpDir), randomUUID());
   } else {
-    context.path = join(tmpdir(), randomUUID());
+    context.path = join(realpathSync(tmpdir()), randomUUID());
   }
   context.emit(
     'data',

--- a/lib/temp-directory.js
+++ b/lib/temp-directory.js
@@ -7,10 +7,14 @@ import { removeDirectory } from './utils.js';
 
 export async function create(context) {
   if (context.options && context.options.tmpDir) {
-    context.path = join(realpathSync(context.options.tmpDir), randomUUID());
+    context.path = join(context.options.tmpDir, randomUUID());
   } else {
-    context.path = join(realpathSync(tmpdir()), randomUUID());
+    context.path = join(tmpdir(), randomUUID());
   }
+
+  await fs.mkdir(context.path, { recursive: true });
+  context.path = realpathSync(context.path);
+
   context.emit(
     'data',
     'verbose',


### PR DESCRIPTION
On macOS, `os.tmpdir()` returns a path that contains a symbolic links.
This can cause issues with modules that expect the environment to only
contain real paths. For example, the `resolve` module uses the HOME env
variable, which is derived from the context's path.

<details>

<summary>
Example of fixed error:
</summary>

```
error: error:              | not ok 450 sanity check: require.resolve finds HNM `baz`
error:                     | ---
error:                     | operator: equal
error:                     | expected: |-
error:                     | '/var/folders/9n/05y6s4ls78515vmnbd86hktm0000gn/T/fc57c0d4-4128-4194-8fb0-f862577957ef/home/.node_modules/baz/quux.js'
error:                     | actual: |-
error:                     | '/private/var/folders/9n/05y6s4ls78515vmnbd86hktm0000gn/T/fc57c0d4-4128-4194-8fb0-f862577957ef/home/.node_modules/baz/quux.js'
error:                     | at: <anonymous> (/private/var/folders/9n/05y6s4ls78515vmnbd86hktm0000gn/T/fc57c0d4-4128-4194-8fb0-f862577957ef/resolve/test/home
error:                     | stack: |-
error:                     | Error: sanity check: require.resolve finds HNM `baz`
error:                     | at Test.assert [as _assert] (/private/var/folders/9n/05y6s4ls78515vmnbd86hktm0000gn/T/fc57c0d4-4128-4194-8fb0-f862577957ef/resol
error:                     | at Test.strictEqual (/private/var/folders/9n/05y6s4ls78515vmnbd86hktm0000gn/T/fc57c0d4-4128-4194-8fb0-f862577957ef/resolve/node_
error:                     | at /private/var/folders/9n/05y6s4ls78515vmnbd86hktm0000gn/T/fc57c0d4-4128-4194-8fb0-f862577957ef/resolve/test/home_paths_sync.js
error:                     | at /private/var/folders/9n/05y6s4ls78515vmnbd86hktm0000gn/T/fc57c0d4-4128-4194-8fb0-f862577957ef/resolve/test/home_paths_sync.js
error:                     | at /private/var/folders/9n/05y6s4ls78515vmnbd86hktm0000gn/T/fc57c0d4-4128-4194-8fb0-f862577957ef/resolve/node_modules/mkdirp/ind
error:                     | at FSReqCallback.oncomplete (node:fs:189:23)
error:                     | ...
```

</details>