### PR TITLE
lookup: do not use head for `csv-parser`

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -113,6 +113,11 @@
     "maintainers": "ctalkington",
     "skip": "win32"
   },
+  "csv-parser": {
+    "head": true,
+    "flaky": "win32",
+    "maintainers": "mafintosh"
+  },
   "debug": {
     "maintainers": ["qix", "tootallnate"],
     "skip": [true, "aix", "ppc", "s390", "win32"],

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -113,11 +113,6 @@
     "maintainers": "ctalkington",
     "skip": "win32"
   },
-  "csv-parser": {
-    "head": true,
-    "flaky": "win32",
-    "maintainers": "mafintosh"
-  },
   "debug": {
     "maintainers": ["qix", "tootallnate"],
     "skip": [true, "aix", "ppc", "s390", "win32"],

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -114,7 +114,6 @@
     "skip": "win32"
   },
   "csv-parser": {
-    "head": true,
     "flaky": "win32",
     "maintainers": "mafintosh"
   },


### PR DESCRIPTION
The module is not maintained anymore and fails on Node.js >=22 because
its test suite uses the `esm` module (abandoned and broken).

