### PR TITLE
lookup: use head for `@hapi/shot`

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -23,6 +23,7 @@
   },
   "@hapi/shot": {
     "maintainers": "cjihrig",
+    "head": true,
     "prefix": "v"
   },
   "@yarnpkg/cli": {


### PR DESCRIPTION
There was no release in almost two years, but tests were fixed recently.

Refs:  https://github.com/hapijs/shot/commit/2dca4110dfa75c844479b2e0c74f0153379fa6bf
