### PR TITLE
lookup: fix npm install for `through2`

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -418,6 +418,7 @@
   "through2": {
     "maintainers": "rvagg",
     "prefix": "v",
+    "install": ["install", "--ignore-scripts"],
     "scripts": ["test:node"],
     "skip": ["aix", "win32"],
     "stripAnsi": true


### PR DESCRIPTION
Run it with `--ignore-scripts` so it doesn't try to install Puppeteer.
