### PR TITLE
lookup: increase timeout for `undici`

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -440,7 +440,8 @@
   },
   "undici": {
     "prefix": "v",
-    "maintainers": ["mcollina", "ronag"]
+    "maintainers": ["mcollina", "ronag"],
+    "timeout": 900000
   },
   "uuid": {
     "prefix": "v",


### PR DESCRIPTION
v22.x citgm runs are timing out for the following targets:

- debian12-x64
- fedora-latest-x64
- osx11
- aix72-ppc64