### PR TITLE
lookup: update jose

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -256,7 +256,7 @@
     "prefix": "v",
     "scripts": ["test", "tap:node"],
     "envVar": { "CITGM": true },
-    "skip": ["<20"]
+    "skip": ["<20", "win32"]
   },
   "jquery": {
     "skip": "win32",

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -256,8 +256,7 @@
     "prefix": "v",
     "scripts": ["test", "tap:node"],
     "envVar": { "CITGM": true },
-    "skip": ["aix"],
-    "comment": "esbuild doesn't support aix"
+    "skip": ["<20"]
   },
   "jquery": {
     "skip": "win32",


### PR DESCRIPTION
Updates the jose CITGM lookup section

- esbuild is no longer used during testing
- versions before 20.x are no longer supported
- skip win32 because the test scripts aren't compatible with windows

[both test scripts passing in jose's CI on 20, 22, and current](https://github.com/panva/jose/actions/runs/13477997120).