### PR TITLE
lookup: use HEAD for `express-session`

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -169,7 +169,8 @@
   },
   "express-session": {
     "prefix": "v",
-    "maintainers": "dougwilson"
+    "maintainers": "dougwilson",
+    "head": true
   },
   "fastify": {
     "maintainers": ["mcollina"],

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -169,7 +169,7 @@
   },
   "express-session": {
     "prefix": "v",
-    "maintainers": "dougwilson",
+    "maintainers": "ulisesGascon",
     "head": true
   },
   "fastify": {


### PR DESCRIPTION
We need https://github.com/expressjs/session/commit/67d61ee1799a8070dff4a5b759189be2023c7a62 until their next release.

