### PR TITLE
lookup: update multer for remove skip and flaky properties

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -309,9 +309,7 @@
   },
   "multer": {
     "prefix": "v",
-    "skip": "win32",
-    "maintainers": "linusu",
-    "flaky": ["darwin"]
+    "maintainers": ["linusu", "ulisesgascon"]
   },
   "nan": {
     "maintainers": ["nodejs/addon-api"],


### PR DESCRIPTION
The skip for win32 was added over 7 years ago (https://github.com/nodejs/citgm/pull/487) — is it still failing?
Also, Multer isn’t failing on macOS anymore. all the tests are passing on macOS (https://github.com/bjohansebas/multer/pull/1).

Closes #999 
Closes https://github.com/expressjs/multer/issues/1295

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
