### PR TITLE
lookup: add on-headers

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -334,6 +334,9 @@
   "on-finished": {
     "maintainers": "wesleytodd"
   },
+  "on-headers": {
+    "maintainers": ["blakeembrey"]
+  },
   "path-to-regexp": {
     "prefix": "v",
     "maintainers": "blakeembrey",


### PR DESCRIPTION
Unfortunately, this module monkey-patches `writeHead`. It’s an important module in the Express ecosystem and probably in other key packages that need to use it as a hook for `writeHead`. Adding it to CITGM wouldn’t be a bad idea while we wait for a solution in Node.js core that would allow us to deprecate this module.

cc: @wesleytodd @UlisesGascon @blakeembrey @ctcpip

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
