### PR TITLE
fix: replace deprecated `read-package-json`

### DIFF
--- a/lib/package-manager/test.js
+++ b/lib/package-manager/test.js
@@ -1,11 +1,8 @@
 import { join, dirname } from 'path';
-import { promisify } from 'util';
 
-import readPackageJson from 'read-package-json';
+import PackageJson from '@npmcli/package-json';
 import stripAnsi from 'strip-ansi';
 import which from 'which';
-
-const readPackage = promisify(readPackageJson);
 
 import { createOptions } from '../create-options.js';
 import { spawn } from '../spawn.js';
@@ -32,7 +29,8 @@ export async function test(packageManager, context) {
   );
   let data;
   try {
-    data = await readPackage(join(wd, 'package.json'), false);
+    const pkg = await PackageJson.load(wd);
+    data = pkg.content;
     // Explicitly set the version to the value in the downloaded package.json.
     context.module.version = data.version;
   } catch {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@npmcli/package-json": "^7.0.0",
     "async": "^3.2.6",
     "bl": "^6.0.16",
     "chalk": "^5.4.0",
@@ -44,7 +45,6 @@
     "npm-package-arg": "^12.0.1",
     "npm-which": "^3.0.1",
     "pnpm": "^9.15.1",
-    "read-package-json": "^7.0.1",
     "root-check": "^2.0.0",
     "semver": "^7.6.3",
     "strip-ansi": "^7.1.0",


### PR DESCRIPTION
> npm warn deprecated read-package-json@7.0.1: This package is no
  longer supported. Please use @npmcli/package-json instead.
