### PR TITLE
lookup: add yargs

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -470,6 +470,10 @@
     "maintainers": ["einaros", "3rd-Eden", "lpinca"],
     "scripts": ["test -- --timeout 30000"]
   },
+  "yargs": {
+    "prefix": "v",
+    "maintainers": ["bcoe"]
+  },
   "yeoman-generator": {
     "prefix": "v",
     "flaky": ["ppc", "rhel"],


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

Due to https://github.com/yargs/yargs/issues/2509 I believe `yargs` should be in CITM.

Currently it is failing because `yargs` does not [ship a lockfile](https://github.com/yargs/yargs/blob/main/.gitignore#L8) and uses `prettier` so it pulls in `prettier` breaking formatting changes into `lint`. I can open a PR to address this in `yargs` or we can exclude `lint` here whatever folks prefer (obviously easier to fix here). 

Additionally, I think the issue that occurred was on `yargs@17` not `18`. Do we have precedent for testing multiple majors? I coudln't find any, but honestly `express` should have this as well until we can EOL v4. So any pointers on that would be great and I can open PRs for that.

<details>
 <summary>Output from `citgm yargs`</summary>

```
./bin/citgm.js yargs
info: starting            | yargs
info: lookup              | yargs
info: lookup-found        | yargs
info: yargs lookup-replace| https://github.com/yargs/yargs/archive/3495aa675d57794a05e84429f3e62fd993009122.tar.gz
info: yargs npm:          | Downloading project: https://github.com/yargs/yargs/archive/3495aa675d57794a05e84429f3e62fd993009122.tar.gz
info: yargs npm:          | Project downloaded 3495aa675d57794a05e84429f3e62fd993009122.tar.gz
info: yargs npm:          | npm install started
info: yargs npm:          | npm install successfully completed
info: yargs npm:          | test suite started
error: failure             | The canary is dead:
error: failing module(s)   |
error: module name:        | yargs
error: version:            | 18.0.0
error: error:              | The canary is dead:
error: error:              | undefined
error:                     | > yargs@18.0.0 prepare
error:                     | > npm run compile
error:                     |
error:                     |
error:                     | > yargs@18.0.0 compile
error:                     | > rimraf build && tsc
error:                     |
error:                     |
error:                     | added 547 packages in 27s
error:                     |
error:                     | > yargs@18.0.0 pretest
error:                     | > npm run compile -- -p tsconfig.test.json
error:                     |
error:                     |
error:                     | > yargs@18.0.0 compile
error:                     | > rimraf build && tsc -p tsconfig.test.json
error:                     |
error:                     |
error:                     | > yargs@18.0.0 test
error:                     | > c8 mocha --enable-source-maps ./test/*.mjs --require ./test/before.mjs --timeout=24000 --check-leaks
error:                     |
error:                     |
error:                     |
error:                     | ✔ should expose yargs-parser as Parser
... <truncated for PR body limit> ...
error:                     | ✔ throws if any async method is used
error:                     |
error:                     |
error:                     | 826 passing (6s)
error:                     | 1 pending
error:                     |
error:                     | --------------------------|---------|----------|---------|---------|--------------------------------
error:                     | File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
error:                     | --------------------------|---------|----------|---------|---------|--------------------------------
error:                     | All files                 |     100 |    96.43 |     100 |     100 |
error:                     | yargs                    |     100 |      100 |     100 |     100 |
error:                     | index.mjs               |     100 |      100 |     100 |     100 |
error:                     | yargs/helpers            |     100 |      100 |     100 |     100 |
error:                     | helpers.mjs             |     100 |      100 |     100 |     100 |
error:                     | yargs/lib                |     100 |    96.59 |     100 |     100 |
error:                     | argsert.ts              |     100 |      100 |     100 |     100 |
error:                     | command.ts              |     100 |      100 |     100 |     100 |
error:                     | completion-templates.ts |     100 |      100 |     100 |     100 |
error:                     | completion.ts           |     100 |    93.84 |     100 |     100 | 45-46,98,260,265,343
error:                     | middleware.ts           |     100 |    97.22 |     100 |     100 | 54
error:                     | parse-command.ts        |     100 |      100 |     100 |     100 |
error:                     | usage.ts                |     100 |    95.85 |     100 |     100 | ...304,554,563,565,638,730,826
error:                     | validation.ts           |     100 |    98.42 |     100 |     100 | 69,355
error:                     | yargs-factory.ts        |     100 |    95.72 |     100 |     100 | ...64-2065,2069,2162,2218,2251
error:                     | yerror.ts               |     100 |      100 |     100 |     100 |
error:                     | yargs/lib/platform-shims |     100 |       90 |     100 |     100 |
error:                     | esm.mjs                 |     100 |       90 |     100 |     100 | 53
error:                     | yargs/lib/typings        |     100 |      100 |     100 |     100 |
error:                     | common-types.ts         |     100 |      100 |     100 |     100 |
error:                     | yargs/lib/utils          |     100 |    93.93 |     100 |     100 |
error:                     | apply-extends.ts        |     100 |    95.65 |     100 |     100 | 16
error:                     | is-promise.ts           |     100 |      100 |     100 |     100 |
error:                     | levenshtein.ts          |     100 |    85.71 |     100 |     100 | 28-29
error:                     | maybe-async-result.ts   |     100 |      100 |     100 |     100 |
error:                     | obj-filter.ts           |     100 |      100 |     100 |     100 |
error:                     | process-argv.ts         |     100 |      100 |     100 |     100 |
error:                     | set-blocking.ts         |     100 |       80 |     100 |     100 | 10
error:                     | --------------------------|---------|----------|---------|---------|--------------------------------
error:                     |
error:                     | > yargs@18.0.0 posttest
error:                     | > npm run check
error:                     |
error:                     |
error:                     | > yargs@18.0.0 check
error:                     | > gts lint && npm run check:js
error:                     |
error:                     | version: 24
error:                     |
error:                     | /private/var/folders/k6/4f4fv9855cl79n44vnt6bnxr0000gn/T/de027c5d/yargs/lib/command.ts
error:                     | 794:42  error  Delete `⏎·`                                                                                                                                                                                       prettier/pr
error:                     | 796:3   error  Replace `··Pick<⏎······CommandHandler,⏎······'deprecated'·|·'description'·|·'handler'·|·'middlewares'⏎····` with `Pick<CommandHandler,·'deprecated'·|·'description'·|·'handler'·|·'middlewares'`  prettier/pr
error:                     | 800:1   error  Delete `··`                                                                                                                                                                                       prettier/pr
error:                     |
error:                     | /private/var/folders/k6/4f4fv9855cl79n44vnt6bnxr0000gn/T/de027c5d/yargs/lib/yargs-factory.ts
error:                     | 2378:31  error  Delete `⏎·`  prettier/prettier
error:                     | 2380:1   error  Delete `··`  prettier/prettier
error:                     | 2381:3   error  Delete `··`  prettier/prettier
error:                     | 2382:1   error  Delete `··`  prettier/prettier
error:                     | 2383:3   error  Delete `··`  prettier/prettier
error:                     | 2384:1   error  Delete `··`  prettier/prettier
error:                     | 2385:3   error  Delete `··`  prettier/prettier
error:                     | 2386:1   error  Delete `··`  prettier/prettier
error:                     | 2387:3   error  Delete `··`  prettier/prettier
error:                     | 2388:1   error  Delete `··`  prettier/prettier
error:                     | 2389:3   error  Delete `··`  prettier/prettier
error:                     | 2390:1   error  Delete `··`  prettier/prettier
error:                     | 2391:3   error  Delete `··`  prettier/prettier
error: error:              | 2392:1   error  Delete `··`  prettier/prettier
error:                     | 2393:3   error  Delete `··`  prettier/prettier
error:                     | 2394:1   error  Delete `··`  prettier/prettier
error:                     |
error:                     | ✖ 19 problems (19 errors, 0 warnings)
error:                     | 19 errors and 0 warnings potentially fixable with the `--fix` option.
error:                     |
error:                     |
error:                     | (node:99625) [DEP0180] DeprecationWarning: fs.Stats constructor is deprecated.
error:                     | (Use `node --trace-deprecation ...` to show where the warning was created)
error: done                | The smoke test has failed.
info: duration            | test duration: 41149ms
```
</details>

- ref: https://github.com/yargs/yargs/pull/2514
- ref: https://github.com/nodejs/node/issues/61971
- ref: https://github.com/nodejs/node/pull/61600
- ref: https://github.com/nodejs/node/pull/62083

cc @bcoe @shadowspawn @nicolo-ribaudo

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
