### PR TITLE
lookup: skip WPT for undici in CITGM

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -441,8 +441,26 @@
   "undici": {
     "prefix": "v",
     "envVar": { "CITGM": true },
+    "scripts": [
+      "generate-pem",
+      "test:unit",
+      "test:fetch",
+      "test:node-fetch",
+      "test:infra",
+      "test:cache",
+      "test:cache-interceptor",
+      "test:interceptors",
+      "test:cookies",
+      "test:eventsource",
+      "test:subresource-integrity",
+      "test:websocket",
+      "test:node-test",
+      "test:cache-tests",
+      "test:jest",
+      "test:typescript"
+    ],
     "maintainers": ["mcollina", "ronag"],
-    "comment": "skip a few tests that are too dependent on the network"
+    "comment": "run the default test suite without WPT; skip a few tests that are too dependent on the network"
   },
   "uuid": {
     "prefix": "v",


### PR DESCRIPTION
### Summary

Run undici's CITGM entry with an explicit script list that mirrors the default test suite while omitting `test:wpt`.

This keeps WPT out of Node.js release canary runs while preserving the existing `CITGM=true` environment for CITGM-specific skips.

### Tests

- `npm test`

##### Checklist

- [x] `npm test` passes
- [x] contribution guidelines followed [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
