### PR TITLE
fix: normalize `repository.url` in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "author": "James M Snell <jasnell@gmail.com> (http://jasnell.me)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nodejs/citgm"
+    "url": "git+https://github.com/nodejs/citgm.git"
   },
   "bugs": {
     "url": "https://github.com/nodejs/citgm/issues",


### PR DESCRIPTION
Addresses warning from npm. Change is the result of running
```
npm pkg fix
```

---

When publishing [10.0.2](https://www.npmjs.com/package/citgm/v/10.0.2) to the npm registry, I got this warning from npm which this PR addresses:
```
npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm warn publish errors corrected:
npm warn publish "repository.url" was normalized to "git+https://github.com/nodejs/citgm.git"
```

