### PR TITLE
fix: initialize selected submodules for Undici CITGM

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ For syntax, see [lookup.json](./lib/lookup.json), the available attributes are:
 "scripts": ["script1", "script2"] - List of scripts from package.json to run instead of 'test'
 "tags": ["tag1", "tag2"]     Specify which tags apply to the module
 "useGitClone": true          Use a shallow git clone instead of downloading the module
+"submodules": ["path/to/submodule"]  Initialize only the listed submodules when using a git clone
 "ignoreGitHead":             Ignore the gitHead field if it exists and fallback to using github tags
 "yarn":                      Install and test the project using yarn instead of npm
 "pnpm":                      Install and test the project using pnpm instead of npm

--- a/lib/git-clone.js
+++ b/lib/git-clone.js
@@ -24,8 +24,15 @@ export async function gitClone(context) {
   await execGit(['remote', 'add', 'origin', gitUrl]);
   await execGit(['fetch', '--depth=1', 'origin', gitRef]);
   await execGit(['checkout', 'FETCH_HEAD']);
-  await execGit(['submodule', 'init']);
-  await execGit(['submodule', 'update']);
+  if (context.module.submodules) {
+    const submodules = Array.isArray(context.module.submodules)
+      ? context.module.submodules
+      : [context.module.submodules];
+    await execGit(['submodule', 'update', '--init', '--', ...submodules]);
+  } else {
+    await execGit(['submodule', 'init']);
+    await execGit(['submodule', 'update']);
+  }
 
   context.unpack = false;
 }

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -190,6 +190,9 @@ export function lookup(context) {
       if (rep.timeout) {
         context.module.timeout = rep.timeout;
       }
+      if (rep.submodules) {
+        context.module.submodules = rep.submodules;
+      }
       context.module.flaky = context.options.failFlaky
         ? false
         : defaultMatcher.isMatch(rep.flaky);

--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -440,6 +440,8 @@
   },
   "undici": {
     "prefix": "v",
+    "useGitClone": true,
+    "submodules": ["test/fixtures/cache-tests"],
     "envVar": { "CITGM": true },
     "scripts": [
       "generate-pem",

--- a/test/fixtures/custom-lookup-useGitClone.json
+++ b/test/fixtures/custom-lookup-useGitClone.json
@@ -1,6 +1,7 @@
 {
   "lodash": {
     "prefix": "v",
-    "useGitClone": true
+    "useGitClone": true,
+    "submodules": ["test/fixtures"]
   }
 }

--- a/test/test-lookup.js
+++ b/test/test-lookup.js
@@ -245,7 +245,7 @@ test('lookup: module in table with scripts', (t) => {
 });
 
 test('lookup: module in table with useGitClone', (t) => {
-  t.plan(2);
+  t.plan(3);
   const context = {
     lookup: null,
     module: parsePackageArg('lodash'),
@@ -269,6 +269,7 @@ test('lookup: module in table with useGitClone', (t) => {
     'raw should be a git URL if useGitClone is true'
   );
   t.equal(context.module.ref, 'v1.2.3');
+  t.strictSame(context.module.submodules, ['test/fixtures']);
   t.end();
 });
 


### PR DESCRIPTION
## Summary

Fix the Undici CITGM failure reported in nodejs/undici#5642.

CITGM's Undici lookup entry runs `test:cache-tests`, but the normal GitHub source archive does not contain the contents of the `test/fixtures/cache-tests` submodule. Use a shallow Git clone and initialize only that required submodule. Avoid initializing the WPT submodule, which is unnecessarily large and is not run by this entry.

This adds a `submodules` lookup option for selecting submodules when `useGitClone` is enabled.

## Tests

- `npm test`
- End-to-end selective clone verified the cache-tests runner is present and WPT remains uninitialized.
