### PR TITLE
chore: update supported Node.js versions (22, 24 & 26)

### DIFF
--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -36,9 +36,9 @@ jobs:
           - ubuntu-latest
           - windows-latest
         node-version:
-          - 20.x
           - 22.x
           - 24.x
+          - 26.x
 
     runs-on: ${{ matrix.os }}
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -51,7 +51,7 @@
         "xml2js": "^0.6.2"
       },
       "engines": {
-        "node": "20.x || 22.x || 24.x"
+        "node": "22.x || 24.x || 26.x"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,6 @@
     "allow-incomplete-coverage": true
   },
   "engines": {
-    "node": "20.x || 22.x || 24.x"
+    "node": "22.x || 24.x || 26.x"
   }
 }


### PR DESCRIPTION
- closes https://github.com/nodejs/citgm/issues/1111

## Situation

The repo is currently configured for Node.js 20, 22 & 24. This does not match the [supported Node.js release lines](https://github.com/nodejs/release#release-schedule) 22, 24 & 26.

## Change

- Remove Node.js 20.x
- Add Node.js 26.x

so that [supported Node.js release lines](https://github.com/nodejs/release#release-schedule) 22, 24 & 26 are covered.

##### Checklist

- [X] `npm test` passes
- [X] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
