### PR TITLE
chore: update prettier to 3.9.6

### DIFF
--- a/lib/reporter/logger.js
+++ b/lib/reporter/logger.js
@@ -20,7 +20,7 @@ function logModule(log, logType, module) {
       return;
     }
     // If the output is too big the log formatter explodes, so we slice.
-    for (let i = 0; i < module.testOutput.length; ) {
+    for (let i = 0; i < module.testOutput.length;) {
       // Slice the output to `outChunkSize` size chunks,
       // from `i` to `i + outChunkSize`, and update `i`.
       const rawChunk = module.testOutput.substring(i, (i += outChunkSize));

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -44,7 +44,7 @@
         "eslint": "^9.35.0",
         "eslint-config-prettier": "^10.1.8",
         "globals": "^16.4.0",
-        "prettier": "^3.6.2",
+        "prettier": "^3.9.6",
         "string-to-stream": "^3.0.1",
         "tap": "^21.1.0",
         "tap-parser": "^18.0.0",
@@ -5128,7 +5128,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.6.2",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "eslint": "^9.35.0",
     "eslint-config-prettier": "^10.1.8",
     "globals": "^16.4.0",
-    "prettier": "^3.6.2",
+    "prettier": "^3.9.6",
     "string-to-stream": "^3.0.1",
     "tap": "^21.1.0",
     "tap-parser": "^18.0.0",


### PR DESCRIPTION
- relates to https://github.com/nodejs/citgm/issues/1117

## Situation

If `npm install && npm test` are run under npm 12, Prettier reports a whitespace formatting issue.

## Change

Update [prettier@3.9.6](https://github.com/prettier/prettier/releases/tag/3.9.6) and use `npm run lint:prettier:fix` to make whitespace change in [lib/reporter/logger.js](https://github.com/nodejs/citgm/blob/main/lib/reporter/logger.js).

##### Checklist

- [X] `npm test` passes
- [X] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
