### PR TITLE
chore: update codecov/codecov-action to v7.0.0

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -38,4 +38,4 @@ jobs:
       test-command: npm run tap -- --coverage-report=lcov
       post-test-steps: |
         - name: Coverage Report
-          uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00  # v5.5.0
+          uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0


### PR DESCRIPTION
- closes https://github.com/nodejs/citgm/issues/1120

## Situation

The Node.js CI workflow [nodejs.yml](https://github.com/nodejs/citgm/actions/workflows/nodejs.yml) shows multiple deprecation warnings similar to the following:

> Test / test (24, macos-latest)
> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Change

Update [nodejs.yml](https://github.com/nodejs/citgm/actions/workflows/nodejs.yml) to use [codecov/codecov-action@v7.0.0](https://github.com/codecov/codecov-action/releases/tag/v7.0.0) (https://github.com/codecov/codecov-action/commit/fb8b3582c8e4def4969c97caa2f19720cb33a72f) (current `latest`).

##### Checklist

- [X] `npm test` passes
- [X] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)
