### PR TITLE
lookup: remove q

### DIFF
--- a/lib/lookup.json
+++ b/lib/lookup.json
@@ -354,11 +354,6 @@
     "maintainers": "mafintosh",
     "skip": "win32"
   },
-  "q": {
-    "prefix": "v",
-    "maintainers": "kriskowal",
-    "skip": ["win32", ">=21"]
-  },
   "readable-stream": {
     "prefix": "v",
     "maintainers": "nodejs/streams",


### PR DESCRIPTION
- relates to https://github.com/nodejs/citgm/issues/1113

## Situation

[q](https://www.npmjs.com/package/q) is deprecated and unsupported. It cannot therefore fulfil the [Hard Requirements](https://github.com/nodejs/citgm/blob/main/CONTRIBUTING.md#hard-requirements):

> The maintainers of the module remain responsive when there are problems

| Item                 | Status                                    |
| -------------------- | ----------------------------------------- |
| npm package          | https://www.npmjs.com/package/q           |
| npm status           | deprecated                                |
| last published       | 1.5.1 Oct 19, 2017                        |
| repo location        | https://github.com/kriskowal/q            |
| repo status          | archived on Jan 22, 2025                  |
| lookup maintainer(s) | [kriskowal](https://github.com/kriskowal) |

npm Author message:

> You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other. (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)

| Node.js | npm     | macos | ubuntu | windows |
| ------- | ------- | ----- | ------ | ------- |
| 22.23.1 | 10.9.8  | pass  | pass   | pass    |
| 24.19.0 | 11.17.0 | pass  | pass   | pass    |
| 26.7.0  | 11.19.0 | fail  | fail   | fail    |
| 26.7.0  | 12.0.2  | -     | fail   | -       |

## Change

Remove [q](https://www.npmjs.com/package/q) from [lib/lookup.json](https://github.com/nodejs/citgm/blob/main/lib/lookup.json)

##### Checklist

- [X] `npm test` passes
- [X] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)

cc: @kriskowal

