### PR TITLE
fix: correct lint:eslint:fix script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "lint": "npm run lint:eslint && npm run lint:prettier",
     "lint:eslint": "eslint --cache",
-    "lint:eslint:fix": "npm run eslint -- --fix",
+    "lint:eslint:fix": "npm run lint:eslint -- --fix",
     "lint:prettier": "prettier --check .",
     "lint:prettier:fix": "prettier --write .",
     "tap": "tap run \"test/**/test-*.js\"",


### PR DESCRIPTION
- relates to https://github.com/nodejs/citgm/pull/1125#discussion_r3830238389

## Situation

Attempting to execute the script `lint:eslint:fix` fails:

```console
$ npm run lint:eslint:fix

> citgm@10.0.2 lint:eslint:fix
> npm run eslint -- --fix

npm error Missing script: "eslint"
npm error
npm error Did you mean this?
npm error   npm run lint # run the "lint" package script
npm error
npm error To see a list of scripts, run:
npm error   npm run
npm error A complete log of this run can be found in: /home/mike/.npm/_logs/2026-08-21T13_16_39_901Z-debug-0.log
```

## Change

Update the script `lint:eslint:fix` definition to delegate to `lint:eslint`

##### Checklist

- [X] `npm test` passes
- [X] contribution guidelines followed
      [here](https://github.com/nodejs/citgm/blob/HEAD/CONTRIBUTING.md)

```console
$ npm run lint:eslint:fix

> citgm@10.0.2 lint:eslint:fix
> npm run lint:eslint -- --fix


> citgm@10.0.2 lint:eslint
> eslint --cache --fix
```

cc: @targos